### PR TITLE
fix: correct grammatically awkward cooldown message (#38)

### DIFF
--- a/Sources/RepoBarCore/API/GitHubRequestRunner.swift
+++ b/Sources/RepoBarCore/API/GitHubRequestRunner.swift
@@ -52,7 +52,7 @@ actor GitHubRequestRunner {
             await self.diag.message("Cooldown active for \(url.absoluteString) until \(cooldown)")
             throw GitHubAPIError.serviceUnavailable(
                 retryAfter: cooldown,
-                message: "Cooling down until \(RelativeFormatter.string(from: cooldown, relativeTo: Date()))."
+                message: "Cooldown active; retry \(RelativeFormatter.string(from: cooldown, relativeTo: Date()))."
             )
         }
 


### PR DESCRIPTION
## Summary
- Changed 'Cooling down until in X sec' to 'Cooldown active; retry in X sec'
- Fixes awkward 'until in' construction
- Matches internal logging style ('Cooldown active for...')
- Works naturally with RelativeFormatter output

## Test Plan
- [x] All tests pass (257 tests in 72 suites)
- [x] Verified message now reads 'Cooldown active; retry in 10 sec' instead of 'Cooling down until in 10 secs'

Closes #38