### PR TITLE
fix: resolve app not launching on macOS 26.4 beta

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "88c021100d9cfb662e80c5e047f9f72f04129f7079c411478303e93b621dcec6",
+  "originHash" : "7c441efedb8eb9ce933695ba9ac0593dff9e736f1ede5beb38663c375bbf862c",
   "pins" : [
     {
       "identity" : "apollo-ios",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/orchetect/MenuBarExtraAccess",
       "state" : {
-        "revision" : "707dff6f55217b3ef5b6be84ced3e83511d4df5c",
-        "version" : "1.2.2"
+        "revision" : "33bb0e4b1e407feac791e047dcaaf9c69b25fd26",
+        "version" : "1.3.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/steipete/Commander", from: "0.2.0"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.8.1"),
-        .package(url: "https://github.com/orchetect/MenuBarExtraAccess", exact: "1.2.2"),
+        .package(url: "https://github.com/orchetect/MenuBarExtraAccess", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-algorithms", from: "1.2.1"),
         .package(url: "https://github.com/apple/swift-log", from: "1.8.0"),
         .package(url: "https://github.com/openid/AppAuth-iOS", from: "2.0.0"),

--- a/Sources/RepoBar/App/RepoBarApp.swift
+++ b/Sources/RepoBar/App/RepoBarApp.swift
@@ -24,7 +24,6 @@ struct RepoBarApp: App {
                     await self.ensureStatusItemAttached()
                 }
         }
-        .menuBarExtraStyle(.menu)
         .menuBarExtraAccess(isPresented: self.$isMenuPresented) { item in
             self.logMenuEvent("menuBarExtraAccess statusItem=\(self.objectID(item)) menuManager=\(self.menuManager != nil)")
             if self.menuManager == nil {
@@ -32,6 +31,7 @@ struct RepoBarApp: App {
             }
             self.menuManager?.attachMainMenu(to: item)
         }
+        .menuBarExtraStyle(.menu)
         .onChange(of: self.isMenuPresented) { _, newValue in
             self.logMenuEvent("isMenuPresented=\(newValue)")
         }


### PR DESCRIPTION
## Summary
- Update MenuBarExtraAccess from pinned 1.2.2 to 1.3.0, which improves status item discovery reliability on macOS 26
- Reorder scene modifiers so `.menuBarExtraAccess()` is applied before `.menuBarExtraStyle()` as required by MenuBarExtraAccess 1.3.0

## Context
The app failed to launch on macOS 26.4 beta. MenuBarExtraAccess 1.2.2 was only tested against macOS 26 beta 4, and the internal `NSSceneStatusItem` / `NSStatusBarWindow` hierarchy changed in later betas. Version 1.3.0 includes improved status item discovery that handles these changes.

## Test plan
- [x] Verified app builds successfully (`swift build -c release`)
- [x] Verified app launches and menu bar icon appears on macOS 26.4 beta
- [x] Verified menu opens and functions correctly on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)