### PR TITLE
feat: add AI PR summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.1 - Unreleased
 
+- Add optional OpenAI-powered PR summaries to the Issue Navigator sidebar using Tachikoma `chat-latest`, with settings for model and API key storage.
 - Keep the separate Issue Navigator window from auto-scrolling embedded GitHub issue previews while preserving the menu dropdown preview scroll offset.
 - Keep Issue Navigator reference clicks from being overwritten by clipboard seeding, and show unresolved GitHub metadata as the reference label instead of "preview unavailable."
 - Keep the Repositories settings table from rendering duplicate rows when the same repository is both pinned and hidden (thanks @devYRPauli). (#73)

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "bf9950d42b5ec432d4b7c3b3b0de9344a757aebffe8e60aafc3679692c7b7fdd",
+  "originHash" : "51d45851063e1df59c2c41d3b998cb7efe88c15a9d3e42b573e81fba18994056",
   "pins" : [
     {
       "identity" : "apollo-ios",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "ae2ce746b386ff94b26648cfe5625cfa8d02639b",
         "version" : "0.2.2"
+      }
+    },
+    {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/eventsource.git",
+      "state" : {
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
       }
     },
     {
@@ -83,12 +92,66 @@
       }
     },
     {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "d0b4a06d0f173a2f3be27d3ea21b3c3aa18db440",
+        "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
       "identity" : "swift-cmark",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-cmark.git",
       "state" : {
         "revision" : "5d9bdaa4228b381639fff09403e39a04926e2dbe",
         "version" : "0.7.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "fea17c02d767f46b23070fdfdacc28a03a39232a",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration",
+      "state" : {
+        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
       }
     },
     {
@@ -119,6 +182,15 @@
       }
     },
     {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "57c0a08a331aaea9f5d7a932ad94ef43be942a95",
+        "version" : "2.100.0"
+      }
+    },
+    {
       "identity" : "swift-numerics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-numerics.git",
@@ -128,12 +200,48 @@
       }
     },
     {
+      "identity" : "swift-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
+      "state" : {
+        "revision" : "a0ae212ebf6eab5f754c3129608bc5557637e605",
+        "version" : "0.12.1"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "669763cfd5806a67e21972d7e5e2d6b80b1ea985",
+        "version" : "1.6.5"
+      }
+    },
+    {
       "identity" : "swiftdansi",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/steipete/Swiftdansi",
       "state" : {
         "revision" : "94b7818be2103ef7c466027bcfce1657833c83bb",
         "version" : "0.2.1"
+      }
+    },
+    {
+      "identity" : "tachikoma",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/openclaw/Tachikoma.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "7b80238d4c1d243e07499a5472508c0fad411584"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,7 @@ let package = Package(
         .package(url: "https://github.com/steipete/Swiftdansi", from: "0.1.1"),
         .package(url: "https://github.com/apple/swift-markdown", from: "0.7.3"),
         .package(url: "https://github.com/groue/GRDB.swift.git", from: "7.10.0"),
+        .package(url: "https://github.com/openclaw/Tachikoma.git", branch: "main"),
     ],
     targets: [
         .target(
@@ -33,6 +34,7 @@ let package = Package(
                 .product(name: "GRDB", package: "GRDB.swift"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Markdown", package: "swift-markdown"),
+                .product(name: "Tachikoma", package: "tachikoma"),
             ],
             swiftSettings: [
                 .enableUpcomingFeature("StrictConcurrency"),

--- a/Sources/RepoBar/App/AppState.swift
+++ b/Sources/RepoBar/App/AppState.swift
@@ -147,6 +147,18 @@ final class AppState {
         self.settingsStore.save(self.session.settings)
     }
 
+    func openAIAPIKeySource() -> OpenAIAPIKeySource {
+        OpenAIAPIKeyStore().resolve().source
+    }
+
+    func saveOpenAIAPIKey(_ key: String) throws {
+        try OpenAIAPIKeyStore().save(key)
+    }
+
+    func clearOpenAIAPIKey() {
+        OpenAIAPIKeyStore().clearStoredKey()
+    }
+
     func updateGitHubReferenceMonitor() {
         guard self.session.settings.gitHubReferenceMonitor.enabled else {
             Task { await DiagnosticsLogger.shared.message("GitHub reference monitor disabled") }
@@ -498,6 +510,7 @@ final class AppState {
                 state: .open,
                 createdAt: $0.createdAt,
                 updatedAt: $0.updatedAt,
+                bodyPreview: $0.bodyPreview,
                 authorLogin: $0.authorLogin
             )
         })

--- a/Sources/RepoBar/Settings/AdvancedSettingsView.swift
+++ b/Sources/RepoBar/Settings/AdvancedSettingsView.swift
@@ -7,6 +7,8 @@ struct AdvancedSettingsView: View {
     let appState: AppState
     @State private var isInstallingCLI = false
     @State private var cliStatus: String?
+    @State private var openAIAPIKey = ""
+    @State private var openAIKeyStatus = OpenAIAPIKeySource.missing.label
 
     var body: some View {
         Form {
@@ -189,6 +191,41 @@ struct AdvancedSettingsView: View {
             }
 
             Section {
+                Toggle("Summarize Issue Navigator PRs", isOn: self.$session.settings.aiSummaries.enabled)
+                    .onChange(of: self.session.settings.aiSummaries.enabled) { _, _ in
+                        self.appState.persistSettings()
+                    }
+
+                LabeledContent("Model") {
+                    TextField("", text: self.aiSummaryModelBinding)
+                        .multilineTextAlignment(.trailing)
+                        .frame(width: 170)
+                }
+
+                LabeledContent("OpenAI API key") {
+                    HStack(spacing: 8) {
+                        SecureField("OPENAI_API_KEY", text: self.$openAIAPIKey)
+                            .frame(width: 190)
+                        Button("Save") {
+                            self.saveOpenAIAPIKey()
+                        }
+                        .disabled(self.openAIAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        Button("Clear") {
+                            self.clearOpenAIAPIKey()
+                        }
+                    }
+                }
+
+                Text(self.openAIKeyStatus)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } header: {
+                Text("AI Summaries")
+            } footer: {
+                Text("Uses the stored key first, then OPENAI_API_KEY or REPOBAR_OPENAI_API_KEY from the app environment.")
+            }
+
+            Section {
                 HStack(spacing: 10) {
                     Button {
                         Task { await self.installCLI() }
@@ -239,6 +276,7 @@ struct AdvancedSettingsView: View {
             self.appState.updateGitHubReferenceMonitor()
             self.appState.refreshLocalProjects()
             self.cliStatus = self.currentCLIStatus()
+            self.refreshOpenAIKeyStatus()
         }
     }
 
@@ -413,6 +451,37 @@ struct AdvancedSettingsView: View {
                 self.appState.persistSettings()
             }
         )
+    }
+
+    private var aiSummaryModelBinding: Binding<String> {
+        Binding(
+            get: { self.session.settings.aiSummaries.model },
+            set: { newValue in
+                let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                self.session.settings.aiSummaries.model = trimmed.isEmpty ? AISummarySettings.defaultModel : trimmed
+                self.appState.persistSettings()
+            }
+        )
+    }
+
+    private func refreshOpenAIKeyStatus() {
+        self.openAIKeyStatus = self.appState.openAIAPIKeySource().label
+    }
+
+    private func saveOpenAIAPIKey() {
+        do {
+            try self.appState.saveOpenAIAPIKey(self.openAIAPIKey)
+            self.openAIAPIKey = ""
+            self.refreshOpenAIKeyStatus()
+        } catch {
+            self.openAIKeyStatus = "Save failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func clearOpenAIAPIKey() {
+        self.appState.clearOpenAIAPIKey()
+        self.openAIAPIKey = ""
+        self.refreshOpenAIKeyStatus()
     }
 
     private func pickProjectFolder() {

--- a/Sources/RepoBar/Support/AppLimits.swift
+++ b/Sources/RepoBar/Support/AppLimits.swift
@@ -48,6 +48,7 @@ enum AppLimits {
         static let minimumSearchCharacters = 2
         static let webPreviewPreloadLimit = 4
         static let webPreviewCacheLimit = 6
+        static let aiSummaryConcurrencyLimit = 2
     }
 
     enum RepoCommits {

--- a/Sources/RepoBar/Views/IssueNavigatorView.swift
+++ b/Sources/RepoBar/Views/IssueNavigatorView.swift
@@ -1,6 +1,14 @@
+import Algorithms
 import AppKit
 import RepoBarCore
 import SwiftUI
+
+// swiftlint:disable file_length
+
+private struct IssueNavigatorAISummary {
+    let signature: String
+    let text: String
+}
 
 struct IssueNavigatorView: View {
     private enum Metrics {
@@ -22,6 +30,8 @@ struct IssueNavigatorView: View {
     @State private var statusText = "Loading recent issues and pull requests."
     @State private var errorText: String?
     @State private var searchTask: Task<Void, Never>?
+    @State private var summaryTask: Task<Void, Never>?
+    @State private var aiSummariesByURL: [URL: IssueNavigatorAISummary] = [:]
     @State private var searchGeneration = UUID()
     @State private var clipboardText: String?
     @State private var clipboardQueries: [GitHubReferenceQuery] = []
@@ -77,11 +87,13 @@ struct IssueNavigatorView: View {
                 self.scheduleSearch(immediate: true)
             } else {
                 self.preloadPreviews(for: self.results)
+                self.scheduleAISummaries(for: self.results, generation: self.searchGeneration)
             }
         }
         .onDisappear {
             self.searchGeneration = UUID()
             self.searchTask?.cancel()
+            self.summaryTask?.cancel()
             self.browserStore.onNavigationStateChange = nil
             self.browserStore.clear()
         }
@@ -109,6 +121,13 @@ struct IssueNavigatorView: View {
         .onChange(of: self.searchText) { _, _ in self.scheduleSearch() }
         .onChange(of: self.kindFilter) { _, _ in self.scheduleSearch(immediate: true) }
         .onChange(of: self.selectedScope) { _, _ in self.scheduleSearch(immediate: true) }
+        .onChange(of: self.appState.session.settings.aiSummaries) { _, settings in
+            self.summaryTask?.cancel()
+            self.aiSummariesByURL = [:]
+            if settings.enabled {
+                self.scheduleAISummaries(for: self.results, generation: self.searchGeneration)
+            }
+        }
     }
 
     private var sidebar: some View {
@@ -213,7 +232,7 @@ struct IssueNavigatorView: View {
                     LazyVStack(spacing: 1) {
                         ForEach(self.results, id: \.url) { match in
                             IssueNavigatorResultRow(
-                                match: match,
+                                match: self.displayMatch(match),
                                 now: Date(),
                                 isSelected: self.selectedURL == match.url,
                                 onOpen: { self.open(match) }
@@ -361,6 +380,7 @@ struct IssueNavigatorView: View {
         let generation = UUID()
         self.searchGeneration = generation
         self.searchTask?.cancel()
+        self.summaryTask?.cancel()
         self.searchTask = Task {
             if !immediate {
                 try? await Task.sleep(for: .milliseconds(250))
@@ -408,6 +428,7 @@ struct IssueNavigatorView: View {
                 self.results = matches
                 self.selectedURL = matches.first?.url
                 self.preloadPreviews(for: matches)
+                self.scheduleAISummaries(for: matches, generation: generation)
                 if matches.isEmpty {
                     self.statusText = "No recent issues or pull requests in this scope."
                 } else if trimmed.isEmpty {
@@ -467,6 +488,7 @@ struct IssueNavigatorView: View {
             self.results = combined
             self.selectedURL = combined.first?.url
             self.preloadPreviews(for: combined)
+            self.scheduleAISummaries(for: combined, generation: generation)
             self.statusText = self.status(for: combined, searchedText: trimmed, preservesReferenceOrder: queries.isEmpty == false)
         } catch is CancellationError {
             return
@@ -479,7 +501,7 @@ struct IssueNavigatorView: View {
         }
     }
 
-    private func isCurrentSearch(_ generation: UUID) -> Bool {
+    func isCurrentSearch(_ generation: UUID) -> Bool {
         !Task.isCancelled && self.searchGeneration == generation
     }
 
@@ -516,6 +538,82 @@ struct IssueNavigatorView: View {
                 .prefix(AppLimits.IssueNavigator.webPreviewPreloadLimit)
                 .map(\.url)
         )
+    }
+
+    private func displayMatch(_ match: GitHubReferenceMatch) -> GitHubReferenceMatch {
+        let settings = self.appState.session.settings.aiSummaries
+        guard settings.enabled,
+              let summary = self.aiSummariesByURL[match.url],
+              summary.signature == Self.aiSummarySignature(for: match, settings: settings)
+        else { return match }
+
+        return match.withAISummary(summary.text)
+    }
+
+    private func scheduleAISummaries(for matches: [GitHubReferenceMatch], generation: UUID) {
+        self.summaryTask?.cancel()
+        let urls = Set(matches.map(\.url))
+        self.aiSummariesByURL = self.aiSummariesByURL.filter { urls.contains($0.key) }
+
+        let settings = self.appState.session.settings.aiSummaries
+        guard settings.enabled else {
+            self.aiSummariesByURL = [:]
+            return
+        }
+
+        let pending = matches.filter {
+            $0.kind == .pullRequest && self.aiSummariesByURL[$0.url]?.signature != Self.aiSummarySignature(for: $0, settings: settings)
+        }
+        guard pending.isEmpty == false else { return }
+
+        self.summaryTask = Task {
+            await self.loadAISummaries(for: pending, settings: settings, generation: generation)
+        }
+    }
+
+    @MainActor
+    private func loadAISummaries(for matches: [GitHubReferenceMatch], settings: AISummarySettings, generation: UUID) async {
+        let summarizer = PullRequestAISummarizer()
+        for chunk in matches.chunks(ofCount: AppLimits.IssueNavigator.aiSummaryConcurrencyLimit) {
+            guard self.isCurrentSearch(generation),
+                  self.appState.session.settings.aiSummaries == settings,
+                  settings.enabled
+            else { return }
+
+            await withTaskGroup(of: (url: URL, signature: String, summary: String?).self) { group in
+                for match in chunk {
+                    let signature = Self.aiSummarySignature(for: match, settings: settings)
+                    group.addTask {
+                        let summary = try? await summarizer.summarize(match, settings: settings)
+                        return (match.url, signature, summary)
+                    }
+                }
+
+                for await (url, signature, summary) in group {
+                    guard self.isCurrentSearch(generation),
+                          self.appState.session.settings.aiSummaries == settings,
+                          settings.enabled
+                    else {
+                        group.cancelAll()
+                        return
+                    }
+
+                    if let summary {
+                        self.aiSummariesByURL[url] = IssueNavigatorAISummary(signature: signature, text: summary)
+                    }
+                }
+            }
+        }
+    }
+
+    private static func aiSummarySignature(for match: GitHubReferenceMatch, settings: AISummarySettings) -> String {
+        [
+            settings.model,
+            match.updatedAt.timeIntervalSinceReferenceDate.description,
+            match.title,
+            match.bodyPreview ?? "",
+            match.authorLogin ?? ""
+        ].joined(separator: "\u{1f}")
     }
 
     private static func deduped(_ matches: [GitHubReferenceMatch]) -> [GitHubReferenceMatch] {
@@ -617,8 +715,9 @@ private struct IssueNavigatorResultRow: View {
                 }
                 .font(.caption)
                 .foregroundStyle(self.secondaryForeground)
-                if let bodyPreview = match.bodyPreview, bodyPreview.isEmpty == false {
-                    Text(bodyPreview)
+                let summary = self.match.aiSummary ?? self.match.bodyPreview
+                if let summary, summary.isEmpty == false {
+                    Text(summary)
                         .font(.caption)
                         .foregroundStyle(self.secondaryForeground)
                         .lineLimit(2)

--- a/Sources/RepoBarCore/API/GitHubClient.swift
+++ b/Sources/RepoBarCore/API/GitHubClient.swift
@@ -12,6 +12,7 @@ public actor GitHubClient {
     private let diag = DiagnosticsLogger.shared
     private let requestRunner: GitHubRequestRunner
     private let responseDiskCache: HTTPResponseDiskCache?
+    private let archiveSettingsProvider: @Sendable () -> GitHubArchiveSettings
     private lazy var restAPI = GitHubRestAPI(
         apiHost: { [weak self] in await self?.apiHost ?? URL(string: "https://api.github.com")! },
         tokenProvider: { [weak self] in
@@ -32,10 +33,16 @@ public actor GitHubClient {
     private var prefetchedReposExpiry: Date?
     private var inflightRepoDetails: [String: Task<Repository, Error>] = [:]
 
-    public init(accountID: String? = nil) {
+    public init(
+        accountID: String? = nil,
+        archiveSettingsProvider: @Sendable @escaping () -> GitHubArchiveSettings = {
+            SettingsStore().load().githubArchives
+        }
+    ) {
         self.responseDiskCache = HTTPResponseDiskCache.scoped(accountID: accountID)
         self.requestRunner = GitHubRequestRunner(etagCache: ETagCache.persistent(accountID: accountID))
         self.graphQL = GraphQLClient(responseCache: GraphQLResponseDiskCache.scoped(accountID: accountID))
+        self.archiveSettingsProvider = archiveSettingsProvider
     }
 
     // MARK: - Config
@@ -578,7 +585,7 @@ public actor GitHubClient {
     private func archiveIssueFallback(owner: String, name: String, limit: Int, error: Error) -> [RepoIssueSummary]? {
         guard self.shouldUseArchiveFallback(for: error) else { return nil }
 
-        let archiveSettings = SettingsStore().load().githubArchives
+        let archiveSettings = self.archiveSettingsProvider()
         guard archiveSettings.preferArchiveWhenRateLimited else { return nil }
 
         return GitHubArchiveReader.recentIssues(settings: archiveSettings, owner: owner, name: name, limit: limit)
@@ -587,7 +594,7 @@ public actor GitHubClient {
     private func archivePullRequestFallback(owner: String, name: String, limit: Int, error: Error) -> [RepoPullRequestSummary]? {
         guard self.shouldUseArchiveFallback(for: error) else { return nil }
 
-        let archiveSettings = SettingsStore().load().githubArchives
+        let archiveSettings = self.archiveSettingsProvider()
         guard archiveSettings.preferArchiveWhenRateLimited else { return nil }
 
         return GitHubArchiveReader.recentPullRequests(settings: archiveSettings, owner: owner, name: name, limit: limit)

--- a/Sources/RepoBarCore/API/GitHubRecentDecoders.swift
+++ b/Sources/RepoBarCore/API/GitHubRecentDecoders.swift
@@ -20,6 +20,7 @@ enum GitHubRecentDecoders {
                 labels: ($0.labels ?? []).map { RepoIssueLabel(name: $0.name, colorHex: $0.color) },
                 headRefName: $0.head?.refName,
                 baseRefName: $0.base?.refName,
+                bodyPreview: Self.bodyPreview(from: $0.body),
                 requestedReviewerLogins: ($0.requestedReviewers ?? []).map(\.login),
                 requestedTeamNames: ($0.requestedTeams ?? []).map(\.name)
             )
@@ -213,11 +214,12 @@ enum GitHubRecentDecoders {
         let labels: [IssueLabel]?
         let head: PullRequestRef?
         let base: PullRequestRef?
+        let body: String?
         let requestedReviewers: [RecentUser]?
         let requestedTeams: [RequestedTeam]?
 
         enum CodingKeys: String, CodingKey {
-            case number, title, state, user, draft, comments, labels, head, base
+            case number, title, state, user, draft, comments, labels, head, base, body
             case htmlUrl = "html_url"
             case updatedAt = "updated_at"
             case createdAt = "created_at"
@@ -226,6 +228,21 @@ enum GitHubRecentDecoders {
             case requestedReviewers = "requested_reviewers"
             case requestedTeams = "requested_teams"
         }
+    }
+
+    private static func bodyPreview(from body: String?) -> String? {
+        guard let body else { return nil }
+
+        let collapsed = body
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { $0.isEmpty == false }
+            .joined(separator: " ")
+        guard collapsed.isEmpty == false else { return nil }
+
+        if collapsed.count <= 240 { return collapsed }
+        return "\(collapsed.prefix(237))..."
     }
 
     private struct RequestedTeam: Decodable {

--- a/Sources/RepoBarCore/API/GitHubRestAPI+PullRequests.swift
+++ b/Sources/RepoBarCore/API/GitHubRestAPI+PullRequests.swift
@@ -73,6 +73,7 @@ extension GitHubRestAPI {
             labels: pullRequest.labels,
             headRefName: pullRequest.headRefName,
             baseRefName: pullRequest.baseRefName,
+            bodyPreview: pullRequest.bodyPreview,
             requestedReviewerLogins: pullRequest.requestedReviewerLogins,
             requestedTeamNames: pullRequest.requestedTeamNames
         )

--- a/Sources/RepoBarCore/Auth/TokenStore.swift
+++ b/Sources/RepoBarCore/Auth/TokenStore.swift
@@ -82,6 +82,11 @@ public struct TokenStore: Sendable {
         self.clearPAT()
     }
 
+    public func clearAllCredentials() {
+        self.clear()
+        self.clearOpenAIAPIKey()
+    }
+
     // MARK: - PAT Storage
 
     public func savePAT(_ token: String) throws {
@@ -97,6 +102,30 @@ public struct TokenStore: Sendable {
 
     public func clearPAT() {
         self.clear(account: "pat")
+    }
+
+    // MARK: - OpenAI API Key Storage
+
+    public func saveOpenAIAPIKey(_ key: String) throws {
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.isEmpty == false else {
+            self.clearOpenAIAPIKey()
+            return
+        }
+
+        try self.save(data: Data(trimmed.utf8), account: "openai-api-key")
+    }
+
+    public func loadOpenAIAPIKey() throws -> String? {
+        guard let data = try self.loadData(account: "openai-api-key") else { return nil }
+
+        let key = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return key?.isEmpty == false ? key : nil
+    }
+
+    public func clearOpenAIAPIKey() {
+        self.clear(account: "openai-api-key")
     }
 
     // MARK: - Account-Scoped Storage (Phase 1)

--- a/Sources/RepoBarCore/Models/GitHubReferenceMatch.swift
+++ b/Sources/RepoBarCore/Models/GitHubReferenceMatch.swift
@@ -106,6 +106,7 @@ public struct GitHubReferenceMatch: Sendable, Hashable {
     public let createdAt: Date?
     public let updatedAt: Date
     public let bodyPreview: String?
+    public let aiSummary: String?
     public let authorLogin: String?
     public let isResolved: Bool
 
@@ -119,6 +120,7 @@ public struct GitHubReferenceMatch: Sendable, Hashable {
         createdAt: Date?,
         updatedAt: Date,
         bodyPreview: String? = nil,
+        aiSummary: String? = nil,
         authorLogin: String? = nil,
         isResolved: Bool = true
     ) {
@@ -131,6 +133,7 @@ public struct GitHubReferenceMatch: Sendable, Hashable {
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.bodyPreview = bodyPreview
+        self.aiSummary = aiSummary
         self.authorLogin = authorLogin
         self.isResolved = isResolved
     }
@@ -167,8 +170,26 @@ public struct GitHubReferenceMatch: Sendable, Hashable {
             createdAt: match.createdAt,
             updatedAt: now,
             bodyPreview: match.bodyPreview,
+            aiSummary: match.aiSummary,
             authorLogin: match.authorLogin,
             isResolved: false
+        )
+    }
+
+    public func withAISummary(_ summary: String?) -> GitHubReferenceMatch {
+        GitHubReferenceMatch(
+            query: self.query,
+            title: self.title,
+            url: self.url,
+            repositoryFullName: self.repositoryFullName,
+            kind: self.kind,
+            state: self.state,
+            createdAt: self.createdAt,
+            updatedAt: self.updatedAt,
+            bodyPreview: self.bodyPreview,
+            aiSummary: summary,
+            authorLogin: self.authorLogin,
+            isResolved: self.isResolved
         )
     }
 

--- a/Sources/RepoBarCore/Models/RepoRecentItems.swift
+++ b/Sources/RepoBarCore/Models/RepoRecentItems.swift
@@ -74,6 +74,7 @@ public struct RepoPullRequestSummary: Sendable, Hashable {
     public let labels: [RepoIssueLabel]
     public let headRefName: String?
     public let baseRefName: String?
+    public let bodyPreview: String?
     public let requestedReviewerLogins: [String]
     public let requestedTeamNames: [String]
 
@@ -93,6 +94,7 @@ public struct RepoPullRequestSummary: Sendable, Hashable {
         labels: [RepoIssueLabel],
         headRefName: String?,
         baseRefName: String?,
+        bodyPreview: String? = nil,
         requestedReviewerLogins: [String] = [],
         requestedTeamNames: [String] = []
     ) {
@@ -111,6 +113,7 @@ public struct RepoPullRequestSummary: Sendable, Hashable {
         self.labels = labels
         self.headRefName = headRefName
         self.baseRefName = baseRefName
+        self.bodyPreview = bodyPreview
         self.requestedReviewerLogins = requestedReviewerLogins
         self.requestedTeamNames = requestedTeamNames
     }

--- a/Sources/RepoBarCore/Settings/UserSettings.swift
+++ b/Sources/RepoBarCore/Settings/UserSettings.swift
@@ -6,6 +6,7 @@ public struct UserSettings: Equatable, Codable {
     public var repoList = RepoListSettings()
     public var localProjects = LocalProjectsSettings()
     public var gitHubReferenceMonitor = GitHubReferenceMonitorSettings()
+    public var aiSummaries = AISummarySettings()
     public var gitHubPullRequestNotifications = GitHubPullRequestNotificationSettings()
     public var githubArchives = GitHubArchiveSettings()
     public var menuCustomization = MenuCustomization()
@@ -36,6 +37,7 @@ public struct UserSettings: Equatable, Codable {
         case repoList
         case localProjects
         case gitHubReferenceMonitor
+        case aiSummaries
         case gitHubPullRequestNotifications
         case legacyIssueNumberMonitor = "issueNumberMonitor"
         case githubArchives
@@ -67,6 +69,7 @@ public struct UserSettings: Equatable, Codable {
         self.gitHubReferenceMonitor = try container.decodeIfPresent(GitHubReferenceMonitorSettings.self, forKey: .gitHubReferenceMonitor)
             ?? container.decodeIfPresent(GitHubReferenceMonitorSettings.self, forKey: .legacyIssueNumberMonitor)
             ?? GitHubReferenceMonitorSettings()
+        self.aiSummaries = try container.decodeIfPresent(AISummarySettings.self, forKey: .aiSummaries) ?? AISummarySettings()
         self.gitHubPullRequestNotifications = try container.decodeIfPresent(
             GitHubPullRequestNotificationSettings.self,
             forKey: .gitHubPullRequestNotifications
@@ -112,6 +115,7 @@ public struct UserSettings: Equatable, Codable {
         try container.encode(self.repoList, forKey: .repoList)
         try container.encode(self.localProjects, forKey: .localProjects)
         try container.encode(self.gitHubReferenceMonitor, forKey: .gitHubReferenceMonitor)
+        try container.encode(self.aiSummaries, forKey: .aiSummaries)
         try container.encode(self.gitHubPullRequestNotifications, forKey: .gitHubPullRequestNotifications)
         try container.encode(self.githubArchives, forKey: .githubArchives)
         try container.encode(self.menuCustomization, forKey: .menuCustomization)
@@ -291,6 +295,28 @@ public struct GitHubReferenceMonitorSettings: Equatable, Codable, Sendable {
     public var enabled = false
 
     public init() {}
+}
+
+public struct AISummarySettings: Equatable, Codable, Sendable {
+    public static let defaultModel = "chat-latest"
+
+    public var enabled = false
+    public var model = defaultModel
+
+    public init() {}
+
+    enum CodingKeys: String, CodingKey {
+        case enabled
+        case model
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
+        let decodedModel = try container.decodeIfPresent(String.self, forKey: .model) ?? Self.defaultModel
+        let trimmed = decodedModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.model = trimmed.isEmpty ? Self.defaultModel : trimmed
+    }
 }
 
 public struct GitHubPullRequestNotificationSettings: Equatable, Codable, Sendable {

--- a/Sources/RepoBarCore/Support/OpenAIAPIKeyStore.swift
+++ b/Sources/RepoBarCore/Support/OpenAIAPIKeyStore.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+public enum OpenAIAPIKeySource: Equatable, Sendable {
+    case keychain
+    case environment(String)
+    case missing
+
+    public var label: String {
+        switch self {
+        case .keychain:
+            "Stored in Keychain"
+        case let .environment(name):
+            "Using \(name)"
+        case .missing:
+            "No key configured"
+        }
+    }
+}
+
+public struct OpenAIAPIKeyResolution: Equatable, Sendable {
+    public let key: String?
+    public let source: OpenAIAPIKeySource
+}
+
+public struct OpenAIAPIKeyStore: Sendable {
+    private let tokenStore: TokenStore
+    private let environmentValue: @Sendable (String) -> String?
+
+    public init(
+        tokenStore: TokenStore = .shared,
+        environmentValue: @escaping @Sendable (String) -> String? = { ProcessInfo.processInfo.environment[$0] }
+    ) {
+        self.tokenStore = tokenStore
+        self.environmentValue = environmentValue
+    }
+
+    public func save(_ key: String) throws {
+        try self.tokenStore.saveOpenAIAPIKey(key)
+    }
+
+    public func clearStoredKey() {
+        self.tokenStore.clearOpenAIAPIKey()
+    }
+
+    public func resolve() -> OpenAIAPIKeyResolution {
+        if let stored = try? self.tokenStore.loadOpenAIAPIKey(), stored.isEmpty == false {
+            return OpenAIAPIKeyResolution(key: stored, source: .keychain)
+        }
+
+        for name in ["OPENAI_API_KEY", "REPOBAR_OPENAI_API_KEY"] {
+            guard let value = self.environmentValue(name)?.trimmingCharacters(in: .whitespacesAndNewlines) else {
+                continue
+            }
+
+            if value.isEmpty == false {
+                return OpenAIAPIKeyResolution(key: value, source: .environment(name))
+            }
+        }
+
+        return OpenAIAPIKeyResolution(key: nil, source: .missing)
+    }
+}

--- a/Sources/RepoBarCore/Support/PullRequestAISummarizer.swift
+++ b/Sources/RepoBarCore/Support/PullRequestAISummarizer.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Tachikoma
+
+public struct PullRequestAISummarizer: Sendable {
+    private let keyStore: OpenAIAPIKeyStore
+
+    public init(keyStore: OpenAIAPIKeyStore = OpenAIAPIKeyStore()) {
+        self.keyStore = keyStore
+    }
+
+    public func summarize(_ match: GitHubReferenceMatch, settings: AISummarySettings) async throws -> String? {
+        guard settings.enabled, match.kind == .pullRequest else { return nil }
+        guard let key = self.keyStore.resolve().key else { return nil }
+
+        let model = Self.openAIModel(from: settings.model)
+        let configuration = TachikomaConfiguration(loadFromEnvironment: false)
+        configuration.setAPIKey(key, for: .openai)
+
+        let summary = try await generate(
+            Self.prompt(for: match),
+            using: model,
+            system: "You write compact pull request sidebar summaries. Return one sentence, no markdown, no labels.",
+            maxTokens: 80,
+            configuration: configuration
+        )
+
+        return Self.clean(summary)
+    }
+
+    private static func openAIModel(from modelID: String) -> LanguageModel {
+        let trimmed = modelID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.isEmpty == false else { return .openai(.chatLatest) }
+
+        if case let .openai(model)? = LanguageModel.parse(from: trimmed) {
+            return .openai(model)
+        }
+
+        return .openai(.custom(trimmed))
+    }
+
+    private static func prompt(for match: GitHubReferenceMatch) -> String {
+        var parts = [
+            "Repository: \(match.repositoryFullName)",
+            "PR: \(match.query.displayText)",
+            "Title: \(match.title)"
+        ]
+        if let author = match.authorLogin, author.isEmpty == false {
+            parts.append("Author: \(author)")
+        }
+        if let body = match.bodyPreview, body.isEmpty == false {
+            parts.append("Body preview: \(body)")
+        }
+        parts.append("Summarize what this pull request appears to change and why it matters.")
+        return parts.joined(separator: "\n")
+    }
+
+    private static func clean(_ raw: String) -> String? {
+        let summary = raw
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { $0.isEmpty == false }
+            .joined(separator: " ")
+        guard summary.isEmpty == false else { return nil }
+
+        if summary.count <= 220 { return summary }
+        return "\(summary.prefix(217))..."
+    }
+}

--- a/Sources/RepoBarCore/Support/SettingsStore.swift
+++ b/Sources/RepoBarCore/Support/SettingsStore.swift
@@ -4,11 +4,26 @@ import Foundation
 public struct SettingsStore {
     private let defaults: UserDefaults
     static let storageKey = "com.steipete.repobar.settings"
+    public static let mainAppSuiteName = "com.steipete.repobar"
     private let key = Self.storageKey
     private static let currentVersion = 3
 
-    public init(defaults: UserDefaults = .standard) {
+    public init(defaults: UserDefaults = Self.defaultDefaults()) {
         self.defaults = defaults
+    }
+
+    public static func defaultDefaults() -> UserDefaults {
+        if let bundleIdentifier = Bundle.main.bundleIdentifier {
+            if let defaults = UserDefaults(suiteName: bundleIdentifier) {
+                return defaults
+            }
+        }
+
+        return .standard
+    }
+
+    public static func mainAppDefaults() -> UserDefaults {
+        UserDefaults(suiteName: self.mainAppSuiteName) ?? .standard
     }
 
     public func load() -> UserSettings {

--- a/Sources/repobarcli/AccountsCommands.swift
+++ b/Sources/repobarcli/AccountsCommands.swift
@@ -56,7 +56,7 @@ struct AccountsListCommand: CommanderRunnableCommand {
     }
 
     mutating func run() async throws {
-        let settings = SettingsStore().load()
+        let settings = cliSettingsStore().load()
         let activeAccountID = settings.resolvedActiveAccount()?.id
         if self.output.jsonOutput {
             let payload = AccountListOutput(
@@ -97,7 +97,7 @@ struct AccountsUseCommand: CommanderRunnableCommand {
     }
 
     mutating func run() async throws {
-        let store = SettingsStore()
+        let store = cliSettingsStore()
         var settings = store.load()
         let account = try AccountResolver.resolve(self.target, settings: settings)
         try mirrorAccountCredentialsToLegacy(account)
@@ -126,7 +126,7 @@ struct AccountsRemoveCommand: CommanderRunnableCommand {
     }
 
     mutating func run() async throws {
-        let store = SettingsStore()
+        let store = cliSettingsStore()
         var settings = store.load()
         let account = try AccountResolver.resolve(self.target, settings: settings)
         TokenStore.shared.clear(accountID: account.id)

--- a/Sources/repobarcli/ArchiveCommands.swift
+++ b/Sources/repobarcli/ArchiveCommands.swift
@@ -18,7 +18,7 @@ struct ArchivesListCommand: CommanderRunnableCommand {
     }
 
     mutating func run() async throws {
-        let settings = SettingsStore().load()
+        let settings = cliSettingsStore().load()
         if self.output.jsonOutput {
             try printJSON(settings.githubArchives)
             return
@@ -66,7 +66,7 @@ struct ArchivesStatusCommand: CommanderRunnableCommand {
     }
 
     mutating func run() async throws {
-        let settings = SettingsStore().load()
+        let settings = cliSettingsStore().load()
         let statuses = try GitHubArchiveStore.statuses(settings: settings.githubArchives, name: self.name)
         let payload = GitHubArchiveStatusOutput(sources: statuses)
         if self.output.jsonOutput {
@@ -119,7 +119,7 @@ struct ArchivesValidateCommand: CommanderRunnableCommand {
     }
 
     mutating func run() async throws {
-        let settings = SettingsStore().load()
+        let settings = cliSettingsStore().load()
         let statuses = try GitHubArchiveStore.statuses(settings: settings.githubArchives, name: self.name)
         let payload = GitHubArchiveStatusOutput(sources: statuses)
         if self.output.jsonOutput {
@@ -163,7 +163,7 @@ struct ArchivesUpdateCommand: CommanderRunnableCommand {
 
     mutating func run() async throws {
         let name = try GitHubArchiveStore.requireName(self.name)
-        let store = SettingsStore()
+        let store = cliSettingsStore()
         var settings = store.load()
         guard let index = settings.githubArchives.sources.firstIndex(where: { $0.name.equalsCaseInsensitive(name) || $0.id == name }) else {
             throw ValidationError("Archive not found: \(name)")
@@ -231,7 +231,7 @@ struct ArchivesAddCommand: CommanderRunnableCommand {
     }
 
     mutating func run() async throws {
-        let store = SettingsStore()
+        let store = cliSettingsStore()
         var settings = store.load()
         let source = try Self.archiveSource(
             repository: self.repository,
@@ -384,7 +384,7 @@ struct ArchivesRemoveCommand: CommanderRunnableCommand {
 
     mutating func run() async throws {
         let name = try GitHubArchiveStore.requireName(self.name)
-        let store = SettingsStore()
+        let store = cliSettingsStore()
         var settings = store.load()
         let before = settings.githubArchives.sources.count
         settings.githubArchives.sources.removeAll { $0.name.equalsCaseInsensitive(name) || $0.id == name }
@@ -428,7 +428,7 @@ struct ArchivesEnableCommand: CommanderRunnableCommand {
 
     private func update(enabled: Bool) throws {
         let name = try GitHubArchiveStore.requireName(self.name)
-        let store = SettingsStore()
+        let store = cliSettingsStore()
         var settings = store.load()
         guard let index = settings.githubArchives.sources.firstIndex(where: { $0.name.equalsCaseInsensitive(name) || $0.id == name }) else {
             throw ValidationError("Archive not found: \(name)")
@@ -467,7 +467,7 @@ struct ArchivesDisableCommand: CommanderRunnableCommand {
 
     mutating func run() async throws {
         let name = try GitHubArchiveStore.requireName(self.name)
-        let store = SettingsStore()
+        let store = cliSettingsStore()
         var settings = store.load()
         guard let index = settings.githubArchives.sources.firstIndex(where: { $0.name.equalsCaseInsensitive(name) || $0.id == name }) else {
             throw ValidationError("Archive not found: \(name)")

--- a/Sources/repobarcli/CLIContext.swift
+++ b/Sources/repobarcli/CLIContext.swift
@@ -22,7 +22,7 @@ struct RepoIdentifier: Equatable {
 }
 
 func makeAuthenticatedClient() async throws -> AuthContext {
-    let settings = SettingsStore().load()
+    let settings = cliSettingsStore().load()
     if let account = settings.resolvedActiveAccount() {
         guard (try? TokenStore.shared.loadTokens(accountID: account.id)) != nil
             || (try? TokenStore.shared.loadPAT(accountID: account.id)) != nil
@@ -30,7 +30,11 @@ func makeAuthenticatedClient() async throws -> AuthContext {
             throw CLIError.notAuthenticated
         }
 
-        let client = GitHubClient(accountID: account.id)
+        let archiveSettings = settings.githubArchives
+        let client = GitHubClient(
+            accountID: account.id,
+            archiveSettingsProvider: { archiveSettings }
+        )
         await client.setAPIHost(account.apiHost)
         await client.setTokenProvider { @Sendable () async throws -> OAuthTokens? in
             if account.authMethod == .pat, let pat = try? TokenStore.shared.loadPAT(accountID: account.id) {
@@ -55,7 +59,8 @@ func makeAuthenticatedClient() async throws -> AuthContext {
         RepoBarAuthDefaults.apiHost
     }
 
-    let client = GitHubClient()
+    let archiveSettings = settings.githubArchives
+    let client = GitHubClient(archiveSettingsProvider: { archiveSettings })
     await client.setAPIHost(apiHost)
     await client.setTokenProvider { @Sendable () async throws -> OAuthTokens? in
         try await OAuthTokenRefresher().refreshIfNeeded(host: host)

--- a/Sources/repobarcli/Commands.swift
+++ b/Sources/repobarcli/Commands.swift
@@ -392,7 +392,7 @@ struct LoginCommand: CommanderRunnableCommand {
             throw ValidationError("--loopback-port must be between 1 and 65535")
         }
 
-        let store = SettingsStore()
+        let store = cliSettingsStore()
         var settings = store.load()
         let rawHost: URL = if let host {
             try parseHost(host)
@@ -487,12 +487,11 @@ struct LogoutCommand: CommanderRunnableCommand {
     }
 
     mutating func run() async throws {
-        let store = SettingsStore()
+        let store = cliSettingsStore()
         var settings = store.load()
 
         if self.all {
-            TokenStore.shared.clear()
-            TokenStore.shared.clearPAT()
+            TokenStore.shared.clearAllCredentials()
             let scopedAccountIDs = Set(settings.accounts.map(\.id))
                 .union((try? TokenStore.shared.allAccountIDs()) ?? [])
             for accountID in scopedAccountIDs {
@@ -507,7 +506,6 @@ struct LogoutCommand: CommanderRunnableCommand {
 
         if settings.accounts.isEmpty {
             TokenStore.shared.clear()
-            TokenStore.shared.clearPAT()
             print("Logged out.")
             return
         }
@@ -547,7 +545,7 @@ struct ImportGHTokenCommand: CommanderRunnableCommand {
     }
 
     mutating func run() async throws {
-        let store = SettingsStore()
+        let store = cliSettingsStore()
         var settings = store.load()
         let rawHost: URL = if let host {
             try parseHost(host)
@@ -656,7 +654,7 @@ struct StatusCommand: CommanderRunnableCommand {
     }
 
     mutating func run() async throws {
-        let settings = SettingsStore().load()
+        let settings = cliSettingsStore().load()
         // When the user explicitly targets an account, read account-scoped tokens.
         if self.account != nil || settings.accounts.isEmpty == false {
             let resolved: Account
@@ -728,7 +726,7 @@ struct StatusCommand: CommanderRunnableCommand {
             return
         }
 
-        let settings = SettingsStore().load()
+        let settings = cliSettingsStore().load()
         let host = (settings.enterpriseHost ?? settings.githubHost).absoluteString
         let now = Date()
         let expiresAt = tokens.expiresAt

--- a/Sources/repobarcli/LocalActionsCommands.swift
+++ b/Sources/repobarcli/LocalActionsCommands.swift
@@ -25,7 +25,7 @@ struct LocalSyncCommand: CommanderRunnableCommand {
 
     mutating func run() async throws {
         let target = try requireLocalTarget(self.target)
-        let settings = SettingsStore().load()
+        let settings = cliSettingsStore().load()
         let resolved = try await resolveLocalRepoTarget(target, settings: settings)
         let result = try LocalGitService().smartSync(at: resolved.path)
 
@@ -74,7 +74,7 @@ struct LocalRebaseCommand: CommanderRunnableCommand {
 
     mutating func run() async throws {
         let target = try requireLocalTarget(self.target)
-        let settings = SettingsStore().load()
+        let settings = cliSettingsStore().load()
         let resolved = try await resolveLocalRepoTarget(target, settings: settings)
         try LocalGitService().rebaseOntoUpstream(at: resolved.path)
 
@@ -123,7 +123,7 @@ struct LocalResetCommand: CommanderRunnableCommand {
 
     mutating func run() async throws {
         let target = try requireLocalTarget(self.target)
-        let settings = SettingsStore().load()
+        let settings = cliSettingsStore().load()
         let resolved = try await resolveLocalRepoTarget(target, settings: settings)
 
         if self.assumeYes == false {
@@ -173,7 +173,7 @@ struct LocalBranchesCommand: CommanderRunnableCommand {
 
     mutating func run() async throws {
         let target = try requireLocalTarget(self.target)
-        let settings = SettingsStore().load()
+        let settings = cliSettingsStore().load()
         let resolved = try await resolveLocalRepoTarget(target, settings: settings)
         let snapshot = try LocalGitService().branchDetails(at: resolved.path)
 
@@ -220,7 +220,7 @@ struct WorktreesCommand: CommanderRunnableCommand {
 
     mutating func run() async throws {
         let target = try requireLocalTarget(self.target)
-        let settings = SettingsStore().load()
+        let settings = cliSettingsStore().load()
         let resolved = try await resolveLocalRepoTarget(target, settings: settings)
         let worktrees = try LocalGitService().worktrees(at: resolved.path)
 
@@ -262,7 +262,7 @@ struct OpenFinderCommand: CommanderRunnableCommand {
 
     mutating func run() async throws {
         let target = try requireLocalTarget(self.target)
-        let settings = SettingsStore().load()
+        let settings = cliSettingsStore().load()
         let resolved = try await resolveLocalRepoTarget(target, settings: settings)
         try openPath(resolved.path.path)
         print("Opened Finder at \(resolved.displayName)")
@@ -288,7 +288,7 @@ struct OpenTerminalCommand: CommanderRunnableCommand {
 
     mutating func run() async throws {
         let target = try requireLocalTarget(self.target)
-        let settings = SettingsStore().load()
+        let settings = cliSettingsStore().load()
         let resolved = try await resolveLocalRepoTarget(target, settings: settings)
         try openTerminal(at: resolved.path, settings: settings)
         print("Opened terminal at \(resolved.displayName)")
@@ -330,7 +330,7 @@ struct CheckoutCommand: CommanderRunnableCommand {
 
     mutating func run() async throws {
         let repo = try requireRepoIdentifier(self.repoName)
-        let settingsStore = SettingsStore()
+        let settingsStore = cliSettingsStore()
         var settings = settingsStore.load()
         let host = settings.enterpriseHost ?? settings.githubHost
 

--- a/Sources/repobarcli/LocalProjectsCommands.swift
+++ b/Sources/repobarcli/LocalProjectsCommands.swift
@@ -40,7 +40,7 @@ struct LocalProjectsCommand: CommanderRunnableCommand {
         if self.depth < 0 { throw ValidationError("--depth must be >= 0") }
         if let limit, limit <= 0 { throw ValidationError("--limit must be > 0") }
 
-        let settings = SettingsStore().load()
+        let settings = cliSettingsStore().load()
         let rootPath = self.root
             ?? settings.localProjects.rootPath
             ?? "~/Projects"

--- a/Sources/repobarcli/SettingsCommands.swift
+++ b/Sources/repobarcli/SettingsCommands.swift
@@ -26,7 +26,7 @@ struct PinCommand: CommanderRunnableCommand {
     mutating func run() async throws {
         let repoName = try requireRepoName(self.repoName)
         let normalized = try normalizeRepoFullName(repoName)
-        let store = SettingsStore()
+        let store = cliSettingsStore()
         var settings = store.load()
 
         settings.repoList.hiddenRepositories.removeAll { $0.equalsCaseInsensitive(normalized) }
@@ -68,7 +68,7 @@ struct UnpinCommand: CommanderRunnableCommand {
     mutating func run() async throws {
         let repoName = try requireRepoName(self.repoName)
         let normalized = try normalizeRepoFullName(repoName)
-        let store = SettingsStore()
+        let store = cliSettingsStore()
         var settings = store.load()
 
         settings.repoList.pinnedRepositories.removeAll { $0.equalsCaseInsensitive(normalized) }
@@ -107,7 +107,7 @@ struct HideCommand: CommanderRunnableCommand {
     mutating func run() async throws {
         let repoName = try requireRepoName(self.repoName)
         let normalized = try normalizeRepoFullName(repoName)
-        let store = SettingsStore()
+        let store = cliSettingsStore()
         var settings = store.load()
 
         settings.repoList.pinnedRepositories.removeAll { $0.equalsCaseInsensitive(normalized) }
@@ -149,7 +149,7 @@ struct ShowCommand: CommanderRunnableCommand {
     mutating func run() async throws {
         let repoName = try requireRepoName(self.repoName)
         let normalized = try normalizeRepoFullName(repoName)
-        let store = SettingsStore()
+        let store = cliSettingsStore()
         var settings = store.load()
 
         settings.repoList.hiddenRepositories.removeAll { $0.equalsCaseInsensitive(normalized) }
@@ -180,7 +180,7 @@ struct SettingsShowCommand: CommanderRunnableCommand {
     }
 
     mutating func run() async throws {
-        var settings = SettingsStore().load()
+        var settings = cliSettingsStore().load()
         settings.menuCustomization.normalize()
         if self.output.jsonOutput {
             try printJSON(settings)
@@ -227,7 +227,7 @@ struct SettingsSetCommand: CommanderRunnableCommand {
             throw ValidationError("Unknown settings key: \(key)")
         }
 
-        let store = SettingsStore()
+        let store = cliSettingsStore()
         var settings = store.load()
         let summary = try applySetting(settingKey, value: value, settings: &settings)
         store.save(settings)

--- a/Sources/repobarcli/SettingsSupport.swift
+++ b/Sources/repobarcli/SettingsSupport.swift
@@ -2,6 +2,10 @@ import Commander
 import Foundation
 import RepoBarCore
 
+func cliSettingsStore() -> SettingsStore {
+    SettingsStore(defaults: SettingsStore.mainAppDefaults())
+}
+
 enum SettingsKey: String, CaseIterable {
     case refreshInterval = "refresh-interval"
     case repoLimit = "repo-limit"
@@ -32,6 +36,8 @@ enum SettingsKey: String, CaseIterable {
     case localPreferredTerminal = "local-preferred-terminal"
     case localGhosttyMode = "local-ghostty-mode"
     case localShowDirtyFiles = "local-show-dirty-files"
+    case aiSummaries = "ai-summaries"
+    case aiSummaryModel = "ai-summary-model"
     case launchAtLogin = "launch-at-login"
 
     init?(argument: String) {
@@ -95,6 +101,10 @@ enum SettingsKey: String, CaseIterable {
             self = .localGhosttyMode
         case "local-show-dirty-files", "show-dirty-files":
             self = .localShowDirtyFiles
+        case "ai-summaries", "ai-summary", "pr-summaries", "pr-summary":
+            self = .aiSummaries
+        case "ai-summary-model", "ai-model", "summary-model":
+            self = .aiSummaryModel
         case "launch-at-login":
             self = .launchAtLogin
         default:
@@ -251,6 +261,14 @@ func applySetting(_ key: SettingsKey, value: String, settings: inout UserSetting
         let flag = try parseBool(value)
         settings.localProjects.showDirtyFilesInMenu = flag
         return flag ? "on" : "off"
+    case .aiSummaries:
+        let flag = try parseBool(value)
+        settings.aiSummaries.enabled = flag
+        return flag ? "on" : "off"
+    case .aiSummaryModel:
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        settings.aiSummaries.model = trimmed.isEmpty ? AISummarySettings.defaultModel : trimmed
+        return settings.aiSummaries.model
     case .launchAtLogin:
         let flag = try parseBool(value)
         settings.launchAtLogin = flag
@@ -290,6 +308,8 @@ func settingsSummaryLines(settings: UserSettings) -> [String] {
         "Local preferred terminal: \(settings.localProjects.preferredTerminal ?? "-")",
         "Local Ghostty mode: \(settings.localProjects.ghosttyOpenMode.rawValue)",
         "Local show dirty files: \(settings.localProjects.showDirtyFilesInMenu ? "on" : "off")",
+        "AI summaries: \(settings.aiSummaries.enabled ? "on" : "off")",
+        "AI summary model: \(settings.aiSummaries.model)",
         "GitHub archives: \(archives.isEmpty ? "-" : archives.map(\.name).joined(separator: ", "))",
         "Archive fallback on rate limit: \(settings.githubArchives.preferArchiveWhenRateLimited ? "on" : "off")",
         "Launch at login: \(settings.launchAtLogin ? "on" : "off")",

--- a/Tests/RepoBarTests/RecentRepoItemsDecodingTests.swift
+++ b/Tests/RepoBarTests/RecentRepoItemsDecodingTests.swift
@@ -98,6 +98,7 @@ struct RecentRepoItemsDecodingTests {
             ],
             "head": { "ref": "feature/menu-rows" },
             "base": { "ref": "main" },
+            "body": "Adds sidebar rows.\\n\\nKeeps summaries compact.",
             "user": { "login": "steipete", "avatar_url": "https://avatars.githubusercontent.com/u/583?v=4" }
           }
         ]
@@ -118,6 +119,7 @@ struct RecentRepoItemsDecodingTests {
         #expect(items.first?.labels.first?.name == "bug")
         #expect(items.first?.headRefName == "feature/menu-rows")
         #expect(items.first?.baseRefName == "main")
+        #expect(items.first?.bodyPreview == "Adds sidebar rows. Keeps summaries compact.")
     }
 
     @Test

--- a/Tests/RepoBarTests/RepoBarCoreModelsTests.swift
+++ b/Tests/RepoBarTests/RepoBarCoreModelsTests.swift
@@ -154,10 +154,12 @@ struct RepoBarCoreModelsTests {
             createdAt: Date(timeIntervalSinceReferenceDate: 10),
             updatedAt: Date(timeIntervalSinceReferenceDate: 20),
             bodyPreview: "Preview text",
+            aiSummary: "AI summary",
             authorLogin: "alice"
         )
 
         #expect(match.bodyPreview == "Preview text")
+        #expect(match.aiSummary == "AI summary")
         #expect(match.authorLogin == "alice")
     }
 

--- a/Tests/RepoBarTests/SettingsStoreCoverageTests.swift
+++ b/Tests/RepoBarTests/SettingsStoreCoverageTests.swift
@@ -26,6 +26,8 @@ struct SettingsStoreCoverageTests {
         settings.gitHubPullRequestNotifications.enabled = true
         settings.gitHubPullRequestNotifications.reviewRequests = true
         settings.gitHubPullRequestNotifications.clickAction = .openIssueNavigator
+        settings.aiSummaries.enabled = true
+        settings.aiSummaries.model = "chat-latest"
         settings.githubHost = try #require(URL(string: "https://github.example.com"))
         settings.githubArchives.sources = [
             GitHubArchiveSource(
@@ -43,6 +45,8 @@ struct SettingsStoreCoverageTests {
         #expect(loaded.gitHubPullRequestNotifications.enabled)
         #expect(loaded.gitHubPullRequestNotifications.reviewRequests)
         #expect(loaded.gitHubPullRequestNotifications.clickAction == .openIssueNavigator)
+        #expect(loaded.aiSummaries.enabled)
+        #expect(loaded.aiSummaries.model == "chat-latest")
         #expect(loaded.githubHost == URL(string: "https://github.example.com")!)
         #expect(loaded.githubArchives.sources.first?.name == "openclaw")
         #expect(loaded.githubArchives.sources.first?.format == .discrawlSnapshot)

--- a/Tests/RepoBarTests/TokenStorePATTests.swift
+++ b/Tests/RepoBarTests/TokenStorePATTests.swift
@@ -58,6 +58,32 @@ struct TokenStorePATTests {
     }
 
     @Test
+    func `clear preserves OpenAI API key`() throws {
+        let service = "com.steipete.repobar.auth.tests.\(UUID().uuidString)"
+        let store = TokenStore(service: service)
+        defer { store.clearAllCredentials() }
+
+        try store.saveOpenAIAPIKey("sk-test")
+
+        store.clear()
+
+        #expect(try store.loadOpenAIAPIKey() == "sk-test")
+    }
+
+    @Test
+    func `clear all credentials clears OpenAI API key`() throws {
+        let service = "com.steipete.repobar.auth.tests.\(UUID().uuidString)"
+        let store = TokenStore(service: service)
+        defer { store.clearAllCredentials() }
+
+        try store.saveOpenAIAPIKey("sk-test")
+
+        store.clearAllCredentials()
+
+        #expect(try store.loadOpenAIAPIKey() == nil)
+    }
+
+    @Test
     func `save PAT overwrites previous`() throws {
         let service = "com.steipete.repobar.auth.tests.\(UUID().uuidString)"
         let store = TokenStore(service: service)
@@ -68,5 +94,49 @@ struct TokenStorePATTests {
 
         let loaded = try store.loadPAT()
         #expect(loaded == "ghp_second")
+    }
+
+    @Test
+    func `save OpenAI API key and load`() throws {
+        let service = "com.steipete.repobar.auth.tests.\(UUID().uuidString)"
+        let store = TokenStore(service: service)
+        defer { store.clearOpenAIAPIKey() }
+
+        try store.saveOpenAIAPIKey(" sk-test ")
+
+        #expect(try store.loadOpenAIAPIKey() == "sk-test")
+    }
+
+    @Test
+    func `OpenAI key store prefers stored key over environment`() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("repobar-openai-key-\(UUID().uuidString)", isDirectory: true)
+        let store = TokenStore(service: "repobar-tests", storage: .file(directory))
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try store.saveOpenAIAPIKey("sk-stored")
+
+        let keyStore = OpenAIAPIKeyStore(tokenStore: store) { name in
+            name == "OPENAI_API_KEY" ? "sk-env" : nil
+        }
+
+        let resolved = keyStore.resolve()
+        #expect(resolved.key == "sk-stored")
+        #expect(resolved.source == .keychain)
+    }
+
+    @Test
+    func `OpenAI key store reads exact environment names`() {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("repobar-openai-env-\(UUID().uuidString)", isDirectory: true)
+        let store = TokenStore(service: "repobar-tests", storage: .file(directory))
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let keyStore = OpenAIAPIKeyStore(tokenStore: store) { name in
+            name == "REPOBAR_OPENAI_API_KEY" ? "sk-repobar" : nil
+        }
+
+        let resolved = keyStore.resolve()
+        #expect(resolved.key == "sk-repobar")
+        #expect(resolved.source == .environment("REPOBAR_OPENAI_API_KEY"))
     }
 }

--- a/Tests/repobarcliTests/SettingsCommandTests.swift
+++ b/Tests/repobarcliTests/SettingsCommandTests.swift
@@ -12,6 +12,8 @@ struct SettingsCommandTests {
         settings.gitHubPullRequestNotifications.reviewRequests = true
         settings.gitHubPullRequestNotifications.comments = true
         settings.gitHubPullRequestNotifications.clickAction = .openIssueNavigator
+        settings.aiSummaries.enabled = true
+        settings.aiSummaries.model = "chat-latest"
 
         let lines = settingsSummaryLines(settings: settings)
 
@@ -19,6 +21,8 @@ struct SettingsCommandTests {
         #expect(lines.contains("PR notifications: on"))
         #expect(lines.contains("PR notification events: new pull requests, updates, review requests, comments"))
         #expect(lines.contains("PR notification click: Issue Navigator"))
+        #expect(lines.contains("AI summaries: on"))
+        #expect(lines.contains("AI summary model: chat-latest"))
     }
 
     @Test
@@ -40,6 +44,17 @@ struct SettingsCommandTests {
         #expect(settings.gitHubPullRequestNotifications.reviewRequests)
         #expect(settings.gitHubPullRequestNotifications.comments)
         #expect(settings.gitHubPullRequestNotifications.clickAction == .openIssueNavigator)
+    }
+
+    @Test
+    func `settings set supports AI summary settings`() throws {
+        var settings = UserSettings()
+
+        #expect(try applySetting(.aiSummaries, value: "on", settings: &settings) == "on")
+        #expect(try applySetting(.aiSummaryModel, value: "chat-latest", settings: &settings) == "chat-latest")
+
+        #expect(settings.aiSummaries.enabled)
+        #expect(settings.aiSummaries.model == "chat-latest")
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add optional OpenAI-powered PR summaries in the Issue Navigator sidebar via Tachikoma chat-latest.
- Add AI summary settings, OpenAI API key storage/env discovery, CLI settings support, and PR body-preview plumbing.
- Preserve app/CLI settings routing and credential lifecycle behavior across bundle variants, account switching, and logout.

## Verification
- pnpm check
- autoreview --mode local: clean
- Tachikoma chat-latest support landed in openclaw/Tachikoma#20 at 7b80238.
- Live Peekaboo test: relaunched packaged debug app, opened Issue Navigator, and verified sidebar rows rendering generated summaries such as "This PR adds a new tart provider...".
