### PR TITLE
feat: enable local repos without GitHub login

### DIFF
--- a/Sources/RepoBar/App/AppState+Refresh.swift
+++ b/Sources/RepoBar/App/AppState+Refresh.swift
@@ -278,7 +278,7 @@ extension AppState {
         let models = repos.map { repo in
             RepositoryDisplayModel(repo: repo, localStatus: localIndex.status(for: repo), now: now)
         }
-        let index = Dictionary(uniqueKeysWithValues: models.map { ($0.title, $0) })
+        let index = Dictionary(uniqueKeysWithValues: models.map { ($0.title.lowercased(), $0) })
         await MainActor.run {
             self.session.menuDisplayIndex = index
         }
@@ -316,7 +316,7 @@ extension AppState {
                         now: capturedAt
                     )
                 }
-                self.session.menuDisplayIndex = Dictionary(uniqueKeysWithValues: models.map { ($0.title, $0) })
+                self.session.menuDisplayIndex = Dictionary(uniqueKeysWithValues: models.map { ($0.title.lowercased(), $0) })
             }
         }
     }

--- a/Sources/RepoBar/App/AppState+Refresh.swift
+++ b/Sources/RepoBar/App/AppState+Refresh.swift
@@ -250,6 +250,10 @@ extension AppState {
             self.session.globalActivityError = nil
             self.session.globalCommitEvents = []
             self.session.globalCommitError = nil
+            // Auto-select local filter when logged out (other filters require GitHub)
+            if self.session.menuRepoSelection != .local {
+                self.session.menuRepoSelection = .local
+            }
         }
     }
 

--- a/Sources/RepoBar/App/Session.swift
+++ b/Sources/RepoBar/App/Session.swift
@@ -38,4 +38,9 @@ enum AccountState: Equatable {
     case loggedOut
     case loggingIn
     case loggedIn(UserIdentity)
+
+    var isLoggedIn: Bool {
+        if case .loggedIn = self { return true }
+        return false
+    }
 }

--- a/Sources/RepoBar/Models/RepositoryDisplayModel.swift
+++ b/Sources/RepoBar/Models/RepositoryDisplayModel.swift
@@ -83,4 +83,49 @@ struct RepositoryDisplayModel: Identifiable, Equatable {
             Stat(id: "forks", label: "Forks", value: repo.stats.forks, systemImage: "tuningfork")
         ]
     }
+
+    init(localStatus: LocalRepoStatus, now: Date = Date()) {
+        let placeholderRepo = Repository(
+            id: "local:\(localStatus.path.path)",
+            name: localStatus.name,
+            owner: "",
+            sortOrder: nil,
+            error: nil,
+            rateLimitedUntil: nil,
+            ciStatus: .unknown,
+            openIssues: 0,
+            openPulls: 0,
+            latestRelease: nil,
+            latestActivity: nil,
+            traffic: nil,
+            heatmap: []
+        )
+        self.source = placeholderRepo
+        self.id = placeholderRepo.id
+        self.title = localStatus.displayName
+        self.ciStatus = .unknown
+        self.ciRunCount = nil
+        self.issues = 0
+        self.pulls = 0
+        self.trafficVisitors = nil
+        self.trafficCloners = nil
+        self.stars = 0
+        self.forks = 0
+        self.heatmap = []
+        self.sortOrder = nil
+        self.error = nil
+        self.rateLimitedUntil = nil
+        self.localStatus = localStatus
+        self.releaseLine = nil
+        self.lastPushAge = nil
+        self.activityLine = nil
+        self.activityURL = nil
+        self.activityEvents = []
+        self.latestActivityAge = nil
+        self.stats = []
+    }
+
+    var isLocalOnly: Bool {
+        self.source.owner.isEmpty && self.id.hasPrefix("local:")
+    }
 }

--- a/Sources/RepoBar/StatusBar/StatusBarMenuBuilder+MenuItems.swift
+++ b/Sources/RepoBar/StatusBar/StatusBarMenuBuilder+MenuItems.swift
@@ -23,7 +23,9 @@ extension StatusBarMenuBuilder {
             }
         )
         let submenu = self.repoSubmenu(for: repo, isPinned: isPinned)
