### PR TITLE
fix: add update diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.6.7 - Unreleased
 
+- Add copyable update diagnostics in About so Sparkle install-location failures include bundle path, resolved path, signing, Homebrew, translocation, and quarantine signals. (#70)
+
 ## 0.6.6 - 2026-05-26
 
 - Open multi-reference GitHub detections in Issue Navigator on left click while keeping the preview menu on right click.

--- a/Sources/RepoBar/Settings/About/AboutSettingsView.swift
+++ b/Sources/RepoBar/Settings/About/AboutSettingsView.swift
@@ -102,6 +102,9 @@ struct AboutSettingsView: View {
                     Button("Check for Updates…") {
                         SparkleController.shared.checkForUpdates()
                     }
+                    Button("Copy Update Diagnostics") {
+                        self.copyUpdateDiagnostics()
+                    }
                 }
             } else {
                 Text("Updates unavailable in this build.")
@@ -133,5 +136,13 @@ struct AboutSettingsView: View {
                 SparkleController.shared.automaticallyDownloadsUpdates = newValue
             }
         }
+    }
+
+    private func copyUpdateDiagnostics() {
+        let diagnostics = UpdateDiagnostics.current(
+            canCheckForUpdates: SparkleController.shared.canCheckForUpdates
+        )
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(diagnostics.pasteboardText, forType: .string)
     }
 }

--- a/Sources/RepoBar/Settings/About/AboutSettingsView.swift
+++ b/Sources/RepoBar/Settings/About/AboutSettingsView.swift
@@ -102,14 +102,14 @@ struct AboutSettingsView: View {
                     Button("Check for Updates…") {
                         SparkleController.shared.checkForUpdates()
                     }
-                    Button("Copy Update Diagnostics") {
-                        self.copyUpdateDiagnostics()
-                    }
                 }
             } else {
                 Text("Updates unavailable in this build.")
                     .foregroundStyle(.secondary)
                     .padding(.top, 4)
+            }
+            Button("Copy Update Diagnostics") {
+                self.copyUpdateDiagnostics()
             }
 
             Text("© 2025 Peter Steinberger. MIT License.")

--- a/Sources/RepoBar/Support/SparkleController.swift
+++ b/Sources/RepoBar/Support/SparkleController.swift
@@ -112,7 +112,7 @@ final class SparkleController: NSObject {
         self.updater.checkForUpdates(nil)
     }
 
