### PR TITLE
[codex] fix restart script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "repobar": "swift build --product repobarcli && ./Scripts/codesign_cli.sh .build/debug/repobarcli && .build/debug/repobarcli",
     "repobarcli": "pnpm -s repobar",
     "start": "./Scripts/compile_and_run.sh",
-    "restart": "true",
+    "restart": "./Scripts/compile_and_run.sh",
     "stop": "pkill -f \"RepoBar.app/Contents/MacOS/RepoBar\" || true",
     "codegen": "./Scripts/apollo_codegen.sh",
     "ghql": "pnpm exec tsx Scripts/ghql.ts",


### PR DESCRIPTION
## Summary

- Restore the documented pnpm restart behavior by wiring it to Scripts/compile_and_run.sh.
- Keep the start/restart commands aligned with README, AGENTS.md, and auth-storage guidance.

## Validation

- pnpm -s exec node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); if (p.scripts.restart !== './Scripts/compile_and_run.sh') process.exit(1); console.log(p.scripts.restart)"
- timeout 60s pnpm test (fails before tests: swift: command not found in this environment)
