### PR TITLE
[codex] fix blank recent-list submenus

### DIFF
--- a/Sources/RepoBar/StatusBar/MenuItemHosting.swift
+++ b/Sources/RepoBar/StatusBar/MenuItemHosting.swift
@@ -185,12 +185,12 @@ final class MenuItemHostingView: NSView, MenuItemMeasuring, MenuItemHighlighting
     }
 
     private func safeMeasuredHeight(from height: CGFloat) -> CGFloat {
-        if height.isFinite, height >= 0 {
+        if height.isFinite, height > 0 {
             return min(height, MenuItemMeasurementMetrics.maxHeight)
         }
 
         let intrinsic = self.hostingController.view.intrinsicContentSize.height
-        if intrinsic.isFinite, intrinsic >= 0 {
+        if intrinsic.isFinite, intrinsic > 0 {
             return min(intrinsic, MenuItemMeasurementMetrics.maxHeight)
         }
 

--- a/Tests/RepoBarTests/MenuItemHostingTests.swift
+++ b/Tests/RepoBarTests/MenuItemHostingTests.swift
@@ -11,8 +11,16 @@ struct MenuItemHostingTests {
         let height = view.measuredHeight(width: 360)
 
         #expect(height.isFinite)
-        #expect(height >= 0)
+        #expect(height > 0)
         #expect(height <= 360)
+    }
+
+    @MainActor
+    @Test
+    func `zero height SwiftUI rows use fallback height`() {
+        let view = MenuItemHostingView(rootView: AnyView(EmptyView()))
+
+        #expect(view.measuredHeight(width: 320) > 0)
     }
 
     @MainActor


### PR DESCRIPTION
## Problem

Fixes #49.

The reporter's screenshot shows the `Open Actions` submenu with only the header and separator visible. There is no loading row, empty row, timeout row, failure row, or workflow row, so the submenu body effectively collapsed.

## Root Cause

Recent-list submenu rows are hosted SwiftUI views inside `NSMenuItem.view`. `MenuItemHostingView` already protects against non-finite or invalid measurements by falling back to a safe row height, but it accepted `0` as a valid measured height.

If SwiftUI/AppKit reports a transient zero-height measurement for a hosted menu row, the row can be present but visually collapsed. That matches the observed state: the static AppKit header remains visible while the dynamic body appears blank.

## Fix

Treat zero-height measurements as invalid, just like non-finite measurements, and use the existing fallback height instead.

This is intentionally at the shared menu-hosting boundary rather than special-casing Actions. The same collapse could affect any hosted recent-list row.

## Validation

- `pnpm test --filter MenuItemHostingTests`
- `pnpm check`
- `pnpm restart`
- GitHub CI: macOS (Xcode 26.1) passing

## Risk

Low. Legitimate menu content should not need a zero-height row. Empty states still use normal disabled menu items; this only prevents hosted SwiftUI rows from disappearing when measurement returns zero.
