### PR TITLE
fix: correct grammatically awkward cooldown message

### DIFF
--- a/Sources/RepoBarCore/API/GitHubRequestRunner.swift
+++ b/Sources/RepoBarCore/API/GitHubRequestRunner.swift
@@ -52,7 +52,7 @@ actor GitHubRequestRunner {
             await self.diag.message("Cooldown active for \(url.absoluteString) until \(cooldown)")
             throw GitHubAPIError.serviceUnavailable(
                 retryAfter: cooldown,
-                message: "Cooling down until \(RelativeFormatter.string(from: cooldown, relativeTo: Date()))."
+                message: "Cooldown active; retry \(RelativeFormatter.string(from: cooldown, relativeTo: Date()))."
             )
         }
 


### PR DESCRIPTION
Fix the grammatically awkward cooldown message in `GitHubRequestRunner.swift`.

**Before:** "Cooling down until in 10 secs." (the "until in" construction is incorrect)
**After:** "Cooldown active; retry in 10 sec."

This matches the internal logging style on line 52 and works naturally with `RelativeFormatter` output.

Fixes #38