### PR TITLE
[codex] fix settings issue and PR counts

### DIFF
--- a/Sources/RepoBar/App/AppState+Refresh.swift
+++ b/Sources/RepoBar/App/AppState+Refresh.swift
@@ -89,6 +89,7 @@ extension AppState {
             let targets = self.selectMenuTargets(from: ordered)
             let hydrated = await self.hydrateMenuTargets(targets)
             try Task.checkCancellation()
+            await self.updateAccessibleRepositories(self.mergeHydrated(hydrated, into: repos))
             let merged = self.mergeHydrated(hydrated, into: ordered)
             let final = self.applyPinnedOrder(to: merged)
             let localSnapshot = await localSnapshotTask.value
@@ -281,11 +282,7 @@ extension AppState {
     }
 
     private func mergeHydrated(_ detailed: [Repository], into repos: [Repository]) -> [Repository] {
-        let lookup = Dictionary(
-            detailed.map { ($0.fullName.lowercased(), $0) },
-            uniquingKeysWith: { first, _ in first }
-        )
-        return repos.map { lookup[$0.fullName.lowercased()] ?? $0 }
+        RepositoryHydration.merge(detailed, into: repos)
     }
 
     private func applyCachedMenuSnapshotIfAvailable(now: Date) async {

--- a/Sources/RepoBar/Support/RepositoryHydration.swift
+++ b/Sources/RepoBar/Support/RepositoryHydration.swift
@@ -1,0 +1,12 @@
+import Foundation
+import RepoBarCore
+
+enum RepositoryHydration {
+    static func merge(_ detailed: [Repository], into repos: [Repository]) -> [Repository] {
+        let lookup = Dictionary(
+            detailed.map { ($0.fullName.lowercased(), $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        return repos.map { lookup[$0.fullName.lowercased()] ?? $0 }
+    }
+}

--- a/Tests/RepoBarTests/RepositoryHydrationTests.swift
+++ b/Tests/RepoBarTests/RepositoryHydrationTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+@testable import RepoBar
+import RepoBarCore
+import Testing
+
+struct RepositoryHydrationTests {
+    @Test
+    func `merge keeps accessible repos and overlays hydrated stats`() {
+        let raw = [
+            Self.makeRepo("stablyai/orca", issues: 249, pulls: 0),
+            Self.makeRepo("steipete/RepoBar", issues: 1, pulls: 0)
+        ]
+        let hydrated = [
+            Self.makeRepo("stablyai/orca", issues: 0, pulls: 249)
+        ]
+
+        let merged = RepositoryHydration.merge(hydrated, into: raw)
+
+        #expect(merged.map(\.fullName) == ["stablyai/orca", "steipete/RepoBar"])
+        #expect(merged[0].openIssues == 0)
+        #expect(merged[0].openPulls == 249)
+        #expect(merged[1].openIssues == 1)
+        #expect(merged[1].openPulls == 0)
+    }
+}
+
+private extension RepositoryHydrationTests {
+    static func makeRepo(_ fullName: String, issues: Int, pulls: Int) -> Repository {
+        let parts = fullName.split(separator: "/", maxSplits: 1).map(String.init)
+        return Repository(
+            id: fullName,
+            name: parts[1],
+            owner: parts[0],
+            sortOrder: nil,
+            error: nil,
+            rateLimitedUntil: nil,
+            ciStatus: .unknown,
+            openIssues: issues,
+            openPulls: pulls,
+            latestRelease: nil,
+            latestActivity: nil,
+            traffic: nil,
+            heatmap: []
+        )
+    }
+}


### PR DESCRIPTION
## Problem

Fixes #50.

Settings could show a repository with `Issues 249 / PRs 0` even when GitHub showed `0` issues and `249` open PRs. The main menu had the right idea, but Settings could still render the broad repository list before detailed issue/PR hydration was applied.

## Root Cause

GitHub REST's repository field `open_issues_count` includes both issues and pull requests. RepoBar fixes that by fetching the open PR count and subtracting it when it hydrates detailed repository rows.

The bug was that `session.accessibleRepositories`, which feeds the Settings repository table, was published from the lightweight `/user/repos` list. The menu snapshot later overlaid hydrated rows, but Settings could keep the raw REST counts.

## Fix

- Extracted the existing hydrated-row overlay into `RepositoryHydration.merge`.
- Reused that merge before publishing `accessibleRepositories`.
- Preserved the full accessible repo list; only rows that have detailed stats are replaced.

That keeps Settings broad and fast while making hydrated rows agree with the menu and GitHub.

## Validation

- `pnpm test --filter RepositoryHydrationTests`
- `pnpm check`
- `pnpm restart`
- GitHub CI: macOS (Xcode 26.1) passing

## Risk

Low. The change reuses the same overlay behavior already used for the menu snapshot, now applied to the Settings source list too.
