### PR TITLE
Add owner filter functionality and tests for repository visibility

### DIFF
--- a/Sources/RepoBar/App/AppState+Visibility.swift
+++ b/Sources/RepoBar/App/AppState+Visibility.swift
@@ -20,7 +20,8 @@ extension AppState {
             hidden: Set(self.session.settings.repoList.hiddenRepositories),
             includeForks: self.session.settings.repoList.showForks,
             includeArchived: self.session.settings.repoList.showArchived,
-            limit: Int.max
+            limit: Int.max,
+            ownerFilter: self.session.settings.repoList.ownerFilter
         )
         return AppState.selectVisible(all: repos, options: options)
     }
@@ -47,7 +48,8 @@ extension AppState {
             ageCutoff: ageCutoff,
             pinned: settings.repoList.pinnedRepositories,
             hidden: Set(settings.repoList.hiddenRepositories),
-            pinPriority: true
+            pinPriority: true,
+            ownerFilter: settings.repoList.ownerFilter
         )
     }
 
@@ -119,6 +121,7 @@ extension AppState {
         let includeForks: Bool
         let includeArchived: Bool
         let limit: Int
+        let ownerFilter: [String]
     }
 
     nonisolated static func selectVisible(all repos: [Repository], options: VisibleSelectionOptions) -> [Repository] {
@@ -128,7 +131,8 @@ extension AppState {
             filtered,
             includeForks: options.includeForks,
             includeArchived: options.includeArchived,
-            pinned: pinnedSet
+            pinned: pinnedSet,
+            ownerFilter: options.ownerFilter
         )
         let limited = Array(visible.prefix(max(options.limit, 0)))
         return limited.sorted { lhs, rhs in

--- a/Sources/RepoBarCore/Settings/UserSettings.swift
+++ b/Sources/RepoBarCore/Settings/UserSettings.swift
@@ -33,6 +33,7 @@ public struct RepoListSettings: Equatable, Codable {
     public var menuSortKey: RepositorySortKey = .activity
     public var pinnedRepositories: [String] = [] // owner/name
     public var hiddenRepositories: [String] = [] // owner/name
+    public var ownerFilter: [String] = [] // owner names to include (empty = show all)
 
     public init() {}
 }

--- a/Sources/RepoBarCore/Support/RepositoryFilter.swift
+++ b/Sources/RepoBarCore/Support/RepositoryFilter.swift
@@ -6,16 +6,20 @@ public enum RepositoryFilter {
         includeForks: Bool,
         includeArchived: Bool,
         pinned: Set<String> = [],
-        onlyWith: RepositoryOnlyWith = .none
+        onlyWith: RepositoryOnlyWith = .none,
+        ownerFilter: [String] = []
     ) -> [Repository] {
-        let needsFilter = includeForks == false || includeArchived == false || onlyWith.isActive
+        let needsFilter = includeForks == false || includeArchived == false || onlyWith.isActive || !ownerFilter.isEmpty
         guard needsFilter else { return repos }
+
+        let ownerSet = Set(ownerFilter.map { $0.lowercased() })
 
         return repos.filter { repo in
             if pinned.contains(repo.fullName) { return true }
             if includeForks == false, repo.isFork { return false }
             if includeArchived == false, repo.isArchived { return false }
             if onlyWith.isActive, onlyWith.matches(repo) == false { return false }
+            if !ownerSet.isEmpty, !ownerSet.contains(repo.owner.lowercased()) { return false }
             return true
         }
     }

--- a/Sources/RepoBarCore/Support/RepositoryPipeline.swift
+++ b/Sources/RepoBarCore/Support/RepositoryPipeline.swift
@@ -17,6 +17,7 @@ public struct RepositoryQuery: Equatable, Sendable {
     public var pinned: [String]
     public var hidden: Set<String>
     public var pinPriority: Bool
+    public var ownerFilter: [String]
 
     public init(
         scope: RepositoryScope = .all,
@@ -28,7 +29,8 @@ public struct RepositoryQuery: Equatable, Sendable {
         ageCutoff: Date? = nil,
         pinned: [String] = [],
         hidden: Set<String> = [],
-        pinPriority: Bool = false
+        pinPriority: Bool = false,
+        ownerFilter: [String] = []
     ) {
         self.scope = scope
         self.onlyWith = onlyWith
@@ -40,6 +42,7 @@ public struct RepositoryQuery: Equatable, Sendable {
         self.pinned = pinned
         self.hidden = hidden
         self.pinPriority = pinPriority
+        self.ownerFilter = ownerFilter
     }
 }
 
@@ -74,7 +77,8 @@ public enum RepositoryPipeline {
             filtered,
             includeForks: query.includeForks,
             includeArchived: query.includeArchived,
-            pinned: pinnedSet
+            pinned: pinnedSet,
+            ownerFilter: query.ownerFilter
         )
 
         if let cutoff = query.ageCutoff {

--- a/Tests/RepoBarTests/ArchivedFilteringTests.swift
+++ b/Tests/RepoBarTests/ArchivedFilteringTests.swift
@@ -43,7 +43,8 @@ struct ArchivedFilteringTests {
                 hidden: [],
                 includeForks: true,
                 includeArchived: false,
-                limit: 10
+                limit: 10,
+                ownerFilter: []
             )
         )
 

--- a/Tests/RepoBarTests/ForkFilteringTests.swift
+++ b/Tests/RepoBarTests/ForkFilteringTests.swift
@@ -43,7 +43,8 @@ struct ForkFilteringTests {
                 hidden: [],
                 includeForks: false,
                 includeArchived: false,
-                limit: 10
+                limit: 10,
+                ownerFilter: []
             )
         )
 

--- a/Tests/RepoBarTests/OwnerFilteringTests.swift
+++ b/Tests/RepoBarTests/OwnerFilteringTests.swift
@@ -1,0 +1,163 @@
+import Foundation
+@testable import RepoBar
+import RepoBarCore
+import Testing
+
+struct OwnerFilteringTests {
+    @Test
+    func repositoryFilterIncludesAllWhenOwnerFilterIsEmpty() {
+        let repos = [
+            Self.repo(owner: "alice", name: "A"),
+            Self.repo(owner: "bob", name: "B"),
+            Self.repo(owner: "charlie", name: "C")
+        ]
+        let filtered = RepositoryFilter.apply(
+            repos,
+            includeForks: true,
+            includeArchived: true,
+            ownerFilter: []
+        )
+        #expect(filtered.count == 3)
+    }
+
+    @Test
+    func repositoryFilterIncludesOnlySpecifiedOwner() {
+        let repos = [
+            Self.repo(owner: "alice", name: "A"),
+            Self.repo(owner: "bob", name: "B"),
+            Self.repo(owner: "charlie", name: "C")
+        ]
+        let filtered = RepositoryFilter.apply(
+            repos,
+            includeForks: true,
+            includeArchived: true,
+            ownerFilter: ["alice"]
+        )
+        #expect(filtered.count == 1)
+        #expect(filtered.first?.owner == "alice")
+    }
+
+    @Test
+    func repositoryFilterIncludesMultipleSpecifiedOwners() {
+        let repos = [
+            Self.repo(owner: "alice", name: "A"),
+            Self.repo(owner: "bob", name: "B"),
+            Self.repo(owner: "charlie", name: "C"),
+            Self.repo(owner: "alice", name: "D")
+        ]
+        let filtered = RepositoryFilter.apply(
+            repos,
+            includeForks: true,
+            includeArchived: true,
+            ownerFilter: ["alice", "charlie"]
+        )
+        #expect(filtered.count == 3)
+        #expect(filtered.map(\.owner).sorted() == ["alice", "alice", "charlie"])
+    }
+
+    @Test
+    func repositoryFilterIsCaseInsensitive() {
+        let repos = [
+            Self.repo(owner: "Alice", name: "A"),
+            Self.repo(owner: "BOB", name: "B"),
+            Self.repo(owner: "charlie", name: "C")
+        ]
+        let filtered = RepositoryFilter.apply(
+            repos,
+            includeForks: true,
+            includeArchived: true,
+            ownerFilter: ["alice", "bob"]
+        )
+        #expect(filtered.count == 2)
+    }
+
+    @Test
+    func repositoryFilterKeepsPinnedReposRegardlessOfOwner() {
+        let pinnedRepo = Self.repo(owner: "dotnet", name: "Pinned")
+        let otherRepo = Self.repo(owner: "dotnet", name: "Other")
+        let myRepo = Self.repo(owner: "me", name: "Mine")
+
+        let filtered = RepositoryFilter.apply(
+            [pinnedRepo, otherRepo, myRepo],
+            includeForks: true,
+            includeArchived: true,
+            pinned: Set([pinnedRepo.fullName]),
+            ownerFilter: ["me"]
+        )
+        #expect(filtered.count == 2)
+        #expect(filtered.map(\.fullName).sorted() == [myRepo.fullName, pinnedRepo.fullName].sorted())
+    }
+
+    @Test
+    func selectVisibleAppliesOwnerFilter() {
+        let myRepo1 = Self.repo(owner: "me", name: "Repo1")
+        let myRepo2 = Self.repo(owner: "me", name: "Repo2")
+        let orgRepo1 = Self.repo(owner: "dotnet", name: "AspNetCore")
+        let orgRepo2 = Self.repo(owner: "microsoft", name: "TypeScript")
+
+        let visible = AppState.selectVisible(
+            all: [myRepo1, orgRepo1, myRepo2, orgRepo2],
+            options: AppState.VisibleSelectionOptions(
+                pinned: [],
+                hidden: [],
+                includeForks: true,
+                includeArchived: true,
+                limit: 10,
+                ownerFilter: ["me"]
+            )
+        )
+
+        #expect(visible.count == 2)
+        #expect(visible.map(\.owner).allSatisfy { $0 == "me" })
+    }
+
+    @Test
+    func repositoryPipelineAppliesOwnerFilter() {
+        let repos = [
+            Self.repo(owner: "alice", name: "A"),
+            Self.repo(owner: "bob", name: "B"),
+            Self.repo(owner: "charlie", name: "C")
+        ]
+        let query = RepositoryQuery(
+            scope: .all,
+            onlyWith: .none,
+            includeForks: true,
+            includeArchived: true,
+            sortKey: .name,
+            limit: nil,
+            ageCutoff: nil,
+            pinned: [],
+            hidden: [],
+            pinPriority: false,
+            ownerFilter: ["alice", "bob"]
+        )
+        let filtered = RepositoryPipeline.apply(repos, query: query)
+        #expect(filtered.count == 2)
+        #expect(filtered.map(\.owner).sorted() == ["alice", "bob"])
+    }
+}
+
+private extension OwnerFilteringTests {
+    static func repo(owner: String, name: String) -> Repository {
+        Repository(
+            id: UUID().uuidString,
+            name: name,
+            owner: owner,
+            isFork: false,
+            isArchived: false,
+            sortOrder: nil,
+            error: nil,
+            rateLimitedUntil: nil,
+            ciStatus: .unknown,
+            ciRunCount: nil,
+            openIssues: 0,
+            openPulls: 0,
+            stars: 0,
+            pushedAt: nil,
+            latestRelease: nil,
+            latestActivity: nil,
+            traffic: nil,
+            heatmap: []
+        )
+    }
+}

--- a/Tests/RepoBarTests/VisibilityTests.swift
+++ b/Tests/RepoBarTests/VisibilityTests.swift
@@ -17,7 +17,8 @@ struct VisibilityTests {
                 hidden: Set(["me/b"]),
                 includeForks: false,
                 includeArchived: false,
-                limit: 5
+                limit: 5,
+                ownerFilter: []
             )
         )
         #expect(visible.count == 1)
@@ -37,7 +38,8 @@ struct VisibilityTests {
                 hidden: [],
                 includeForks: false,
                 includeArchived: false,
-                limit: 5
+                limit: 5,
+                ownerFilter: []
             )
         )
         #expect(visible.first?.fullName == "me/a")
@@ -55,7 +57,8 @@ struct VisibilityTests {
                 hidden: Set(["me/r1", "me/r2", "me/r3"]),
                 includeForks: false,
                 includeArchived: false,
-                limit: 3
+                limit: 3,
+                ownerFilter: []
             )
         )
         #expect(visible.count == 3)


