### PR TITLE
local: handle ghq-style repo layouts

### DIFF
--- a/Sources/RepoBarCore/Support/Constants.swift
+++ b/Sources/RepoBarCore/Support/Constants.swift
@@ -10,7 +10,9 @@ public enum RepoCacheConstants {
 }
 
 public enum LocalProjectsConstants {
-    public static let defaultMaxDepth: Int = 2
+    // Allow ghq-style layouts (e.g. ~/ghq/github.com/owner/repo) which sit 3–4 levels
+    // below the configured root path.
+    public static let defaultMaxDepth: Int = 4
     public static let defaultSnapshotConcurrencyLimit: Int = 8
     public static let dirtyFileLimit: Int = 10
 }


### PR DESCRIPTION
## Summary
- raise local projects default scan depth from 2 to 4 so ghq-style paths (e.g. ~/ghq/github.com/owner/repo) are discovered
- document the rationale inline

## Reference
- [ghq cli](https://github.com/x-motemen/ghq)