### PR TITLE
feat: add Local filter to show all local git repositories

### DIFF
--- a/Sources/RepoBar/Models/RepositoryDisplayModel.swift
+++ b/Sources/RepoBar/Models/RepositoryDisplayModel.swift
@@ -83,4 +83,49 @@ struct RepositoryDisplayModel: Identifiable, Equatable {
             Stat(id: "forks", label: "Forks", value: repo.stats.forks, systemImage: "tuningfork")
         ]
     }
+
+    init(localStatus: LocalRepoStatus, now: Date = Date()) {
+        let placeholderRepo = Repository(
+            id: "local:\(localStatus.path.path)",
+            name: localStatus.name,
+            owner: "",
+            sortOrder: nil,
+            error: nil,
+            rateLimitedUntil: nil,
+            ciStatus: .unknown,
+            openIssues: 0,
+            openPulls: 0,
+            latestRelease: nil,
+            latestActivity: nil,
+            traffic: nil,
+            heatmap: []
+        )
+        self.source = placeholderRepo
+        self.id = placeholderRepo.id
+        self.title = localStatus.displayName
+        self.ciStatus = .unknown
+        self.ciRunCount = nil
+        self.issues = 0
+        self.pulls = 0
+        self.trafficVisitors = nil
+        self.trafficCloners = nil
+        self.stars = 0
+        self.forks = 0
+        self.heatmap = []
+        self.sortOrder = nil
+        self.error = nil
+        self.rateLimitedUntil = nil
+        self.localStatus = localStatus
+        self.releaseLine = nil
+        self.lastPushAge = nil
+        self.activityLine = nil
+        self.activityURL = nil
+        self.activityEvents = []
+        self.latestActivityAge = nil
+        self.stats = []
+    }
+
+    var isLocalOnly: Bool {
+        self.source.owner.isEmpty && self.id.hasPrefix("local:")
+    }
 }

--- a/Sources/RepoBar/StatusBar/StatusBarMenuBuilder+MenuItems.swift
+++ b/Sources/RepoBar/StatusBar/StatusBarMenuBuilder+MenuItems.swift
@@ -23,7 +23,9 @@ extension StatusBarMenuBuilder {
             }
         )
         let submenu = self.repoSubmenu(for: repo, isPinned: isPinned)
