### PR TITLE
feat: sortable columns in Settings Repository table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.6.3 - Unreleased
 
+- Make the Settings Repository table columns sortable (thanks @XueshiQiao).
 - Improve copied GitHub reference parsing for maintainer triage lists so bullet-leading references stay prioritized, compound issue lists resolve, and status counts are ignored.
 
 ## 0.6.2 - 2026-05-20

--- a/Sources/RepoBar/Settings/RepoBrowserRows.swift
+++ b/Sources/RepoBar/Settings/RepoBrowserRows.swift
@@ -29,15 +29,30 @@ struct RepoBrowserRow: Identifiable, Hashable {
     }
 
     // MARK: - Sortable keys
+
     //
     // KeyPathComparator needs concrete Comparable values, so optional stats are
     // folded to sentinels that sink unknown rows to the "low" end of the order.
 
-    var visibilitySortKey: Int { self.visibility.sortPriority }
-    var sortableIssues: Int { self.openIssues ?? -1 }
-    var sortablePulls: Int { self.openPulls ?? -1 }
-    var sortableStars: Int { self.stars ?? -1 }
-    var sortablePushedAt: Date { self.pushedAt ?? .distantPast }
+    var visibilitySortKey: Int {
+        self.visibility.sortPriority
+    }
+
+    var sortableIssues: Int {
+        self.openIssues ?? -1
+    }
+
+    var sortablePulls: Int {
+        self.openPulls ?? -1
+    }
+
+    var sortableStars: Int {
+        self.stars ?? -1
+    }
+
+    var sortablePushedAt: Date {
+        self.pushedAt ?? .distantPast
+    }
 
     func matches(_ query: String) -> Bool {
         let terms = query

--- a/Sources/RepoBar/Settings/RepoBrowserRows.swift
+++ b/Sources/RepoBar/Settings/RepoBrowserRows.swift
@@ -28,6 +28,17 @@ struct RepoBrowserRow: Identifiable, Hashable {
         self.stars.map(String.init) ?? "-"
     }
 
+    // MARK: - Sortable keys
+    //
+    // KeyPathComparator needs concrete Comparable values, so optional stats are
+    // folded to sentinels that sink unknown rows to the "low" end of the order.
+
+    var visibilitySortKey: Int { self.visibility.sortPriority }
+    var sortableIssues: Int { self.openIssues ?? -1 }
+    var sortablePulls: Int { self.openPulls ?? -1 }
+    var sortableStars: Int { self.stars ?? -1 }
+    var sortablePushedAt: Date { self.pushedAt ?? .distantPast }
+
     func matches(_ query: String) -> Bool {
         let terms = query
             .split(whereSeparator: \.isWhitespace)

--- a/Sources/RepoBar/Settings/RepoSettingsView.swift
+++ b/Sources/RepoBar/Settings/RepoSettingsView.swift
@@ -11,6 +11,10 @@ struct RepoSettingsView: View {
     @State private var allRows: [RepoBrowserRow] = []
     @State private var filteredRows: [RepoBrowserRow] = []
     @State private var statusLine = ""
+    @State private var sortOrder: [KeyPathComparator<RepoBrowserRow>] = [
+        KeyPathComparator(\RepoBrowserRow.visibilitySortKey, order: .forward),
+        KeyPathComparator(\RepoBrowserRow.fullName, order: .forward)
+    ]
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -50,8 +54,8 @@ struct RepoSettingsView: View {
                 .frame(width: 200)
             }
 
-            Table(self.filteredRows, selection: self.$selection) {
-                TableColumn("Repository") { row in
+            Table(self.filteredRows, selection: self.$selection, sortOrder: self.$sortOrder) {
+                TableColumn("Repository", value: \RepoBrowserRow.fullName) { row in
                     VStack(alignment: .leading, spacing: 2) {
                         Text(row.fullName)
                             .lineLimit(1)
@@ -77,35 +81,35 @@ struct RepoSettingsView: View {
                 }
                 .width(min: 300, ideal: 420, max: .infinity)
 
-                TableColumn("Issues") { row in
+                TableColumn("Issues", value: \RepoBrowserRow.sortableIssues) { row in
                     Text(row.issueLabel)
                         .monospacedDigit()
                         .foregroundStyle(row.isManual ? .secondary : .primary)
                 }
                 .width(min: 56, ideal: 64, max: 76)
 
-                TableColumn("PRs") { row in
+                TableColumn("PRs", value: \RepoBrowserRow.sortablePulls) { row in
                     Text(row.pullRequestLabel)
                         .monospacedDigit()
                         .foregroundStyle(row.isManual ? .secondary : .primary)
                 }
                 .width(min: 44, ideal: 52, max: 64)
 
-                TableColumn("Stars") { row in
+                TableColumn("Stars", value: \RepoBrowserRow.sortableStars) { row in
                     Text(row.starLabel)
                         .monospacedDigit()
                         .foregroundStyle(row.isManual ? .secondary : .primary)
                 }
                 .width(min: 52, ideal: 64, max: 76)
 
-                TableColumn("Updated") { row in
+                TableColumn("Updated", value: \RepoBrowserRow.sortablePushedAt) { row in
                     Text(row.updatedLabel)
                         .lineLimit(1)
                         .foregroundStyle(.secondary)
                 }
                 .width(min: 80, ideal: 96, max: 120)
 
-                TableColumn("Visibility") { row in
+                TableColumn("Visibility", value: \RepoBrowserRow.visibilitySortKey) { row in
                     RepoVisibilityMenu(visibility: row.visibility) { newValue in
                         Task { await self.set(row.fullName, to: newValue) }
                     }
@@ -152,6 +156,7 @@ struct RepoSettingsView: View {
             Task { try? await self.appState.github.prefetchedRepositories() }
         }
         .onChange(of: self.searchQuery) { _, _ in self.applySearch() }
+        .onChange(of: self.sortOrder) { _, _ in self.applySearch() }
         .onChange(of: self.session.accessibleRepositories) { _, _ in self.rebuildRows() }
         .onChange(of: self.session.repositories) { _, _ in self.rebuildRows() }
         .onChange(of: self.session.menuSnapshot) { _, _ in self.rebuildRows() }
@@ -207,7 +212,16 @@ struct RepoSettingsView: View {
     }
 
     private func applySearch() {
-        self.filteredRows = RepoBrowserRows.filter(self.allRows, query: self.searchQuery)
+        var rows = RepoBrowserRows.filter(self.allRows, query: self.searchQuery)
+        if !self.sortOrder.isEmpty {
+            // Append a stable fullName tiebreaker so equal-count rows keep a
+            // predictable order even when a header click reduces sortOrder
+            // to a single comparator.
+            var effective = self.sortOrder
+            effective.append(KeyPathComparator(\RepoBrowserRow.fullName, order: .forward))
+            rows.sort(using: effective)
+        }
+        self.filteredRows = rows
         self.selection.formIntersection(Set(self.filteredRows.map(\.id)))
         self.statusLine = RepoBrowserRows.statusLine(allRows: self.allRows, filteredRows: self.filteredRows)
     }

--- a/Tests/RepoBarTests/RepoBrowserRowsTests.swift
+++ b/Tests/RepoBarTests/RepoBrowserRowsTests.swift
@@ -41,6 +41,47 @@ struct RepoBrowserRowsTests {
     }
 
     @Test
+    func `sortable keys fold missing stats to a low sentinel`() {
+        let loaded = RepoBrowserRows.make(
+            repositories: [Self.makeRepo("a/loaded", issues: 3, pulls: 4, stars: 5)],
+            pinnedRepositories: [],
+            hiddenRepositories: [],
+            now: Date(timeIntervalSinceReferenceDate: 1000)
+        ).first!
+        let manual = RepoBrowserRows.make(
+            repositories: [],
+            pinnedRepositories: ["a/manual"],
+            hiddenRepositories: [],
+            now: Date(timeIntervalSinceReferenceDate: 1000)
+        ).first!
+
+        #expect(loaded.sortableIssues == 3)
+        #expect(loaded.sortablePulls == 4)
+        #expect(loaded.sortableStars == 5)
+        #expect(manual.sortableIssues == -1)
+        #expect(manual.sortablePulls == -1)
+        #expect(manual.sortableStars == -1)
+        #expect(manual.sortablePushedAt == .distantPast)
+    }
+
+    @Test
+    func `sorted by stars descending puts highest first and manual rows last`() {
+        let rows = RepoBrowserRows.make(
+            repositories: [
+                Self.makeRepo("a/low", stars: 1),
+                Self.makeRepo("a/high", stars: 100),
+                Self.makeRepo("a/mid", stars: 50)
+            ],
+            pinnedRepositories: ["a/manual"],
+            hiddenRepositories: [],
+            now: Date(timeIntervalSinceReferenceDate: 1000)
+        )
+        let comparator = KeyPathComparator(\RepoBrowserRow.sortableStars, order: .reverse)
+        let sorted = rows.sorted(using: [comparator])
+        #expect(sorted.map(\.fullName) == ["a/high", "a/mid", "a/low", "a/manual"])
+    }
+
+    @Test
     func `matches finds private org repository by owner or name`() {
         let row = RepoBrowserRows.make(
             repositories: [Self.makeRepo("amantus-ai/sweetistics")],

--- a/Tests/RepoBarTests/RepoBrowserRowsTests.swift
+++ b/Tests/RepoBarTests/RepoBrowserRowsTests.swift
@@ -41,19 +41,19 @@ struct RepoBrowserRowsTests {
     }
 
     @Test
-    func `sortable keys fold missing stats to a low sentinel`() {
-        let loaded = RepoBrowserRows.make(
+    func `sortable keys fold missing stats to a low sentinel`() throws {
+        let loaded = try #require(RepoBrowserRows.make(
             repositories: [Self.makeRepo("a/loaded", issues: 3, pulls: 4, stars: 5)],
             pinnedRepositories: [],
             hiddenRepositories: [],
             now: Date(timeIntervalSinceReferenceDate: 1000)
-        ).first!
-        let manual = RepoBrowserRows.make(
+        ).first)
+        let manual = try #require(RepoBrowserRows.make(
             repositories: [],
             pinnedRepositories: ["a/manual"],
             hiddenRepositories: [],
             now: Date(timeIntervalSinceReferenceDate: 1000)
-        ).first!
+        ).first)
 
         #expect(loaded.sortableIssues == 3)
         #expect(loaded.sortablePulls == 4)


### PR DESCRIPTION
## Summary

The Repository table under **Settings → Repository** previously rendered as a static list — clicking column headers did nothing. This PR makes every header sortable.

- Wire SwiftUI's `Table(sortOrder:)` and `TableColumn(_:value:)` for all six columns (Repository, Issues, PRs, Stars, Updated, Visibility).
- Expose `Comparable` sort keys on `RepoBrowserRow`. Optional stats (`Int?` counts, `Date?` push time) are folded to sentinels (`-1`, `.distantPast`) so manual rows (no fetched stats) sink to the low end of any ordering.
- After every sort, append a stable `fullName` ascending tiebreaker inside `applySearch()` so equal-count rows stay deterministic even after SwiftUI replaces `sortOrder` with a single comparator on header click.

## Demo

https://github.com/user-attachments/assets/510fb3e4-173d-4d96-92e9-078a2ba1155b


## Test plan

- [x] `swift build` clean
- [x] `swift test --filter RepoBrowserRowsTests` — 5/5 pass, including two new tests:
  - `sortable keys fold missing stats to a low sentinel`
  - `sorted by stars descending puts highest first and manual rows last`
- [x] Launched debug build via `./scripts/compile_and_run.sh` and verified each column sorts ascending/descending in **Settings → Repository**.

## Notes / open questions

- Sentinel asymmetry: manual rows surface first in ascending mode, last in descending mode. Always sinking them to the bottom would require a custom `SortComparator` instead of `KeyPathComparator`. Happy to add that if preferred.
- Initial `sortOrder` defaults to `[visibilitySortKey, fullName]` so first-load matches the previous visibility-priority-then-name behavior. A header click reduces this to a single column; the `fullName` tiebreaker is then re-injected by `applySearch()`.