### PR TITLE
Align AI summary sidebar budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.7.1 - Unreleased
 
 - Add optional OpenAI-powered PR summaries to the Issue Navigator sidebar using Tachikoma `chat-latest`, with settings for model and API key storage.
+- Give AI PR summaries more Issue Navigator sidebar room and tune generated summary length to the visible row budget.
 - Keep the separate Issue Navigator window from auto-scrolling embedded GitHub issue previews while preserving the menu dropdown preview scroll offset.
 - Keep Issue Navigator reference clicks from being overwritten by clipboard seeding, and show unresolved GitHub metadata as the reference label instead of "preview unavailable."
 - Keep the Repositories settings table from rendering duplicate rows when the same repository is both pinned and hidden (thanks @devYRPauli). (#73)

--- a/Sources/RepoBar/StatusBar/IssueNavigatorWindowController.swift
+++ b/Sources/RepoBar/StatusBar/IssueNavigatorWindowController.swift
@@ -11,7 +11,7 @@ final class IssueNavigatorWindowController: NSObject, NSWindowDelegate {
             width: Self.baseContentSize.width * Self.defaultContentScale,
             height: Self.baseContentSize.height * Self.defaultContentScale
         )
-        static let minimumContentSize = NSSize(width: 980, height: 620)
+        static let minimumContentSize = NSSize(width: 1080, height: 620)
     }
 
     private let appState: AppState

