### PR TITLE
fix: build iOS app target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Infer the GitHub repository for bare references from copied local git paths like `~/Projects/crabbox`.
 - Make GitHub reference updates feel faster with shorter clipboard polling, cached local path inference, and progressive concurrent lookups.
 - Grow inline GitHub reference previews on larger displays so more of the issue or pull request is visible in the menu.
+- Fix the iOS app target build by avoiding macOS-only filesystem and git APIs (#61, thanks @jsj).
 
 ## 0.5.0 - 2026-05-09
 

--- a/RepoBariOS/Sources/Auth/OAuthCoordinator.swift
+++ b/RepoBariOS/Sources/Auth/OAuthCoordinator.swift
@@ -152,7 +152,7 @@ final class OAuthCoordinator: NSObject, ASWebAuthenticationPresentationContextPr
 
 private extension OAuthCoordinator {
     static func formUrlEncoded(_ params: [String: String]) -> Data? {
-        let encoded = params.map { key, value in
+        let encoded: String = params.map { key, value -> String in
             let k = key.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? key
             let v = value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? value
             return "\(k)=\(v)"

--- a/Sources/RepoBarCore/Auth/TokenStore.swift
+++ b/Sources/RepoBarCore/Auth/TokenStore.swift
@@ -145,8 +145,13 @@ extension TokenStore {
     }
 
     static func defaultFileDirectory() -> URL {
+        #if os(iOS)
+            let fallback = FileManager.default.temporaryDirectory
+        #else
+            let fallback = FileManager.default.homeDirectoryForCurrentUser
+        #endif
         let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
-            .first ?? FileManager.default.homeDirectoryForCurrentUser
+            .first ?? fallback
         return base
             .appendingPathComponent("RepoBar", isDirectory: true)
             .appendingPathComponent("DebugAuth", isDirectory: true)

--- a/Sources/RepoBarCore/Support/GitHubArchiveStore.swift
+++ b/Sources/RepoBarCore/Support/GitHubArchiveStore.swift
@@ -304,23 +304,28 @@ public enum GitHubArchiveStore {
     }
 
     private static func runGit(arguments: [String], workingDirectory: String?) throws {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
-        process.arguments = arguments
-        if let workingDirectory {
-            process.currentDirectoryURL = URL(fileURLWithPath: workingDirectory)
-        }
-        process.standardOutput = Pipe()
-        let error = Pipe()
-        process.standardError = error
-        try process.run()
-        process.waitUntilExit()
-        guard process.terminationStatus == 0 else {
-            let errorData = try error.fileHandleForReading.readToEnd() ?? Data()
-            let message = (String(bytes: errorData, encoding: .utf8) ?? "")
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            throw GitHubArchiveStoreError.gitFailed(message.isEmpty ? "git failed: \(arguments.joined(separator: " "))" : message)
-        }
+        #if os(macOS)
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+            process.arguments = arguments
+            if let workingDirectory {
+                process.currentDirectoryURL = URL(fileURLWithPath: workingDirectory)
+            }
+            process.standardOutput = Pipe()
+            let error = Pipe()
+            process.standardError = error
+            try process.run()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else {
+                let errorData = try error.fileHandleForReading.readToEnd() ?? Data()
+                let message = (String(bytes: errorData, encoding: .utf8) ?? "")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                throw GitHubArchiveStoreError.gitFailed(message.isEmpty ? "git failed: \(arguments.joined(separator: " "))" : message)
+            }
+
+        #else
+            throw GitHubArchiveStoreError.gitFailed("git is unavailable on this platform")
+        #endif
     }
 }
 

--- a/Sources/RepoBarCore/Support/GitHubReferenceLocalContext.swift
+++ b/Sources/RepoBarCore/Support/GitHubReferenceLocalContext.swift
@@ -73,28 +73,32 @@ public enum GitHubReferenceLocalContext {
     }
 
     public nonisolated static func gitHubRepositoryFullName(at path: String) -> String? {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        process.arguments = ["git", "-C", path, "remote", "get-url", "origin"]
-        var environment = ProcessInfo.processInfo.environment
-        environment["GIT_TERMINAL_PROMPT"] = "0"
-        environment["GIT_OPTIONAL_LOCKS"] = "0"
-        process.environment = environment
+        #if os(macOS)
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            process.arguments = ["git", "-C", path, "remote", "get-url", "origin"]
+            var environment = ProcessInfo.processInfo.environment
+            environment["GIT_TERMINAL_PROMPT"] = "0"
+            environment["GIT_OPTIONAL_LOCKS"] = "0"
+            process.environment = environment
 
-        let output = Pipe()
-        process.standardOutput = output
-        process.standardError = Pipe()
-        do {
-            try process.run()
-        } catch {
-            return nil
-        }
-        process.waitUntilExit()
-        guard process.terminationStatus == 0 else { return nil }
+            let output = Pipe()
+            process.standardOutput = output
+            process.standardError = Pipe()
+            do {
+                try process.run()
+            } catch {
+                return nil
+            }
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else { return nil }
 
-        let data = output.fileHandleForReading.readDataToEndOfFile()
-        let remote = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return self.gitHubRepositoryFullName(fromRemoteURL: remote)
+            let data = output.fileHandleForReading.readDataToEndOfFile()
+            let remote = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return self.gitHubRepositoryFullName(fromRemoteURL: remote)
+        #else
+            nil
+        #endif
     }
 
     public nonisolated static func gitHubRepositoryFullName(fromRemoteURL remote: String) -> String? {


### PR DESCRIPTION
## Summary
- include @jsj's iOS app target build fix from #61
- add the unreleased changelog entry crediting @jsj

## Verification
- main fails: `TokenStore.swift:149:43: 'homeDirectoryForCurrentUser' is unavailable in iOS`
- `xcodebuild -project RepoBariOS/RepoBariOS.xcodeproj -scheme RepoBariOS -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -derivedDataPath /tmp/RepoBar-pr61-dd build CODE_SIGNING_ALLOWED=NO`