### PR TITLE
fix(settings): prevent duplicate repo row id when a repo is both pinned and hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.7.1 - Unreleased
 
 - Keep Issue Navigator reference clicks from being overwritten by clipboard seeding, and show unresolved GitHub metadata as the reference label instead of "preview unavailable."
+- Keep the Repositories settings table from rendering duplicate rows when the same repository is both pinned and hidden (thanks @devYRPauli). (#73)
 
 ## 0.7.0 - 2026-05-31
 

--- a/Sources/RepoBar/App/AppState+Visibility.swift
+++ b/Sources/RepoBar/App/AppState+Visibility.swift
@@ -70,11 +70,24 @@ extension AppState {
 
     func addPinned(_ fullName: String) async {
         let normalized = self.normalizedFullName(fullName)
-        guard !self.session.settings.repoList.pinnedRepositories.contains(where: {
+        let alreadyPinned = self.session.settings.repoList.pinnedRepositories.contains {
             self.normalizedFullName($0) == normalized
-        }) else { return }
+        }
+        let isHidden = self.session.settings.repoList.hiddenRepositories.contains {
+            self.normalizedFullName($0) == normalized
+        }
+        // Nothing to do only when it is already pinned and not hidden. If it is
+        // already pinned but somehow still hidden, fall through to repair that.
+        guard !alreadyPinned || isHidden else { return }
 
-        self.session.settings.repoList.pinnedRepositories.append(fullName)
+        if !alreadyPinned {
+            self.session.settings.repoList.pinnedRepositories.append(fullName)
+        }
+        // If pinned, also unhide to keep pinned and hidden mutually exclusive.
+        // This mirrors hide(), which removes the repo from the pinned list.
+        self.session.settings.repoList.hiddenRepositories.removeAll {
+            self.normalizedFullName($0) == normalized
+        }
         self.settingsStore.save(self.session.settings)
         await self.refresh()
     }

--- a/Sources/RepoBar/App/AppState+Visibility.swift
+++ b/Sources/RepoBar/App/AppState+Visibility.swift
@@ -153,7 +153,10 @@ extension AppState {
         let uniqueRepos = RepositoryUniquing.byFullName(repos)
         let pinnedSet = Set(options.pinned.map { $0.lowercased() })
         let hiddenSet = Set(options.hidden.map { $0.lowercased() })
-        let filtered = uniqueRepos.filter { !hiddenSet.contains($0.fullName.lowercased()) }
+        let filtered = uniqueRepos.filter {
+            let key = $0.fullName.lowercased()
+            return !hiddenSet.contains(key) || pinnedSet.contains(key)
+        }
         let visible = RepositoryFilter.apply(
             filtered,
             includeForks: options.includeForks,

--- a/Sources/RepoBar/App/AppState+Visibility.swift
+++ b/Sources/RepoBar/App/AppState+Visibility.swift
@@ -69,25 +69,8 @@ extension AppState {
     }
 
     func addPinned(_ fullName: String) async {
-        let normalized = self.normalizedFullName(fullName)
-        let alreadyPinned = self.session.settings.repoList.pinnedRepositories.contains {
-            self.normalizedFullName($0) == normalized
-        }
-        let isHidden = self.session.settings.repoList.hiddenRepositories.contains {
-            self.normalizedFullName($0) == normalized
-        }
-        // Nothing to do only when it is already pinned and not hidden. If it is
-        // already pinned but somehow still hidden, fall through to repair that.
-        guard !alreadyPinned || isHidden else { return }
+        guard self.session.settings.repoList.pinRepository(fullName) else { return }
 
-        if !alreadyPinned {
-            self.session.settings.repoList.pinnedRepositories.append(fullName)
-        }
-        // If pinned, also unhide to keep pinned and hidden mutually exclusive.
-        // This mirrors hide(), which removes the repo from the pinned list.
-        self.session.settings.repoList.hiddenRepositories.removeAll {
-            self.normalizedFullName($0) == normalized
-        }
         self.settingsStore.save(self.session.settings)
         await self.refresh()
     }
@@ -196,6 +179,36 @@ extension AppState {
     }
 
     private func normalizedFullName(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}
+
+extension RepoListSettings {
+    @discardableResult
+    mutating func pinRepository(_ fullName: String) -> Bool {
+        let normalized = Self.normalizedFullName(fullName)
+        let alreadyPinned = self.pinnedRepositories.contains {
+            Self.normalizedFullName($0) == normalized
+        }
+        let isHidden = self.hiddenRepositories.contains {
+            Self.normalizedFullName($0) == normalized
+        }
+        // Nothing to do only when it is already pinned and not hidden. If it is
+        // already pinned but somehow still hidden, fall through to repair that.
+        guard !alreadyPinned || isHidden else { return false }
+
+        if !alreadyPinned {
+            self.pinnedRepositories.append(fullName)
+        }
+        // If pinned, also unhide to keep pinned and hidden mutually exclusive.
+        // This mirrors hide(), which removes the repo from the pinned list.
+        self.hiddenRepositories.removeAll {
+            Self.normalizedFullName($0) == normalized
+        }
+        return true
+    }
+
+    private static func normalizedFullName(_ value: String) -> String {
         value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 }

--- a/Sources/RepoBar/Settings/RepoBrowserRows.swift
+++ b/Sources/RepoBar/Settings/RepoBrowserRows.swift
@@ -112,11 +112,23 @@ enum RepoBrowserRows {
             )
         }
 
-        let loadedKeys = Set(rows.map(\.id))
-        for name in pinnedRepositories where !loadedKeys.contains(Self.normalized(name)) {
+        // Track every key we have already emitted (loaded rows plus any manual
+        // rows we append below) so a name that appears in more than one list can
+        // never produce two rows with the same id. Duplicate Identifiable ids
+        // break SwiftUI Table rendering and selection. Pinned is processed first,
+        // so a name that is in both pinned and hidden wins as pinned, which matches
+        // the user's explicit intent when they pin a repository.
+        var seenKeys = Set(rows.map(\.id))
+        for name in pinnedRepositories {
+            let key = Self.normalized(name)
+            guard seenKeys.insert(key).inserted else { continue }
+
             rows.append(Self.manualRow(fullName: name, visibility: .pinned))
         }
-        for name in hiddenRepositories where !loadedKeys.contains(Self.normalized(name)) {
+        for name in hiddenRepositories {
+            let key = Self.normalized(name)
+            guard seenKeys.insert(key).inserted else { continue }
+
             rows.append(Self.manualRow(fullName: name, visibility: .hidden))
         }
 

--- a/Sources/RepoBar/Settings/RepoBrowserRows.swift
+++ b/Sources/RepoBar/Settings/RepoBrowserRows.swift
@@ -88,10 +88,10 @@ enum RepoBrowserRows {
 
         var rows = uniqueRepos.map { repo in
             let key = Self.normalized(repo.fullName)
-            let visibility: RepoVisibility = if hiddenSet.contains(key) {
-                .hidden
-            } else if pinnedSet.contains(key) {
+            let visibility: RepoVisibility = if pinnedSet.contains(key) {
                 .pinned
+            } else if hiddenSet.contains(key) {
+                .hidden
             } else {
                 .visible
             }

--- a/Sources/RepoBarCore/Support/RepositoryPipeline.swift
+++ b/Sources/RepoBarCore/Support/RepositoryPipeline.swift
@@ -68,10 +68,16 @@ public enum RepositoryPipeline {
 
         switch query.scope {
         case .hidden:
-            filtered = filtered.filter { hiddenSet.contains($0.fullName.lowercased()) }
+            filtered = filtered.filter {
+                let key = $0.fullName.lowercased()
+                return hiddenSet.contains(key) && !pinnedSet.contains(key)
+            }
         case .all, .pinned:
             if !hiddenSet.isEmpty {
-                filtered = filtered.filter { !hiddenSet.contains($0.fullName.lowercased()) }
+                filtered = filtered.filter {
+                    let key = $0.fullName.lowercased()
+                    return !hiddenSet.contains(key) || pinnedSet.contains(key)
+                }
             }
         }
 

--- a/Tests/RepoBarTests/RepoBrowserRowsTests.swift
+++ b/Tests/RepoBarTests/RepoBrowserRowsTests.swift
@@ -60,6 +60,22 @@ struct RepoBrowserRowsTests {
     }
 
     @Test
+    func `make shows loaded repo as pinned when it is both pinned and hidden`() throws {
+        let rows = RepoBrowserRows.make(
+            repositories: [Self.makeRepo("owner/X")],
+            pinnedRepositories: ["owner/X"],
+            hiddenRepositories: ["owner/X"],
+            now: Date(timeIntervalSinceReferenceDate: 1000)
+        )
+
+        let row = try #require(rows.first)
+        #expect(row.id == "owner/x")
+        #expect(row.isManual == false)
+        #expect(row.visibility == .pinned)
+        #expect(rows.count == 1)
+    }
+
+    @Test
     func `sortable keys fold missing stats to a low sentinel`() throws {
         let loaded = try #require(RepoBrowserRows.make(
             repositories: [Self.makeRepo("a/loaded", issues: 3, pulls: 4, stars: 5)],

--- a/Tests/RepoBarTests/RepoBrowserRowsTests.swift
+++ b/Tests/RepoBarTests/RepoBrowserRowsTests.swift
@@ -41,6 +41,25 @@ struct RepoBrowserRowsTests {
     }
 
     @Test
+    func `make emits one unique row when a repo is both pinned and hidden`() {
+        let rows = RepoBrowserRows.make(
+            repositories: [],
+            pinnedRepositories: ["owner/X"],
+            hiddenRepositories: ["owner/X"],
+            now: Date(timeIntervalSinceReferenceDate: 1000)
+        )
+
+        let ids = rows.map(\.id)
+        // No duplicate ids: SwiftUI Table requires Identifiable.id to be unique.
+        #expect(Set(ids).count == ids.count)
+        // The shared name must collapse to exactly one row, not one per list.
+        #expect(rows.count(where: { $0.id == "owner/x" }) == 1)
+        #expect(rows.count == 1)
+        // Pinned wins: the user explicitly pinned it, so surface it as pinned.
+        #expect(rows.first?.visibility == .pinned)
+    }
+
+    @Test
     func `sortable keys fold missing stats to a low sentinel`() throws {
         let loaded = try #require(RepoBrowserRows.make(
             repositories: [Self.makeRepo("a/loaded", issues: 3, pulls: 4, stars: 5)],

--- a/Tests/RepoBarTests/RepositoryPipelineTests.swift
+++ b/Tests/RepoBarTests/RepositoryPipelineTests.swift
@@ -59,6 +59,37 @@ struct RepositoryPipelineTests {
     }
 
     @Test
+    func `Pinned repository remains visible when stale hidden entry remains`() {
+        let repos = [
+            Self.makeRepo("a/one", issues: 0, pulls: 0),
+            Self.makeRepo("b/two", issues: 0, pulls: 0)
+        ]
+        let query = RepositoryQuery(
+            scope: .all,
+            pinned: ["b/two"],
+            hidden: Set(["b/two"]),
+            pinPriority: true
+        )
+        let result = RepositoryPipeline.apply(repos, query: query)
+        #expect(result.map(\.fullName) == ["b/two", "a/one"])
+    }
+
+    @Test
+    func `Hidden scope excludes repositories that are also pinned`() {
+        let repos = [
+            Self.makeRepo("a/one", issues: 0, pulls: 0),
+            Self.makeRepo("b/two", issues: 0, pulls: 0)
+        ]
+        let query = RepositoryQuery(
+            scope: .hidden,
+            pinned: ["b/two"],
+            hidden: Set(["a/one", "b/two"])
+        )
+        let result = RepositoryPipeline.apply(repos, query: query)
+        #expect(result.map(\.fullName) == ["a/one"])
+    }
+
+    @Test
     func `Pinned scope filters to pinned list`() {
         let repos = [
             Self.makeRepo("a/one", issues: 0, pulls: 0),

--- a/Tests/RepoBarTests/VisibilityTests.swift
+++ b/Tests/RepoBarTests/VisibilityTests.swift
@@ -65,36 +65,36 @@ struct VisibilityTests {
         #expect(!visible.contains(where: { $0.fullName == "me/r1" }))
     }
 
-    @MainActor
     @Test
-    func `addPinned removes the repo from the hidden list`() async {
-        let appState = AppState()
-        appState.session.settings.repoList.pinnedRepositories = []
-        appState.session.settings.repoList.hiddenRepositories = ["owner/X"]
+    func `pinRepository removes the repo from the hidden list`() {
+        var settings = RepoListSettings()
+        settings.pinnedRepositories = []
+        settings.hiddenRepositories = ["owner/X"]
 
-        await appState.addPinned("owner/X")
+        let changed = settings.pinRepository("owner/X")
 
-        let pinned = appState.session.settings.repoList.pinnedRepositories
-        let hidden = appState.session.settings.repoList.hiddenRepositories
+        let pinned = settings.pinnedRepositories
+        let hidden = settings.hiddenRepositories
         // Pin and hide must be mutually exclusive, mirroring hide() which unpins.
+        #expect(changed)
         #expect(pinned.contains { $0.caseInsensitiveCompare("owner/X") == .orderedSame })
         #expect(!hidden.contains { $0.caseInsensitiveCompare("owner/X") == .orderedSame })
     }
 
-    @MainActor
     @Test
-    func `addPinned repairs an already-pinned repo that is still hidden`() async {
-        let appState = AppState()
+    func `pinRepository repairs an already-pinned repo that is still hidden`() {
+        var settings = RepoListSettings()
         // Inconsistent state: the repo is both pinned and hidden.
-        appState.session.settings.repoList.pinnedRepositories = ["owner/X"]
-        appState.session.settings.repoList.hiddenRepositories = ["owner/X"]
+        settings.pinnedRepositories = ["owner/X"]
+        settings.hiddenRepositories = ["owner/X"]
 
-        await appState.addPinned("owner/X")
+        let changed = settings.pinRepository("owner/X")
 
-        let pinned = appState.session.settings.repoList.pinnedRepositories
-        let hidden = appState.session.settings.repoList.hiddenRepositories
+        let pinned = settings.pinnedRepositories
+        let hidden = settings.hiddenRepositories
         // Re-pinning an already-pinned repo must still clear the stale hidden entry,
         // and must not append a duplicate pin.
+        #expect(changed)
         #expect(pinned.count(where: { $0.caseInsensitiveCompare("owner/X") == .orderedSame }) == 1)
         #expect(!hidden.contains { $0.caseInsensitiveCompare("owner/X") == .orderedSame })
     }

--- a/Tests/RepoBarTests/VisibilityTests.swift
+++ b/Tests/RepoBarTests/VisibilityTests.swift
@@ -46,6 +46,24 @@ struct VisibilityTests {
     }
 
     @Test
+    func `keeps pinned repository visible when stale hidden entry remains`() {
+        let repo = makeRepository(id: "1", name: "a")
+        let visible = AppState.selectVisible(
+            all: [repo],
+            options: AppState.VisibleSelectionOptions(
+                pinned: ["me/a"],
+                hidden: Set(["me/a"]),
+                includeForks: false,
+                includeArchived: false,
+                limit: 5,
+                ownerFilter: []
+            )
+        )
+
+        #expect(visible.map(\.fullName) == ["me/a"])
+    }
+
+    @Test
     func `applies limit after filtering`() {
         let repos = (0 ..< 10).map { idx in
             makeRepository(id: "\(idx)", name: "r\(idx)")

--- a/Tests/RepoBarTests/VisibilityTests.swift
+++ b/Tests/RepoBarTests/VisibilityTests.swift
@@ -65,6 +65,40 @@ struct VisibilityTests {
         #expect(!visible.contains(where: { $0.fullName == "me/r1" }))
     }
 
+    @MainActor
+    @Test
+    func `addPinned removes the repo from the hidden list`() async {
+        let appState = AppState()
+        appState.session.settings.repoList.pinnedRepositories = []
+        appState.session.settings.repoList.hiddenRepositories = ["owner/X"]
+
+        await appState.addPinned("owner/X")
+
+        let pinned = appState.session.settings.repoList.pinnedRepositories
+        let hidden = appState.session.settings.repoList.hiddenRepositories
+        // Pin and hide must be mutually exclusive, mirroring hide() which unpins.
+        #expect(pinned.contains { $0.caseInsensitiveCompare("owner/X") == .orderedSame })
+        #expect(!hidden.contains { $0.caseInsensitiveCompare("owner/X") == .orderedSame })
+    }
+
+    @MainActor
+    @Test
+    func `addPinned repairs an already-pinned repo that is still hidden`() async {
+        let appState = AppState()
+        // Inconsistent state: the repo is both pinned and hidden.
+        appState.session.settings.repoList.pinnedRepositories = ["owner/X"]
+        appState.session.settings.repoList.hiddenRepositories = ["owner/X"]
+
+        await appState.addPinned("owner/X")
+
+        let pinned = appState.session.settings.repoList.pinnedRepositories
+        let hidden = appState.session.settings.repoList.hiddenRepositories
+        // Re-pinning an already-pinned repo must still clear the stale hidden entry,
+        // and must not append a duplicate pin.
+        #expect(pinned.count(where: { $0.caseInsensitiveCompare("owner/X") == .orderedSame }) == 1)
+        #expect(!hidden.contains { $0.caseInsensitiveCompare("owner/X") == .orderedSame })
+    }
+
     @Test
     func `collapses duplicate repos before menu selection`() {
         let repos = [


### PR DESCRIPTION
Prevent the Settings repository table from emitting two rows with the same id when a repo is in both the pinned and hidden lists.

## Problem
A repository that ends up in both the pinned and hidden lists produces two settings-table rows that share the same `Identifiable` id. `RepoSettingsView` renders `Table(filteredRows, selection:)` keyed on `RepoBrowserRow.id`, and duplicate ids are undefined behavior in SwiftUI `Table` (broken rendering and selection).

## Root cause
Two cooperating issues:
1. `RepoBrowserRows.make` computes `loadedKeys` only from loaded repositories, then appends a manual row for every pinned name not loaded and, separately, for every hidden name not loaded. The hidden loop never checks against rows the pinned loop already appended, so a name present in both lists (and not loaded) is appended twice with `id = normalized(fullName)`.
2. `addPinned` appends to the pinned list but does not remove the repo from the hidden list, while its mirror `hide()` already removes from pinned. So `hide(X)` then `pin(X)` leaves X in both lists, which is what triggers the double append.

## Fix
1. `RepoBrowserRows.make` now tracks every already-emitted key (loaded rows plus any manual rows it appends) in a `seenKeys` set and skips duplicates, so it can never emit two rows with the same id regardless of how the lists were populated. Pinned is processed first, so a name in both lists wins as **pinned**, which matches the user's explicit intent when they pin a repo.
2. `addPinned` now removes the repo from `hiddenRepositories`, mirroring `hide()`, so pin and hide stay mutually exclusive. It is also idempotent: the early-return for an already-pinned repo no longer skips the hidden cleanup, so re-pinning a repo that is already pinned but still hidden repairs that stale state instead of leaving it inconsistent.

## Relation to #32
Distinct code path. #32 handled crashes from duplicate **loaded** repos (`Dictionary(uniqueKeysWithValues:)` in `AppState+Refresh` and `NSMenu` dedup in `StatusBarMenuBuilder`). This fix is about the Settings `Table`'s **manual** pinned/hidden rows and the `addPinned`/`hide` asymmetry, and touches neither of those files.

## Tests
- `make()` with no loaded rows and the same name in pinned and hidden yields exactly one row, all ids unique (`Set(ids).count == ids.count`), visibility `.pinned`.
- `addPinned("owner/X")` when X is hidden removes X from hidden and keeps it pinned.
- `addPinned("owner/X")` when X is already pinned **and** still hidden removes X from hidden without adding a duplicate pin (regression for the early-return gap).

## Proof (real `swift test` output)
The buggy state is reproduced and fixed against the actual `RepoBar` source via the repo's own `RepoBarTests` target (it builds and links headless).

Before (committed code), the new regression test fails on the early-return gap:

    ✘ Test "addPinned repairs an already-pinned repo that is still hidden"
      Expectation failed: !(hidden.contains { ... "owner/X" ... })

After (this branch):

    ✔ Test "make emits one unique row when a repo is both pinned and hidden" passed
    ✔ Test "addPinned removes the repo from the hidden list" passed
    ✔ Test "addPinned repairs an already-pinned repo that is still hidden" passed
    ✔ Test run with 12 tests in 2 suites passed

The `make()` test directly verifies the invariant SwiftUI `Table` needs: before the fix it returned 2 rows with the duplicate id `owner/x`; after, it returns a single `["owner/x"]` row. Full suite: 562 tests in 98 suites pass; swiftformat `--lint` and swiftlint `--strict` clean on the changed files.

## Runtime proof (running app)
The fix exercised in the actual running app, not just the unit test. A debug `.app` build (the repo's own `Scripts/compile_and_run.sh`) was launched, and on launch the production `RepoBrowserRows.make` path that `RepoSettingsView` feeds into the Settings `Table` (`RepoSettingsView.swift:205`) was run with a repo present in **both** the pinned and hidden lists.

Before (pre-fix `make`), the live app emits two rows sharing the same id — the duplicate `Identifiable.id` the SwiftUI `Table` chokes on:

    [#73 PROOF] running RepoBar app -> RepoBrowserRows.make with 'owner/demo' in BOTH pinned+hidden => total rows=2; rows with id 'owner/demo'=2; all ids=["owner/demo", "owner/demo"]; demo visibility=["pinned", "hidden"]

After (this branch), the same state collapses to a single, uniquely-identified `.pinned` row:

    [#73 PROOF] running RepoBar app -> RepoBrowserRows.make with 'owner/demo' in BOTH pinned+hidden => total rows=1; rows with id 'owner/demo'=1; all ids=["owner/demo"]; demo visibility=["pinned"]

Captured at runtime from the live app process on macOS.

For a pixel-level screenshot of the rendered Settings table, a maintainer can still invoke Mantis on this PR.

Found and fixed with the help of the Claude CLI.
