### PR TITLE
feat: keep menu open after hide/pin/unpin/move actions

### DIFF
--- a/Sources/RepoBar/StatusBar/StatusBarMenuManager+Actions.swift
+++ b/Sources/RepoBar/StatusBar/StatusBarMenuManager+Actions.swift
@@ -216,24 +216,29 @@ extension StatusBarMenuManager {
     @objc func pinRepo(_ sender: NSMenuItem) {
         guard let fullName = self.repoFullName(from: sender) else { return }
         Task { await self.appState.addPinned(fullName) }
+        self.reopenMenuAfterAction()
     }
 
     @objc func unpinRepo(_ sender: NSMenuItem) {
         guard let fullName = self.repoFullName(from: sender) else { return }
         Task { await self.appState.removePinned(fullName) }
+        self.reopenMenuAfterAction()
     }
 
     @objc func hideRepo(_ sender: NSMenuItem) {
         guard let fullName = self.repoFullName(from: sender) else { return }
         Task { await self.appState.hide(fullName) }
+        self.reopenMenuAfterAction()
     }
 
     @objc func moveRepoUp(_ sender: NSMenuItem) {
         self.moveRepo(sender: sender, direction: -1)
+        self.reopenMenuAfterAction()
     }
 
     @objc func moveRepoDown(_ sender: NSMenuItem) {
         self.moveRepo(sender: sender, direction: 1)
+        self.reopenMenuAfterAction()
     }
 
     private func moveRepo(sender: NSMenuItem, direction: Int) {

--- a/Sources/RepoBar/StatusBar/StatusBarMenuManager.swift
+++ b/Sources/RepoBar/StatusBar/StatusBarMenuManager.swift
@@ -71,6 +71,15 @@ final class StatusBarMenuManager: NSObject, NSMenuDelegate {
         self.logMenuEvent("attachMainMenu statusItem=\(self.objectID(statusItem)) menuItems=\(menu.items.count)")
     }
 
+    /// Re-opens the menu after an action to keep it visible.
+    /// Call this from actions like hide/pin/unpin that shouldn't close the menu.
+    func reopenMenuAfterAction() {
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(50))
+            self.statusItem?.button?.performClick(nil)
+        }
+    }
+
     // MARK: - Menu actions
 
     @objc func refreshNow() {


### PR DESCRIPTION
## Summary

Adds a helper method `reopenMenuAfterAction()` that re-opens the menu after organizational actions, allowing users to perform multiple actions (like hiding several repos) without manually reopening the menu each time.

## Problem

Currently, when you click "Hide" on a repo, the menu closes. If you want to hide multiple repos, you have to:
1. Click menu bar icon
2. Click Hide on repo
3. Menu closes
4. Click menu bar icon again
5. Repeat...

## Solution

After hide/pin/unpin/move actions, the menu automatically reopens so you can continue managing repos without extra clicks.

## Affected actions

- `hideRepo`
- `pinRepo`
- `unpinRepo`
- `moveRepoUp`
- `moveRepoDown`

## Test plan

- [x] Click "Hide" on a repo → menu stays open
- [x] Click "Pin" on a repo → menu stays open
- [x] Click "Unpin" on a repo → menu stays open
- [x] Move pinned repo up/down → menu stays open
- [x] Other menu actions (open repo, copy URL, etc.) still close menu as expected