--- a/Sources/RepoBar/Views/IssueNavigatorView.swift
+++ b/Sources/RepoBar/Views/IssueNavigatorView.swift
@@ -12,9 +12,9 @@ private struct IssueNavigatorAISummary {
 
 struct IssueNavigatorView: View {
     private enum Metrics {
-        static let sidebarMinWidth: CGFloat = 340
-        static let sidebarIdealWidth: CGFloat = 390
-        static let sidebarMaxWidth: CGFloat = 430
+        static let sidebarMinWidth: CGFloat = 380
+        static let sidebarIdealWidth: CGFloat = 470
+        static let sidebarMaxWidth: CGFloat = 560
         static let sidebarPadding: CGFloat = 14
         static let controlHeight: CGFloat = 28
         static let controlCornerRadius: CGFloat = 10
@@ -77,7 +77,7 @@ struct IssueNavigatorView: View {
                 .frame(minWidth: 560, maxWidth: .infinity, maxHeight: .infinity)
         }
         .background(.ultraThinMaterial)
-        .frame(minWidth: 980, minHeight: 620)
+        .frame(minWidth: 1080, minHeight: 620)
         .onAppear {
             self.browserStore.onNavigationStateChange = {
                 self.browserNavigationVersion &+= 1
@@ -715,12 +715,12 @@ private struct IssueNavigatorResultRow: View {
                 }
                 .font(.caption)
                 .foregroundStyle(self.secondaryForeground)
-                let summary = self.match.aiSummary ?? self.match.bodyPreview
-                if let summary, summary.isEmpty == false {
+                if let summary = self.summaryDisplayText, summary.isEmpty == false {
                     Text(summary)
                         .font(.caption)
                         .foregroundStyle(self.secondaryForeground)
-                        .lineLimit(2)
+                        .lineLimit(self.summaryLineLimit)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
             Spacer(minLength: 0)
@@ -769,6 +769,14 @@ private struct IssueNavigatorResultRow: View {
 
     private var iconForeground: Color {
         self.isSelected ? Color.white.opacity(0.92) : self.tint
+    }
+
+    private var summaryDisplayText: String? {
+        self.match.aiSummary ?? self.match.bodyPreview
+    }
+
+    private var summaryLineLimit: Int {
+        self.match.aiSummary == nil ? 2 : 4
     }
 
     private var rowBackground: Color {

--- a/Sources/RepoBarCore/Support/PullRequestAISummarizer.swift
+++ b/Sources/RepoBarCore/Support/PullRequestAISummarizer.swift
@@ -2,6 +2,14 @@ import Foundation
 import Tachikoma
 
 public struct PullRequestAISummarizer: Sendable {
+    static let maximumSummaryCharacters = 280
+    private static let systemPrompt = [
+        "You write pull request summaries for a macOS sidebar.",
+        "Return one complete sentence, 24-34 words, no more than 280 characters, ending with punctuation.",
+        "Use no markdown and no labels.",
+        "Prefer concrete implementation details over generic phrasing."
+    ].joined(separator: " ")
+
     private let keyStore: OpenAIAPIKeyStore
 
     public init(keyStore: OpenAIAPIKeyStore = OpenAIAPIKeyStore()) {
@@ -19,8 +27,8 @@ public struct PullRequestAISummarizer: Sendable {
         let summary = try await generate(
             Self.prompt(for: match),
             using: model,
-            system: "You write compact pull request sidebar summaries. Return one sentence, no markdown, no labels.",
-            maxTokens: 80,
+            system: Self.systemPrompt,
+            maxTokens: 120,
             configuration: configuration
         )
 
@@ -50,11 +58,11 @@ public struct PullRequestAISummarizer: Sendable {
         if let body = match.bodyPreview, body.isEmpty == false {
             parts.append("Body preview: \(body)")
         }
-        parts.append("Summarize what this pull request appears to change and why it matters.")
+        parts.append("Summarize what this pull request changes and why it matters in one sidebar-sized sentence.")
         return parts.joined(separator: "\n")
     }
 
-    private static func clean(_ raw: String) -> String? {
+    static func clean(_ raw: String) -> String? {
         let summary = raw
             .replacingOccurrences(of: "\r\n", with: "\n")
             .split(whereSeparator: \.isNewline)
@@ -63,7 +71,16 @@ public struct PullRequestAISummarizer: Sendable {
             .joined(separator: " ")
         guard summary.isEmpty == false else { return nil }
 
-        if summary.count <= 220 { return summary }
-        return "\(summary.prefix(217))..."
+        if summary.count <= Self.maximumSummaryCharacters { return summary }
+
+        let prefix = String(summary.prefix(Self.maximumSummaryCharacters - 3))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let lastSpace = prefix.lastIndex(where: \.isWhitespace) {
+            let cutIndex = prefix.distance(from: prefix.startIndex, to: lastSpace)
+            if cutIndex > Self.maximumSummaryCharacters / 2 {
+                return "\(prefix[..<lastSpace])..."
+            }
+        }
+        return "\(prefix)..."
     }
 }

--- a/Tests/RepoBarTests/PullRequestAISummarizerTests.swift
+++ b/Tests/RepoBarTests/PullRequestAISummarizerTests.swift
@@ -1,0 +1,21 @@
+@testable import RepoBarCore
+import Testing
+
+struct PullRequestAISummarizerTests {
+    @Test
+    func `cleaned summary fits sidebar character budget`() throws {
+        let raw = String(repeating: "This summary explains a concrete pull request change with enough detail to overflow the sidebar. ", count: 8)
+
+        let summary = try #require(PullRequestAISummarizer.clean(raw))
+
+        #expect(summary.count <= PullRequestAISummarizer.maximumSummaryCharacters)
+        #expect(summary.hasSuffix("..."))
+    }
+
+    @Test
+    func `cleaned summary collapses multiline output`() throws {
+        let summary = try #require(PullRequestAISummarizer.clean(" First line.\n\n Second line. "))
+
+        #expect(summary == "First line. Second line.")
+    }
+}


### PR DESCRIPTION
## Summary
- widen the Issue Navigator sidebar/window minimum so AI PR summaries get enough visible room
- render AI summaries up to four lines while keeping fallback body previews compact
- tune the `chat-latest` prompt and cleanup cap to produce one complete sidebar-sized sentence

## Proof
- `pnpm check`
- `pnpm restart`
- `peekaboo see --app RepoBar --window-title "Issue Navigator" --json --no-remote`
- `peekaboo image --app RepoBar --window-title "Issue Navigator" --path /tmp/repobar-ai-summary-align-after-min.png --no-remote`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local`
