### PR TITLE
feat: add import-gh-token command for SSO-enabled organizations

### DIFF
--- a/Sources/repobarcli/CLIEntry.swift
+++ b/Sources/repobarcli/CLIEntry.swift
@@ -68,6 +68,7 @@ enum RepoBarCLI {
         SettingsSetCommand.commandName: SettingsSetCommand.self,
         LoginCommand.commandName: LoginCommand.self,
         LogoutCommand.commandName: LogoutCommand.self,
+        ImportGHTokenCommand.commandName: ImportGHTokenCommand.self,
         StatusCommand.commandName: StatusCommand.self
     ]
 

--- a/Sources/repobarcli/CLIHelpers.swift
+++ b/Sources/repobarcli/CLIHelpers.swift
@@ -257,6 +257,7 @@ enum HelpTarget: String {
     case settingsSet
     case login
     case logout
+    case importGHToken
     case status
 
     static func from(argv: [String]) -> HelpTarget? {
@@ -341,6 +342,8 @@ enum HelpTarget: String {
             return .login
         case LogoutCommand.commandName:
             return .logout
+        case ImportGHTokenCommand.commandName:
+            return .importGHToken
         case StatusCommand.commandName:
             return .status
         default:
@@ -389,6 +392,7 @@ func printHelp(_ target: HelpTarget) {
           repobar settings set <key> <value> [--json] [--plain]
           repobar login [--host URL] [--client-id ID] [--client-secret SECRET] [--loopback-port PORT]
           repobar logout
+          repobar import-gh-token
           repobar status [--json]
 
         Options:
@@ -826,6 +830,22 @@ func printHelp(_ target: HelpTarget) {
 
         Usage:
           repobar logout
+        """
+    case .importGHToken:
+        """
+        repobar import-gh-token - import token from GitHub CLI (gh)
+
+        Usage:
+          repobar import-gh-token
+
+        Imports the authentication token from GitHub CLI (gh) into RepoBar.
+        This is useful for SSO-enabled organizations where you've already
+        authorized the gh CLI but need to use that same access in RepoBar.
+
+        Prerequisites:
+          - GitHub CLI must be installed (brew install gh)
+          - You must be logged in via gh (gh auth login)
+          - Your gh token should have SSO authorization for your org
         """
     case .status:
         """


### PR DESCRIPTION
## Summary

Adds a new CLI command `repobar import-gh-token` that imports the authentication token from GitHub CLI (gh) into RepoBar's keychain.

This is useful for users in **SSO-enabled organizations** where:
- The gh CLI is already authorized for their org via SAML SSO
- RepoBar's built-in OAuth flow can't get org access (requires org admin approval for third-party OAuth apps)

## Usage

```bash
repobar import-gh-token
```

## How it works

1. Reads the token from `gh auth token`
2. Stores it in RepoBar's keychain with a 1-year expiry
3. Works with both the CLI and the menu bar app (shared keychain)

## Prerequisites

- GitHub CLI must be installed (`brew install gh`)
- User must be logged in via gh (`gh auth login`)
- The gh token should have SSO authorization for the target org

## Test plan

- [x] Build and run `repobar import-gh-token`
- [x] Verify token is imported successfully
- [x] Verify `repobar list` shows organization repos
- [x] Verify menu bar app shows organization repos
- [x] Verify `repobar import-gh-token --help` shows usage info

Fixes #2