-        if let cached = self.repoMenuItemCache[repo.title] {
+        if let cached = self.repoMenuItemCache[repo.id] {
+            // Remove from current menu if attached (prevents crash when reusing cached items)
+            cached.menu?.removeItem(cached)
             self.menuItemFactory.updateItem(cached, with: card, highlightable: true, showsSubmenuIndicator: true)
             cached.isEnabled = true
             cached.submenu = submenu
@@ -32,7 +34,7 @@ extension StatusBarMenuBuilder {
             return cached
         }
         let item = self.viewItem(for: card, enabled: true, highlightable: true, submenu: submenu)
-        self.repoMenuItemCache[repo.title] = item
+        self.repoMenuItemCache[repo.id] = item
         return item
     }
 
@@ -59,11 +61,11 @@ extension StatusBarMenuBuilder {
             changelogHeadline: changelogHeadline,
             isPinned: isPinned
         )
-        if let cached = self.repoSubmenuCache[repo.title], cached.signature == signature {
+        if let cached = self.repoSubmenuCache[repo.id], cached.signature == signature {
             return cached.menu
         }
         let menu = self.makeRepoSubmenu(for: repo, isPinned: isPinned)
-        self.repoSubmenuCache[repo.title] = RepoSubmenuCacheEntry(menu: menu, signature: signature)
+        self.repoSubmenuCache[repo.id] = RepoSubmenuCacheEntry(menu: menu, signature: signature)
         return menu
     }
 

--- a/Sources/RepoBar/StatusBar/StatusBarMenuBuilder.swift
+++ b/Sources/RepoBar/StatusBar/StatusBarMenuBuilder.swift
@@ -291,7 +291,7 @@ final class StatusBarMenuBuilder {
         let sorted = RepositoryPipeline.apply(baseRepos, query: query)
         let displayIndex = session.menuDisplayIndex
         let models = sorted.map { repo in
-            displayIndex[repo.fullName]
+            displayIndex[repo.fullName.lowercased()]
                 ?? RepositoryDisplayModel(
                     repo: repo,
                     localStatus: session.localRepoIndex.status(for: repo),
@@ -312,7 +312,7 @@ final class StatusBarMenuBuilder {
 
         var models: [RepositoryDisplayModel] = []
         for localStatus in localRepos {
-            if let fullName = localStatus.fullName,
+            if let fullName = localStatus.fullName?.lowercased(),
                let existingModel = displayIndex[fullName] {
                 models.append(existingModel)
             } else {

--- a/Sources/RepoBar/StatusBar/StatusBarMenuBuilder.swift
+++ b/Sources/RepoBar/StatusBar/StatusBarMenuBuilder.swift
@@ -185,7 +185,7 @@ final class StatusBarMenuBuilder {
                 if index < repos.count - 1 {
                     items.append(self.repoCardSeparator())
                 }
-                usedRepoKeys.insert(repo.title)
+                usedRepoKeys.insert(repo.id)
             }
             self.repoMenuItemCache = self.repoMenuItemCache.filter { usedRepoKeys.contains($0.key) }
             self.repoSubmenuCache = self.repoSubmenuCache.filter { usedRepoKeys.contains($0.key) }
@@ -301,7 +301,8 @@ final class StatusBarMenuBuilder {
         settings: UserSettings,
         now: Date
     ) -> [RepositoryDisplayModel] {
-        let localRepos = session.localRepoIndex.all
+        // Filter out worktrees - they appear in parent repo's "Switch Worktree" submenu
+        let localRepos = session.localRepoIndex.all.filter { $0.worktreeName == nil }
         let displayIndex = session.menuDisplayIndex
 
         var models: [RepositoryDisplayModel] = []

--- a/Sources/RepoBar/StatusBar/StatusBarMenuBuilder.swift
+++ b/Sources/RepoBar/StatusBar/StatusBarMenuBuilder.swift
@@ -154,15 +154,20 @@ final class StatusBarMenuBuilder {
             }
             return []
         case .filters:
-            guard case .loggedIn = session.account else { return [] }
-            guard session.hasLoadedRepositories else { return [] }
+            let isLoggedIn = session.account.isLoggedIn
+            let hasLocalFolder = session.settings.localProjects.rootPath?.isEmpty == false
+            // Show filters if logged in with repos, OR if local folder is configured
+            guard isLoggedIn ? session.hasLoadedRepositories : hasLocalFolder else { return [] }
             let filters = MenuRepoFiltersView(session: session)
                 .padding(.horizontal, 0)
                 .padding(.vertical, 0)
             return [self.viewItem(for: filters, enabled: true)]
         case .repoList:
-            guard case .loggedIn = session.account else { return [] }
-            if !session.hasLoadedRepositories {
+            let isLoggedIn = session.account.isLoggedIn
+            let isLocalScope = session.menuRepoSelection.isLocalScope
+            // Allow repo list for logged in users, or for local scope when logged out
+            guard isLoggedIn || isLocalScope else { return [] }
+            if isLoggedIn && !session.hasLoadedRepositories {
                 let loading = MenuLoadingRowView()
                     .padding(.horizontal, MenuStyle.sectionHorizontalPadding)
                     .padding(.vertical, MenuStyle.sectionVerticalPadding)

--- a/Sources/RepoBar/StatusBar/StatusBarMenuManager.swift
+++ b/Sources/RepoBar/StatusBar/StatusBarMenuManager.swift
@@ -92,13 +92,17 @@ final class StatusBarMenuManager: NSObject, NSMenuDelegate {
 
     @objc func menuFiltersChanged() {
         guard let menu = self.mainMenu else { return }
-        self.recentListCoordinator.clearMenus()
-        self.appState.persistSettings()
-        let plan = self.menuBuilder.mainMenuPlan()
-        self.menuBuilder.populateMainMenu(menu, repos: plan.repos)
-        self.lastMainMenuSignature = plan.signature
-        self.menuBuilder.refreshMenuViewHeights(in: menu)
-        menu.update()
+        // Defer menu rebuild to next run loop to avoid modifying menu during layout
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.recentListCoordinator.clearMenus()
+            self.appState.persistSettings()
+            let plan = self.menuBuilder.mainMenuPlan()
+            self.menuBuilder.populateMainMenu(menu, repos: plan.repos)
+            self.lastMainMenuSignature = plan.signature
+            self.menuBuilder.refreshMenuViewHeights(in: menu)
+            menu.update()
+        }
     }
 
     @objc private func recentListFiltersChanged() {

--- a/Sources/RepoBar/Support/MenuRepoFilters.swift
+++ b/Sources/RepoBar/Support/MenuRepoFilters.swift
@@ -3,28 +3,32 @@ import RepoBarCore
 enum MenuRepoSelection: String, CaseIterable, Hashable {
     case all
     case pinned
+    case local
     case work
 
     var label: String {
         switch self {
         case .all: "All"
         case .pinned: "Pinned"
+        case .local: "Loc"
         case .work: "Work"
         }
     }
 
     var onlyWith: RepositoryOnlyWith {
         switch self {
-        case .all:
+        case .all, .pinned, .local:
             .none
         case .work:
             RepositoryOnlyWith(requireIssues: true, requirePRs: true)
-        case .pinned:
-            .none
         }
     }
 
     var isPinnedScope: Bool {
         self == .pinned
+    }
+
+    var isLocalScope: Bool {
+        self == .local
     }
 }

--- a/Sources/RepoBar/Support/MenuRepoFilters.swift
+++ b/Sources/RepoBar/Support/MenuRepoFilters.swift
@@ -10,7 +10,7 @@ enum MenuRepoSelection: String, CaseIterable, Hashable {
         switch self {
         case .all: "All"
         case .pinned: "Pinned"
-        case .local: "Loc"
+        case .local: "Local"
         case .work: "Work"
         }
     }

--- a/Sources/RepoBar/Views/MenuFilterViews.swift
+++ b/Sources/RepoBar/Views/MenuFilterViews.swift
@@ -7,15 +7,30 @@ struct MenuRepoFiltersView: View {
     private var availableFilters: [MenuRepoSelection] {
         if session.account.isLoggedIn {
             return MenuRepoSelection.allCases
-        } else {
-            // Only local filter when logged out (All/Pinned/Work require GitHub)
-            return [.local]
         }
+        // Only local filter when logged out (All/Pinned/Work require GitHub)
+        return [.local]
+    }
+
+    private var filterSelection: Binding<MenuRepoSelection> {
+        Binding(
+            get: {
+                if self.session.account.isLoggedIn { return self.session.menuRepoSelection }
+                return .local
+            },
+            set: { newValue in
+                if self.session.account.isLoggedIn {
+                    self.session.menuRepoSelection = newValue
+                } else {
+                    self.session.menuRepoSelection = .local
+                }
+            }
+        )
     }
 
     var body: some View {
         HStack(spacing: 1) {
-            Picker("Filter", selection: self.$session.menuRepoSelection) {
+            Picker("Filter", selection: self.filterSelection) {
                 ForEach(self.availableFilters, id: \.self) { selection in
                     Text(selection.label).tag(selection)
                 }

--- a/Sources/RepoBar/Views/MenuFilterViews.swift
+++ b/Sources/RepoBar/Views/MenuFilterViews.swift
@@ -4,10 +4,19 @@ import SwiftUI
 struct MenuRepoFiltersView: View {
     @Bindable var session: Session
 
+    private var availableFilters: [MenuRepoSelection] {
+        if session.account.isLoggedIn {
+            return MenuRepoSelection.allCases
+        } else {
+            // Only local filter when logged out (All/Pinned/Work require GitHub)
+            return [.local]
+        }
+    }
+
     var body: some View {
         HStack(spacing: 1) {
             Picker("Filter", selection: self.$session.menuRepoSelection) {
-                ForEach(MenuRepoSelection.allCases, id: \.self) { selection in
+                ForEach(self.availableFilters, id: \.self) { selection in
                     Text(selection.label).tag(selection)
                 }
             }

--- a/Tests/RepoBarTests/LocalProjectsServiceTests.swift
+++ b/Tests/RepoBarTests/LocalProjectsServiceTests.swift
@@ -183,6 +183,35 @@ struct LocalProjectsServiceTests {
     }
 
     @Test
+    func localRepoIndex_prefersHigherHierarchyForDuplicateFullNames() {
+        let worktree = LocalRepoStatus(
+            path: URL(fileURLWithPath: "/tmp/Repo/.work/feature"),
+            name: "Repo",
+            fullName: "owner/Repo",
+            branch: "feature",
+            isClean: true,
+            aheadCount: 0,
+            behindCount: 0,
+            syncState: .synced,
+            worktreeName: "feature"
+        )
+        let root = LocalRepoStatus(
+            path: URL(fileURLWithPath: "/tmp/Repo"),
+            name: "Repo",
+            fullName: "owner/Repo",
+            branch: "main",
+            isClean: true,
+            aheadCount: 0,
+            behindCount: 0,
+            syncState: .synced
+        )
+        let index = LocalRepoIndex(statuses: [worktree, root])
+
+        let selected = index.status(forFullName: "OWNER/REPO")
+        #expect(selected?.path.path == root.path.path)
+    }
+
+    @Test
     func localRepoIndex_prefersPreferredPath() {
         let primary = LocalRepoStatus(
             path: URL(fileURLWithPath: "/tmp/repo-a"),


### PR DESCRIPTION
## Summary
Enable users to view and manage local repositories without signing into GitHub. The local scanning infrastructure was already independent - this change unlocks the UI.

> **Note:** This PR builds on #19. Merge #19 first.

## Changes
- Add `isLoggedIn` helper to `AccountState` for cleaner guard logic
- Show filter bar when logged out if local folder is configured
- Show repo list for local scope when logged out
- Only display "Local" filter option when not signed in (hide All/Pinned/Work)
- Auto-select local filter when user logs out

## Why
Users can now use RepoBar purely for local git repository management without requiring a GitHub account. This makes the app useful for:
- Developers who don't use GitHub
- Air-gapped environments
- Quick local repo overview without authentication

## Test plan
- [x] Sign out of GitHub (or use fresh app with no login)
- [x] Set local projects folder in Settings
- [x] Verify only "Local" filter shows (not All/Pinned/Work)
- [x] Verify local repos appear in the menu
- [x] Sign back in - verify all filters return

🤖 Generated with [Claude Code](https://claude.ai/code)

<img width="365" height="482" alt="Screenshot 2026-01-18 at 11 17 31 PM" src="https://github.com/user-attachments/assets/63181a8a-9913-403a-afda-a332aa2dcd53" />