-        if let cached = self.repoMenuItemCache[repo.title] {
+        if let cached = self.repoMenuItemCache[repo.id] {
+            // Remove from current menu if attached (prevents crash when reusing cached items)
+            cached.menu?.removeItem(cached)
             self.menuItemFactory.updateItem(cached, with: card, highlightable: true, showsSubmenuIndicator: true)
             cached.isEnabled = true
             cached.submenu = submenu
@@ -32,7 +34,7 @@ extension StatusBarMenuBuilder {
             return cached
         }
         let item = self.viewItem(for: card, enabled: true, highlightable: true, submenu: submenu)
-        self.repoMenuItemCache[repo.title] = item
+        self.repoMenuItemCache[repo.id] = item
         return item
     }
 
@@ -59,11 +61,11 @@ extension StatusBarMenuBuilder {
             changelogHeadline: changelogHeadline,
             isPinned: isPinned
         )
-        if let cached = self.repoSubmenuCache[repo.title], cached.signature == signature {
+        if let cached = self.repoSubmenuCache[repo.id], cached.signature == signature {
             return cached.menu
         }
         let menu = self.makeRepoSubmenu(for: repo, isPinned: isPinned)
-        self.repoSubmenuCache[repo.title] = RepoSubmenuCacheEntry(menu: menu, signature: signature)
+        self.repoSubmenuCache[repo.id] = RepoSubmenuCacheEntry(menu: menu, signature: signature)
         return menu
     }
 

--- a/Sources/RepoBar/StatusBar/StatusBarMenuBuilder.swift
+++ b/Sources/RepoBar/StatusBar/StatusBarMenuBuilder.swift
@@ -185,7 +185,7 @@ final class StatusBarMenuBuilder {
                 if index < repos.count - 1 {
                     items.append(self.repoCardSeparator())
                 }
-                usedRepoKeys.insert(repo.title)
+                usedRepoKeys.insert(repo.id)
             }
             self.repoMenuItemCache = self.repoMenuItemCache.filter { usedRepoKeys.contains($0.key) }
             self.repoSubmenuCache = self.repoSubmenuCache.filter { usedRepoKeys.contains($0.key) }
@@ -301,7 +301,8 @@ final class StatusBarMenuBuilder {
         settings: UserSettings,
         now: Date
     ) -> [RepositoryDisplayModel] {
-        let localRepos = session.localRepoIndex.all
+        // Filter out worktrees - they appear in parent repo's "Switch Worktree" submenu
+        let localRepos = session.localRepoIndex.all.filter { $0.worktreeName == nil }
         let displayIndex = session.menuDisplayIndex
 
         var models: [RepositoryDisplayModel] = []

--- a/Sources/RepoBar/StatusBar/StatusBarMenuManager.swift
+++ b/Sources/RepoBar/StatusBar/StatusBarMenuManager.swift
@@ -92,13 +92,17 @@ final class StatusBarMenuManager: NSObject, NSMenuDelegate {
 
     @objc func menuFiltersChanged() {
         guard let menu = self.mainMenu else { return }
-        self.recentListCoordinator.clearMenus()
-        self.appState.persistSettings()
-        let plan = self.menuBuilder.mainMenuPlan()
-        self.menuBuilder.populateMainMenu(menu, repos: plan.repos)
-        self.lastMainMenuSignature = plan.signature
-        self.menuBuilder.refreshMenuViewHeights(in: menu)
-        menu.update()
+        // Defer menu rebuild to next run loop to avoid modifying menu during layout
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.recentListCoordinator.clearMenus()
+            self.appState.persistSettings()
+            let plan = self.menuBuilder.mainMenuPlan()
+            self.menuBuilder.populateMainMenu(menu, repos: plan.repos)
+            self.lastMainMenuSignature = plan.signature
+            self.menuBuilder.refreshMenuViewHeights(in: menu)
+            menu.update()
+        }
     }
 
     @objc private func recentListFiltersChanged() {

--- a/Sources/RepoBar/Support/MenuRepoFilters.swift
+++ b/Sources/RepoBar/Support/MenuRepoFilters.swift
@@ -3,28 +3,32 @@ import RepoBarCore
 enum MenuRepoSelection: String, CaseIterable, Hashable {
     case all
     case pinned
+    case local
     case work
 
     var label: String {
         switch self {
         case .all: "All"
         case .pinned: "Pinned"
+        case .local: "Loc"
         case .work: "Work"
         }
     }
 
     var onlyWith: RepositoryOnlyWith {
         switch self {
-        case .all:
+        case .all, .pinned, .local:
             .none
         case .work:
             RepositoryOnlyWith(requireIssues: true, requirePRs: true)
-        case .pinned:
-            .none
         }
     }
 
     var isPinnedScope: Bool {
         self == .pinned
+    }
+
+    var isLocalScope: Bool {
+        self == .local
     }
 }

--- a/Sources/RepoBar/Support/MenuRepoFilters.swift
+++ b/Sources/RepoBar/Support/MenuRepoFilters.swift
@@ -10,7 +10,7 @@ enum MenuRepoSelection: String, CaseIterable, Hashable {
         switch self {
         case .all: "All"
         case .pinned: "Pinned"
-        case .local: "Loc"
+        case .local: "Local"
         case .work: "Work"
         }
     }


### PR DESCRIPTION
## Summary
Add a new "Local" filter option in the repository filter bar that displays all git repositories found in the configured local folder, including repos that don't have GitHub remotes.

## Changes
- Add `local` case to `MenuRepoSelection` enum with `isLocalScope` property
- Add `RepositoryDisplayModel` initializer for local-only repos
- Fix `LocalRepoManager` to scan ALL discovered repos, not just GitHub-matching ones
- Improve bookmark fallback handling for app restart scenarios
- Filter worktrees from Local scope (accessible via parent repo's "Switch Worktree" submenu)
- Use `repo.id` for menu cache keys instead of `repo.title` (fixes duplicate name issues)
- Handle duplicate `fullName` entries in `LocalRepoIndex` (worktrees share same remote)
- Defer menu rebuild to next run loop to prevent layout crashes

## Test plan
- [x] Set local projects folder in Settings
- [x] Click on "Local" filter tab
- [x] Verify all local git repos appear (including those without GitHub remotes)
- [x] Verify worktrees do NOT appear as separate entries (only in parent's Switch Worktree submenu)
- [x] Switch between filters rapidly - no crashes
- [x] Quit and restart app - verify local repos load automatically

🤖 Generated with [Claude Code](https://claude.ai/code)

<img width="366" height="495" alt="Screenshot 2026-01-18 at 11 18 01 PM" src="https://github.com/user-attachments/assets/c8f6d6d1-250d-455e-b205-89d25f08ec35" />
