### PR TITLE
fix: strip keychain-access-groups entitlement in release builds

### DIFF
--- a/Scripts/sign-and-notarize.sh
+++ b/Scripts/sign-and-notarize.sh
@@ -52,7 +52,7 @@ if [[ -z "$APP_BUNDLE" ]]; then
 fi
 
 echo "Signing with $APP_IDENTITY"
-export REPOBAR_SKIP_KEYCHAIN_GROUPS="${REPOBAR_SKIP_KEYCHAIN_GROUPS:-0}"
+export REPOBAR_SKIP_KEYCHAIN_GROUPS="${REPOBAR_SKIP_KEYCHAIN_GROUPS:-1}"
 ./Scripts/codesign_app.sh "$APP_BUNDLE" "$APP_IDENTITY"
 
 DITTO_BIN=${DITTO_BIN:-/usr/bin/ditto}


### PR DESCRIPTION
## Summary

The release build is killed by AMFI (Apple Mobile File Integrity) on macOS 15.7+ and Tahoe because it ships with a `keychain-access-groups` entitlement but no provisioning profile to validate it. This affects every user who installs the release binary (issues #27, #29, #34). The local dev build works fine because it already strips this entitlement.

**One-line fix:** Change the default for `REPOBAR_SKIP_KEYCHAIN_GROUPS` from `0` to `1` in `Scripts/sign-and-notarize.sh`, so the release build strips the entitlement by default — matching the dev build behavior.

Closes #27, closes #29, closes #34

## Root Cause

- `sign-and-notarize.sh:55` defaulted `REPOBAR_SKIP_KEYCHAIN_GROUPS` to `0` (keep entitlement)
- `compile_and_run.sh:47-49` defaults to `1` (strip entitlement) when no provisioning profile exists
- The release build shipped with `keychain-access-groups: Y5PE65HELJ.com.steipete.repobar.shared` but no `embedded.provisionprofile` to satisfy AMFI

## Why This Is Safe

`TokenStore.swift` already handles the missing entitlement gracefully:
- `defaultAccessGroup()` (line 92-111) returns `nil` when the entitlement isn't present
- `accessGroupsForOperation()` (line 169-172) falls back to `[nil]` — keychain ops work without an access group
- `shouldRetryWithoutAccessGroup()` (line 186-194) retries on `errSecMissingEntitlement`

The only trade-off: the app and bundled CLI (`repobarcli`) won't use a shared keychain access group. Both use their default group, which means tokens saved by one won't be directly readable by the other. This is the same behavior the dev build has always had.

The override is preserved — set `REPOBAR_SKIP_KEYCHAIN_GROUPS=0` if a provisioning profile is available.

## Prompts Used

> The project doesn't work when I try launch it on my mac. How can I get some kind of logs to help debug the issue and fix it?

> The main thing is that I get this error from using the release version on github. If you look at the issues, everyone has this problem so its not a problem with the dev build here locally, its the release version that has this problem too

## Plan

<details>
<summary>Full investigation and fix plan</summary>

### Context

The release build of RepoBar is killed by AMFI (Apple Mobile File Integrity) on macOS 15.7+ and Tahoe because it includes a `keychain-access-groups` entitlement without a provisioning profile to validate it. This affects every user who installs the release binary (issues #27, #29, #34). The local dev build (`pnpm start` / `compile_and_run.sh`) works because it strips this entitlement when no provisioning profile is present.

### Root Cause

- `sign-and-notarize.sh:55` defaults `REPOBAR_SKIP_KEYCHAIN_GROUPS` to `0` (keep entitlement)
- `compile_and_run.sh:47-49` defaults to `1` (strip entitlement) when no provisioning profile exists
- The release build ships with `keychain-access-groups: Y5PE65HELJ.com.steipete.repobar.shared` but no `embedded.provisionprofile` to satisfy AMFI

### Fix

One-line change in `Scripts/sign-and-notarize.sh`:

Change line 55 from:
```bash
export REPOBAR_SKIP_KEYCHAIN_GROUPS="${REPOBAR_SKIP_KEYCHAIN_GROUPS:-0}"
```
To:
```bash
export REPOBAR_SKIP_KEYCHAIN_GROUPS="${REPOBAR_SKIP_KEYCHAIN_GROUPS:-1}"
```

### Why This Is Safe

`TokenStore.swift` already handles the missing entitlement gracefully:
- `defaultAccessGroup()` (line 92-111) returns `nil` when the entitlement isn't present
- `accessGroupsForOperation()` (line 169-172) falls back to `[nil]` — keychain ops work without an access group
- `shouldRetryWithoutAccessGroup()` (line 186-194) retries on `errSecMissingEntitlement`

### Verification

1. Build locally with `pnpm start` — confirm it still works (no change to this path)
2. Inspect entitlements: `codesign -d --entitlements :- /Applications/RepoBar.app 2>&1` — confirm `keychain-access-groups` is absent
3. Launch the app — confirm no AMFI rejection in system logs

</details>

## Test plan

- [ ] Build locally with `pnpm start` — confirm dev build still works
- [ ] Build release with `sign-and-notarize.sh` — confirm app launches without AMFI rejection
- [ ] Inspect release entitlements with `codesign -d --entitlements :-` — confirm `keychain-access-groups` is absent
- [ ] Verify keychain operations (login/token storage) still work