### PR TITLE
fix: add LRU eviction to unbounded caches to prevent memory leaks

### DIFF
--- a/Sources/RepoBar/StatusBar/RecentMenuService.swift
+++ b/Sources/RepoBar/StatusBar/RecentMenuService.swift
@@ -194,6 +194,20 @@ final class RecentMenuService {
         return hasher.finalize()
     }
 
+    /// Clears all in-memory caches to free memory.
+    func clearAllCaches() {
+        self.recentIssuesCache.clear()
+        self.recentPullRequestsCache.clear()
+        self.recentReleasesCache.clear()
+        self.recentWorkflowRunsCache.clear()
+        self.recentCommitsCache.clear()
+        self.recentDiscussionsCache.clear()
+        self.recentTagsCache.clear()
+        self.recentBranchesCache.clear()
+        self.recentContributorsCache.clear()
+        self.recentCommitCounts.removeAll()
+    }
+
     private func commitDescriptor() -> RecentMenuDescriptor {
         RecentMenuDescriptor(
             kind: .commits,
@@ -319,18 +333,29 @@ enum RecentMenuItems: Sendable {
     }
 }
 
+@MainActor
 final class RecentListCache<Item: Sendable> {
     struct Entry {
         var fetchedAt: Date
         var items: [Item]
     }
 
+    /// Maximum number of repository entries to retain per cache type.
+    private let maxEntries: Int
     private var entries: [String: Entry] = [:]
+    /// Tracks access order for LRU eviction (most recent at end)
+    private var accessOrder: [String] = []
     private var inflight: [String: Task<[Item], Error>] = [:]
+
+    init(maxEntries: Int = 50) {
+        self.maxEntries = maxEntries
+    }
 
     func cached(for key: String, now: Date, maxAge: TimeInterval) -> [Item]? {
         guard let entry = self.entries[key] else { return nil }
         guard now.timeIntervalSince(entry.fetchedAt) <= maxAge else { return nil }
+        // Move to end of access order (most recently used)
+        self.touchAccessOrder(key)
         return entry.items
     }
 
@@ -355,6 +380,39 @@ final class RecentListCache<Item: Sendable> {
     }
 
     func store(_ items: [Item], for key: String, fetchedAt: Date) {
+        let isNewKey = self.entries[key] == nil
+
+        if isNewKey {
+            // Only evict when inserting a new key
+            while self.entries.count >= self.maxEntries, let oldest = self.accessOrder.first {
+                self.accessOrder.removeFirst()
+                self.entries.removeValue(forKey: oldest)
+            }
+            self.accessOrder.append(key)
+        } else {
+            // Update existing key - move to end of access order
+            self.touchAccessOrder(key)
+        }
+
         self.entries[key] = Entry(fetchedAt: fetchedAt, items: items)
+    }
+
+    func clear() {
+        self.entries.removeAll()
+        self.accessOrder.removeAll()
+        self.inflight.values.forEach { $0.cancel() }
+        self.inflight.removeAll()
+    }
+
+    var count: Int {
+        self.entries.count
+    }
+
+    /// Moves key to end of access order (most recently used)
+    private func touchAccessOrder(_ key: String) {
+        if let index = self.accessOrder.firstIndex(of: key) {
+            self.accessOrder.remove(at: index)
+            self.accessOrder.append(key)
+        }
     }
 }

--- a/Sources/RepoBarCore/Support/ETagCache.swift
+++ b/Sources/RepoBarCore/Support/ETagCache.swift
@@ -28,22 +28,24 @@ actor ETagCache {
     func save(url: URL, etag: String?, data: Data) {
         guard let etag else { return }
         let key = url.absoluteString
+        let isNewKey = self.store[key] == nil
 
-        // If key already exists, remove from access order (will re-add at end)
-        if self.store[key] != nil {
+        if isNewKey {
+            // Only evict when inserting a new key
+            while self.store.count >= self.maxEntries, let oldest = self.accessOrder.first {
+                self.accessOrder.removeFirst()
+                self.store.removeValue(forKey: oldest)
+            }
+            self.accessOrder.append(key)
+        } else {
+            // Update existing key - move to end of access order
             if let index = self.accessOrder.firstIndex(of: key) {
                 self.accessOrder.remove(at: index)
+                self.accessOrder.append(key)
             }
         }
 
-        // Evict oldest entries if at capacity
-        while self.store.count >= self.maxEntries, let oldest = self.accessOrder.first {
-            self.accessOrder.removeFirst()
-            self.store.removeValue(forKey: oldest)
-        }
-
         self.store[key] = (etag, data)
-        self.accessOrder.append(key)
     }
 
     func setRateLimitReset(date: Date) {

--- a/Sources/RepoBarCore/Support/ETagCache.swift
+++ b/Sources/RepoBarCore/Support/ETagCache.swift
@@ -1,17 +1,49 @@
 import Foundation
 
-/// Simple in-memory ETag cache keyed by URL string.
+/// Simple in-memory ETag cache keyed by URL string with LRU eviction.
 actor ETagCache {
+    /// Maximum number of entries to retain. Oldest entries are evicted when exceeded.
+    private let maxEntries: Int
+
     private var store: [String: (etag: String, data: Data)] = [:]
+    /// Tracks access order for LRU eviction (most recent at end)
+    private var accessOrder: [String] = []
     private var rateLimitedUntil: Date?
 
+    init(maxEntries: Int = 200) {
+        self.maxEntries = maxEntries
+    }
+
     func cached(for url: URL) -> (etag: String, data: Data)? {
-        self.store[url.absoluteString]
+        let key = url.absoluteString
+        guard let value = self.store[key] else { return nil }
+        // Move to end of access order (most recently used)
+        if let index = self.accessOrder.firstIndex(of: key) {
+            self.accessOrder.remove(at: index)
+            self.accessOrder.append(key)
+        }
+        return value
     }
 
     func save(url: URL, etag: String?, data: Data) {
         guard let etag else { return }
-        self.store[url.absoluteString] = (etag, data)
+        let key = url.absoluteString
+
+        // If key already exists, remove from access order (will re-add at end)
+        if self.store[key] != nil {
+            if let index = self.accessOrder.firstIndex(of: key) {
+                self.accessOrder.remove(at: index)
+            }
+        }
+
+        // Evict oldest entries if at capacity
+        while self.store.count >= self.maxEntries, let oldest = self.accessOrder.first {
+            self.accessOrder.removeFirst()
+            self.store.removeValue(forKey: oldest)
+        }
+
+        self.store[key] = (etag, data)
+        self.accessOrder.append(key)
     }
 
     func setRateLimitReset(date: Date) {
@@ -34,6 +66,7 @@ actor ETagCache {
 
     func clear() {
         self.store.removeAll()
+        self.accessOrder.removeAll()
         self.rateLimitedUntil = nil
     }
 


### PR DESCRIPTION
## Summary

- Add LRU eviction to `ETagCache` with 200 entry limit
- Add LRU eviction to `RecentListCache` with 50 entry limit per cache type
- Add `@MainActor` to `RecentListCache` for explicit thread safety
- Add `clearAllCaches()` method to `RecentMenuService` for manual cache clearing

## Problem

After running for ~2.5 days, RepoBar accumulated ~2GB of memory due to unbounded in-memory caches:

1. **ETagCache**: Stored `(etag, Data)` tuples for every URL ever fetched with no eviction
2. **RecentListCache**: 9 separate caches (issues, PRs, releases, commits, discussions, tags, branches, contributors, workflow runs) that stored data per repository key without eviction
3. **recentCommitCounts**: Dictionary that grew without bound

## Solution

Add LRU (Least Recently Used) eviction to both cache types using an access-order tracking array:

### ETagCache
- Track access order with an array
- Evict least recently used entries when exceeding 200 entries
- Move accessed entries to end of order list (most recently used)

### RecentListCache
- Track access order with an array (same pattern as ETagCache)
- Only evict when inserting new keys (not when updating existing)
- Evict least recently accessed entries when exceeding 50 entries per cache type
- Add `@MainActor` isolation for thread safety

The limits are conservative to maintain good cache hit rates while preventing unbounded growth.

## Test plan

- [x] Build succeeds (`swift build`)
- [x] All 257 tests pass (`swift test`)
- [x] CodeRabbit review passed (addressed all issues)
- [ ] Memory usage stays bounded after extended runtime (requires multi-day testing)

Fixes #13

🤖 Generated with [Claude Code](https://claude.ai/code)