### PR TITLE
fix: restore restart script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Make GitHub reference updates feel faster with shorter clipboard polling, cached local path inference, and progressive concurrent lookups.
 - Grow inline GitHub reference previews on larger displays so more of the issue or pull request is visible in the menu.
 - Fix the iOS app target build by avoiding macOS-only filesystem and git APIs (#61, thanks @jsj).
+- Restore `pnpm restart` so it rebuilds and relaunches the debug app as documented (#60, thanks @biefan).
 
 ## 0.5.0 - 2026-05-09
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "repobar": "swift build --product repobarcli && ./Scripts/codesign_cli.sh .build/debug/repobarcli && .build/debug/repobarcli",
     "repobarcli": "pnpm -s repobar",
     "start": "./Scripts/compile_and_run.sh",
-    "restart": "true",
+    "restart": "./Scripts/compile_and_run.sh",
     "stop": "pkill -f \"RepoBar.app/Contents/MacOS/RepoBar\" || true",
     "codegen": "./Scripts/apollo_codegen.sh",
     "ghql": "pnpm exec tsx Scripts/ghql.ts",


### PR DESCRIPTION
## Summary
- include @biefan's `pnpm restart` script fix from #60
- add the unreleased changelog entry crediting @biefan

## Verification
- `node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); if (p.scripts.restart !== './Scripts/compile_and_run.sh') process.exit(1); console.log(p.scripts.restart)"`
- `pnpm check`