### PR TITLE
fix: preserve keychain access group

### DIFF
--- a/Scripts/sign-and-notarize.sh
+++ b/Scripts/sign-and-notarize.sh
@@ -52,7 +52,7 @@ if [[ -z "$APP_BUNDLE" ]]; then
 fi
 
 echo "Signing with $APP_IDENTITY"
-export REPOBAR_SKIP_KEYCHAIN_GROUPS="${REPOBAR_SKIP_KEYCHAIN_GROUPS:-1}"
+export REPOBAR_SKIP_KEYCHAIN_GROUPS="${REPOBAR_SKIP_KEYCHAIN_GROUPS:-0}"
 ./Scripts/codesign_app.sh "$APP_BUNDLE" "$APP_IDENTITY"
 
 DITTO_BIN=${DITTO_BIN:-/usr/bin/ditto}

--- a/Sources/RepoBarCore/Auth/TokenStore.swift
+++ b/Sources/RepoBarCore/Auth/TokenStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Logging
 import Security
 
 public struct OAuthTokens: Codable, Equatable, Sendable {
@@ -32,6 +33,7 @@ public struct TokenStore: Sendable {
     public static var shared: TokenStore { TokenStore() }
     private let service: String
     private let accessGroup: String?
+    private let logger = RepoBarLogging.logger("token-store")
 
     public init(
         service: String = "com.steipete.repobar.auth",
@@ -43,90 +45,27 @@ public struct TokenStore: Sendable {
 
     public func save(tokens: OAuthTokens) throws {
         let data = try JSONEncoder().encode(tokens)
-        var query: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrService: service,
-            kSecAttrAccount: "default",
-            kSecValueData: data
-        ]
-        if let accessGroup {
-            query[kSecAttrAccessGroup] = accessGroup
-        }
-        SecItemDelete(query as CFDictionary)
-        let status = SecItemAdd(query as CFDictionary, nil)
-        guard status == errSecSuccess else { throw TokenStoreError.saveFailed }
+        try self.save(data: data, account: "default")
     }
 
     public func load() throws -> OAuthTokens? {
-        var query: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrService: service,
-            kSecAttrAccount: "default",
-            kSecReturnData: true
-        ]
-        if let accessGroup {
-            query[kSecAttrAccessGroup] = accessGroup
-        }
-        var item: CFTypeRef?
-        let status = SecItemCopyMatching(query as CFDictionary, &item)
-        if status == errSecItemNotFound { return nil }
-        guard status == errSecSuccess, let data = item as? Data else { throw TokenStoreError.loadFailed }
+        guard let data = try self.loadData(account: "default") else { return nil }
         return try JSONDecoder().decode(OAuthTokens.self, from: data)
     }
 
     public func save(clientCredentials: OAuthClientCredentials) throws {
         let data = try JSONEncoder().encode(clientCredentials)
-        var query: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrService: service,
-            kSecAttrAccount: "client",
-            kSecValueData: data
-        ]
-        if let accessGroup {
-            query[kSecAttrAccessGroup] = accessGroup
-        }
-        SecItemDelete(query as CFDictionary)
-        let status = SecItemAdd(query as CFDictionary, nil)
-        guard status == errSecSuccess else { throw TokenStoreError.saveFailed }
+        try self.save(data: data, account: "client")
     }
 
     public func loadClientCredentials() throws -> OAuthClientCredentials? {
-        var query: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrService: service,
-            kSecAttrAccount: "client",
-            kSecReturnData: true
-        ]
-        if let accessGroup {
-            query[kSecAttrAccessGroup] = accessGroup
-        }
-        var item: CFTypeRef?
-        let status = SecItemCopyMatching(query as CFDictionary, &item)
-        if status == errSecItemNotFound { return nil }
-        guard status == errSecSuccess, let data = item as? Data else { throw TokenStoreError.loadFailed }
+        guard let data = try self.loadData(account: "client") else { return nil }
         return try JSONDecoder().decode(OAuthClientCredentials.self, from: data)
     }
 
     public func clear() {
-        var tokenQuery: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrService: service,
-            kSecAttrAccount: "default"
-        ]
-        if let accessGroup {
-            tokenQuery[kSecAttrAccessGroup] = accessGroup
-        }
-        SecItemDelete(tokenQuery as CFDictionary)
-
-        var clientQuery: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrService: service,
-            kSecAttrAccount: "client"
-        ]
-        if let accessGroup {
-            clientQuery[kSecAttrAccessGroup] = accessGroup
-        }
-        SecItemDelete(clientQuery as CFDictionary)
+        self.clear(account: "default")
+        self.clear(account: "client")
     }
 }
 
@@ -152,5 +91,98 @@ extension TokenStore {
             }
             return nil
         #endif