### PR DESCRIPTION
Fixes #7 

Let me know thoughts here if you take a quick look and i can go back and revise as needed.

Generated with Sonnet 4.5 with a detailed prompt all up. Putting in draft as I still need to get things working and running on my local machine.

This pull request adds a new "owner filter" feature to the repository list, allowing users to filter repositories by owner (e.g., show only their own repositories). It updates the data models, filtering logic, and user settings to support this, and adds a toggle in the settings UI to enable "Show only my repositories". Comprehensive tests are included to verify correct filtering behavior, including case insensitivity and pinning logic.

**Owner filtering support:**

* Added an `ownerFilter` field to `RepoListSettings`, `RepositoryQuery`, and `VisibleSelectionOptions` to specify which repository owners should be included in lists and searches. [[1]](diffhunk://#diff-a95f6e5ee74ea04fe44a5007573e9ce046a7a619a01aa754bcb34551d81ebe3aR36) [[2]](diffhunk://#diff-ec6919b5d3dff2ab306ad0635b6801bde6c274d73715d3da5c12f3c827c65d7eR20) [[3]](diffhunk://#diff-107bbe64b0f0fec270923089072ff639aa18e281d473d53d9b4d00828bd25363R124)
* Updated `RepositoryFilter.apply` and `RepositoryPipeline.apply` to apply the owner filter, ensuring only repositories from specified owners are shown, with case-insensitive matching and pinned repositories always included. [[1]](diffhunk://#diff-0ea5e335967b1efe4473fa7483a53d5f24763e6af57676d7f3f9d6b74e9a216cL9-R22) [[2]](diffhunk://#diff-ec6919b5d3dff2ab306ad0635b6801bde6c274d73715d3da5c12f3c827c65d7eL77-R81) [[3]](diffhunk://#diff-107bbe64b0f0fec270923089072ff639aa18e281d473d53d9b4d00828bd25363L131-R135)

**UI and settings integration:**

* Added a "Show only my repositories" toggle to `GeneralSettingsView`, which sets the owner filter to the current user's username and updates settings and refreshes the UI accordingly. [[1]](diffhunk://#diff-85890aa39710fe2f031d38db964cc6df71e495d4658d6128560ad3d0a913879cR9-R36) [[2]](diffhunk://#diff-85890aa39710fe2f031d38db964cc6df71e495d4658d6128560ad3d0a913879cR109-R116)
* Updated visibility selection logic in `AppState` to pass the owner filter through all relevant selection paths. [[1]](diffhunk://#diff-107bbe64b0f0fec270923089072ff639aa18e281d473d53d9b4d00828bd25363L23-R24) [[2]](diffhunk://#diff-107bbe64b0f0fec270923089072ff639aa18e281d473d53d9b4d00828bd25363L50-R52)

**Testing and validation:**

* Added comprehensive unit tests in `OwnerFilteringTests.swift` to verify owner filtering behavior, including empty filters, multiple owners, case insensitivity, and pinned repositories.
* Updated existing tests to include the new `ownerFilter` parameter for consistency. [[1]](diffhunk://#diff-a815d97fa6a65689589b4620eda5dc41a78f04e431b21b30e312410935a2efcbL46-R47) [[2]](diffhunk://#diff-5f06e5417facf47bda7ec015621e907fca2174a445c4fd256cd5dda0890cf5f9L46-R47) [[3]](diffhunk://#diff-37bba2cf732a26c11a09152827cb78560d530abfd3762dcf7a9b828c23fb8941L20-R21) [[4]](diffhunk://#diff-37bba2cf732a26c11a09152827cb78560d530abfd3762dcf7a9b828c23fb8941L40-R42) [[5]](diffhunk://#diff-37bba2cf732a26c11a09152827cb78560d530abfd3762dcf7a9b828c23fb8941L58-R61)