-    private static func isDeveloperIDSigned(bundleURL: URL) -> Bool {
+    nonisolated static func isDeveloperIDSigned(bundleURL: URL) -> Bool {
         var staticCode: SecStaticCode?
         guard SecStaticCodeCreateWithPath(bundleURL as CFURL, SecCSFlags(), &staticCode) == errSecSuccess,
               let code = staticCode else { return false }

--- a/Sources/RepoBar/Support/UpdateDiagnostics.swift
+++ b/Sources/RepoBar/Support/UpdateDiagnostics.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+#if os(macOS)
+    import Darwin
+#endif
+
+struct UpdateDiagnostics {
+    let bundlePath: String
+    let resolvedBundlePath: String
+    let canCheckForUpdates: Bool
+    let developerIDSigned: Bool
+    let homebrewCask: Bool
+    let appTranslocated: Bool
+    let quarantinePresent: Bool
+
+    static func current(canCheckForUpdates: Bool) -> UpdateDiagnostics {
+        let bundleURL = Bundle.main.bundleURL
+        return UpdateDiagnostics(
+            bundleURL: bundleURL,
+            canCheckForUpdates: canCheckForUpdates,
+            developerIDSigned: SparkleController.isDeveloperIDSigned(bundleURL: bundleURL)
+        )
+    }
+
+    init(
+        bundleURL: URL,
+        canCheckForUpdates: Bool,
+        developerIDSigned: Bool,
+        quarantineReader: (URL) -> Bool = UpdateDiagnostics.hasQuarantineAttribute
+    ) {
+        let resolvedURL = bundleURL.resolvingSymlinksInPath()
+        self.bundlePath = bundleURL.path
+        self.resolvedBundlePath = resolvedURL.path
+        self.canCheckForUpdates = canCheckForUpdates
+        self.developerIDSigned = developerIDSigned
+        self.homebrewCask = InstallOrigin.isHomebrewCask(appBundleURL: bundleURL)
+        self.appTranslocated = bundleURL.path.contains("/AppTranslocation/") || resolvedURL.path.contains("/AppTranslocation/")
+        self.quarantinePresent = quarantineReader(bundleURL)
+    }
+
+    var pasteboardText: String {
+        """
+        RepoBar update diagnostics
+        bundle_path: \(self.bundlePath)
+        resolved_bundle_path: \(self.resolvedBundlePath)
+        can_check_for_updates: \(self.canCheckForUpdates)
+        developer_id_signed: \(self.developerIDSigned)
+        homebrew_cask: \(self.homebrewCask)
+        app_translocated: \(self.appTranslocated)
+        quarantine_present: \(self.quarantinePresent)
+        """
+    }
+
+    private static func hasQuarantineAttribute(url: URL) -> Bool {
+        #if os(macOS)
+            let path = url.path
+            return path.withCString { cPath in
+                getxattr(cPath, "com.apple.quarantine", nil, 0, 0, 0) >= 0
+            }
+        #else
+            return false
+        #endif
+    }
+}

--- a/Tests/RepoBarTests/UpdateDiagnosticsTests.swift
+++ b/Tests/RepoBarTests/UpdateDiagnosticsTests.swift
@@ -4,8 +4,10 @@ import Testing
 
 struct UpdateDiagnosticsTests {
     @Test
-    func `diagnostics include update location and install-origin signals`() throws {
-        let bundleURL = try #require(URL(string: "file:///Applications/RepoBar.app"))
+    func `diagnostics include update location and install-origin signals`() {
+        let bundleURL = FileManager.default.temporaryDirectory
+            .appending(path: "RepoBarDiagnosticsFixture", directoryHint: .isDirectory)
+            .appending(path: "RepoBar.app", directoryHint: .isDirectory)
         let diagnostics = UpdateDiagnostics(
             bundleURL: bundleURL,
             canCheckForUpdates: true,
@@ -13,13 +15,13 @@ struct UpdateDiagnosticsTests {
             quarantineReader: { _ in true }
         )
 
-        #expect(diagnostics.bundlePath == "/Applications/RepoBar.app")
+        #expect(diagnostics.bundlePath == bundleURL.path)
         #expect(diagnostics.canCheckForUpdates)
         #expect(diagnostics.developerIDSigned)
         #expect(!diagnostics.homebrewCask)
         #expect(!diagnostics.appTranslocated)
         #expect(diagnostics.quarantinePresent)
-        #expect(diagnostics.pasteboardText.contains("bundle_path: /Applications/RepoBar.app"))
+        #expect(diagnostics.pasteboardText.contains("bundle_path: \(bundleURL.path)"))
         #expect(diagnostics.pasteboardText.contains("quarantine_present: true"))
     }
 

--- a/Tests/RepoBarTests/UpdateDiagnosticsTests.swift
+++ b/Tests/RepoBarTests/UpdateDiagnosticsTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+@testable import RepoBar
+import Testing
+
+struct UpdateDiagnosticsTests {
+    @Test
+    func `diagnostics include update location and install-origin signals`() throws {
+        let bundleURL = try #require(URL(string: "file:///Applications/RepoBar.app"))
+        let diagnostics = UpdateDiagnostics(
+            bundleURL: bundleURL,
+            canCheckForUpdates: true,
+            developerIDSigned: true,
+            quarantineReader: { _ in true }
+        )
+
+        #expect(diagnostics.bundlePath == "/Applications/RepoBar.app")
+        #expect(diagnostics.canCheckForUpdates)
+        #expect(diagnostics.developerIDSigned)
+        #expect(!diagnostics.homebrewCask)
+        #expect(!diagnostics.appTranslocated)
+        #expect(diagnostics.quarantinePresent)
+        #expect(diagnostics.pasteboardText.contains("bundle_path: /Applications/RepoBar.app"))
+        #expect(diagnostics.pasteboardText.contains("quarantine_present: true"))
+    }
+
+    @Test
+    func `diagnostics flag homebrew and translocated app paths`() throws {
+        let homebrewURL = try #require(URL(string: "file:///opt/homebrew/Caskroom/repobar/0.6.6/RepoBar.app"))
+        let translocatedURL = try #require(URL(string: "file:///private/var/folders/xx/AppTranslocation/RepoBar.app"))
+
+        #expect(UpdateDiagnostics(bundleURL: homebrewURL, canCheckForUpdates: false, developerIDSigned: false).homebrewCask)
+        #expect(UpdateDiagnostics(bundleURL: translocatedURL, canCheckForUpdates: false, developerIDSigned: false).appTranslocated)
+    }
+}


### PR DESCRIPTION
## Summary

Adds copyable update diagnostics in About so Sparkle install-location failures include the runtime bundle path, resolved bundle path, update availability, Developer ID signing, Homebrew cask, App Translocation, and quarantine signals.

Fixes #70.

## Proof

- pnpm test --filter UpdateDiagnosticsTests
- pnpm build
- pnpm check
- git diff --check