+    }
+}
+
+private extension TokenStore {
+    func save(data: Data, account: String) throws {
+        let accessGroups = self.accessGroupsForOperation()
+        var lastStatus: OSStatus = errSecSuccess
+        for (index, group) in accessGroups.enumerated() {
+            let query = self.baseQuery(account: account, accessGroup: group)
+            let attributes: [CFString: Any] = [kSecValueData: data]
+            var addQuery = query
+            addQuery.merge(attributes) { _, new in new }
+            var status = SecItemAdd(addQuery as CFDictionary, nil)
+            if status == errSecDuplicateItem {
+                status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+            }
+            if status == errSecSuccess { return }
+            lastStatus = status
+            let isFinalAttempt = index == accessGroups.count - 1
+            if isFinalAttempt || self.shouldRetryWithoutAccessGroup(status: status, accessGroup: group) == false {
+                break
+            }
+        }
+        self.logFailure("save", status: lastStatus)
+        throw TokenStoreError.saveFailed
+    }
+
+    func loadData(account: String) throws -> Data? {
+        let accessGroups = self.accessGroupsForOperation()
+        var lastStatus: OSStatus = errSecSuccess
+        for (index, group) in accessGroups.enumerated() {
+            var query = self.baseQuery(account: account, accessGroup: group)
+            query[kSecReturnData] = true
+            var item: CFTypeRef?
+            let status = SecItemCopyMatching(query as CFDictionary, &item)
+            if status == errSecItemNotFound {
+                if index == accessGroups.count - 1 { return nil }
+                continue
+            }
+            if status == errSecSuccess, let data = item as? Data { return data }
+            lastStatus = status
+            let isFinalAttempt = index == accessGroups.count - 1
+            if isFinalAttempt || self.shouldRetryWithoutAccessGroup(status: status, accessGroup: group) == false {
+                break
+            }
+        }
+        self.logFailure("load", status: lastStatus)
+        throw TokenStoreError.loadFailed
+    }
+
+    func clear(account: String) {
+        let accessGroups = self.accessGroupsForOperation()
+        for group in accessGroups {
+            let query = self.baseQuery(account: account, accessGroup: group)
+            SecItemDelete(query as CFDictionary)
+        }
+    }
+
+    func accessGroupsForOperation() -> [String?] {
+        guard let accessGroup else { return [nil] }
+        return [accessGroup, nil]
+    }
+
+    func baseQuery(account: String, accessGroup: String?) -> [CFString: Any] {
+        var query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: account
+        ]
+        if let accessGroup {
+            query[kSecAttrAccessGroup] = accessGroup
+        }
+        return query
+    }
+
+    func shouldRetryWithoutAccessGroup(status: OSStatus, accessGroup: String?) -> Bool {
+        guard accessGroup != nil else { return false }
+        switch status {
+        case errSecMissingEntitlement, errSecInteractionNotAllowed:
+            return true
+        default:
+            return false
+        }
+    }
+
+    func logFailure(_ action: String, status: OSStatus) {
+        guard status != errSecSuccess else { return }
+        let statusMessage = SecCopyErrorMessageString(status, nil) as String?
+        if let statusMessage {
+            self.logger.error("Keychain \(action) failed: \(statusMessage)")
+        } else {
+            self.logger.error("Keychain \(action) failed: OSStatus \(status)")
+        }
     }
 }

--- a/docs/release.md
+++ b/docs/release.md
@@ -20,6 +20,7 @@ read_when:
    - About → “Check for Updates…”
    - Menu only shows “Update ready, restart now?” once the update is downloaded.
    - Sparkle dialog shows formatted release notes (not escaped HTML).
+   - Verify entitlements include `keychain-access-groups` for both app + CLI (login depends on shared Keychain).
 
 ## Manual steps (only when re-running pieces)
 1) Debug smoke build/tests  

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -133,6 +133,7 @@ _Last updated: 2025-11-24_
 
 ## Security & Privacy
 - Tokens and secrets only in Keychain; never log.
+- App + CLI share tokens via Keychain access group; release builds must include `keychain-access-groups` entitlement.
 - TLS required (no ATS exceptions); reject self-signed for GHE.
 - Minimal scopes; per-installation tokens only.
 - Single-instance enforced via Info.plist.


### PR DESCRIPTION
## Summary

Fixes login failures caused by missing keychain access-group entitlements, and hardens the TokenStore to tolerate access-group mismatches without changing public API.

Fixes #15

## Changes

- Keep `keychain-access-groups` in release signing by default (release script now defaults `REPOBAR_SKIP_KEYCHAIN_GROUPS=0`).
- TokenStore: update-then-add path, and access-group fallback on entitlement-related errors.
- Brief documentation notes in `docs/release.md` and `docs/spec.md` to make the entitlement requirement explicit.

## Why this is needed

The TokenStore uses a shared Keychain access group so the app and bundled CLI can share tokens. If the entitlement is missing (standalone/unentitled CLI or signing with `REPOBAR_SKIP_KEYCHAIN_GROUPS=1`) or the Team ID prefix differs, the CLI cannot see tokens stored by the app and can appear logged out. In some states, Keychain writes can also fail (e.g. `RepoBarCore.TokenStoreError`).

## Validation

- `pnpm check` (format, lint, tests) — pass
- Manual validation:
  ```bash
  .build/apple/Products/Release/repobarcli login
  ```
  succeeds with access groups present.
- Notarization test (local Developer ID): app bundle is accepted by `spctl` when notarized.

## Known limitation (local test only)

When installing the local notarized build via a cask, macOS can block direct execution of the embedded CLI (`RepoBar.app/Contents/MacOS/repobarcli`) with a Gatekeeper exec-policy error for nested binaries. The same CLI binary runs correctly from the build output. This appears to be a macOS policy quirk rather than a regression from this change.

## Additional context

PR prepared and reviewed with Codex 5.2, consistent with the maintainer's guidance:
https://steipete.me/posts/2025/shipping-at-inference-speed
