### PR TITLE
[codex] clarify endpoint cooldown messages

### DIFF
--- a/Sources/RepoBarCore/API/GitHubRequestRunner.swift
+++ b/Sources/RepoBarCore/API/GitHubRequestRunner.swift
@@ -58,7 +58,7 @@ actor GitHubRequestRunner {
             await self.diag.message("Cooldown active for \(url.absoluteString) until \(cooldown)")
             throw GitHubAPIError.serviceUnavailable(
                 retryAfter: cooldown,
-                message: "Cooldown active; retry \(RelativeFormatter.string(from: cooldown, relativeTo: Date()))."
+                message: Self.cooldownMessage(for: url, until: cooldown)
             )
         }
 
@@ -152,6 +152,10 @@ actor GitHubRequestRunner {
         return request
     }
 
+    static func cooldownMessage(for url: URL, until: Date, now: Date = Date()) -> String {
+        "GitHub endpoint cooldown (\(self.endpointDescription(for: url))); retry \(RelativeFormatter.string(from: until, relativeTo: now))"
+    }
+
     func clear() async {
         await self.etagCache.clear()
         await self.backoff.clear()
@@ -222,6 +226,36 @@ actor GitHubRequestRunner {
         } else if let reset = self.lastRateLimitReset, reset <= Date() {
             self.lastRateLimitReset = nil
             self.lastRateLimitError = nil
+        }
+    }
+
+    private static func endpointDescription(for url: URL) -> String {
+        let components = url.path.split(separator: "/").map(String.init)
+        let suffix: String = if let repoIndex = components.firstIndex(of: "repos"), components.count > repoIndex + 3 {
+            components[(repoIndex + 3)...].joined(separator: "/")
+        } else {
+            components.joined(separator: "/")
+        }
+
+        switch suffix {
+        case "":
+            return "repository details"
+        case "actions/runs":
+            return "Actions runs"
+        case "pulls":
+            return "pull requests"
+        case "issues":
+            return "issues"
+        case "releases":
+            return "releases"
+        case "stats/commit_activity":
+            return "commit activity"
+        case "traffic/clones":
+            return "traffic clones"
+        case "traffic/views":
+            return "traffic views"
+        default:
+            return suffix
         }
     }
 }

--- a/Tests/RepoBarTests/GitHubRequestRunnerTests.swift
+++ b/Tests/RepoBarTests/GitHubRequestRunnerTests.swift
@@ -16,7 +16,7 @@ struct GitHubRequestRunnerTests {
     }
 
     @Test
-    func `cooldown message reads naturally`() async throws {
+    func `cooldown message names endpoint`() async throws {
         let url = try #require(URL(string: "https://api.github.com/repos/owner/repo/stats/commit_activity"))
         let backoff = BackoffTracker()
         let retryAfter = Date().addingTimeInterval(30)
@@ -27,10 +27,21 @@ struct GitHubRequestRunnerTests {
             _ = try await runner.get(url: url, token: "token")
             Issue.record("Expected cooldown error")
         } catch let error as GitHubAPIError {
-            #expect(error.displayMessage.hasPrefix("Cooldown active; retry in "))
+            #expect(error.displayMessage.hasPrefix("GitHub endpoint cooldown (commit activity); retry in "))
             #expect(error.displayMessage.contains("until in") == false)
         } catch {
             Issue.record("Unexpected error: \(error)")
         }
+    }
+
+    @Test
+    func `cooldown message identifies actions endpoint`() throws {
+        let url = try #require(URL(string: "https://api.github.com/repos/owner/repo/actions/runs?per_page=20"))
+        let retryAfter = Date(timeIntervalSinceReferenceDate: 60)
+        let now = Date(timeIntervalSinceReferenceDate: 30)
+
+        let message = GitHubRequestRunner.cooldownMessage(for: url, until: retryAfter, now: now)
+
+        #expect(message == "GitHub endpoint cooldown (Actions runs); retry in 30 sec.")
     }
 }


### PR DESCRIPTION
## Problem

Fixes #51.

RepoBar could show cooldown/retry messages while the GitHub Rate Limits panel still showed plenty of REST and GraphQL budget. That made the UI look contradictory: users saw healthy global rate limits but refresh rows still claimed they had to retry.

## Root Cause

RepoBar tracks two different things:

- global GitHub rate-limit exhaustion, based on REST/GraphQL rate-limit headers
- per-endpoint cooldown/backoff, used for retryable endpoint-specific responses such as generated stats, Actions runs, traffic, or other temporarily unavailable resources

The user-facing cooldown message only said `Cooldown active`, so it did not explain that a specific endpoint was backed off while the global API budget remained healthy.

## Fix

- Build cooldown messages through `GitHubRequestRunner.cooldownMessage`.
- Name the endpoint category in the message, for example `Actions runs` or `commit activity`.
- Keep the retry timing from the existing `RelativeFormatter` path.

Example after this change:

`GitHub endpoint cooldown (Actions runs); retry in 30 sec.`

## Validation

- `pnpm test --filter GitHubRequestRunnerTests`
- `pnpm check`
- `pnpm restart`
- GitHub CI: macOS (Xcode 26.1) passing

## Risk

Low. This changes the displayed error text only; the cooldown/backoff behavior and retry timing are unchanged.
