### PR TITLE
Summarize all Issue Navigator items with AI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add optional OpenAI-powered PR summaries to the Issue Navigator sidebar using Tachikoma `chat-latest`, with settings for model and API key storage.
 - Give AI PR summaries more Issue Navigator sidebar room and tune generated summary length to the visible row budget.
+- Summarize all resolved Issue Navigator items with AI, add an AI settings test button, and replace the model text field with a fixed OpenAI model selector.
 - Keep the separate Issue Navigator window from auto-scrolling embedded GitHub issue previews while preserving the menu dropdown preview scroll offset.
 - Keep Issue Navigator reference clicks from being overwritten by clipboard seeding, and show unresolved GitHub metadata as the reference label instead of "preview unavailable."
 - Keep the Repositories settings table from rendering duplicate rows when the same repository is both pinned and hidden (thanks @devYRPauli). (#73)

--- a/Sources/RepoBar/Settings/AdvancedSettingsView.swift
+++ b/Sources/RepoBar/Settings/AdvancedSettingsView.swift
@@ -9,6 +9,8 @@ struct AdvancedSettingsView: View {
     @State private var cliStatus: String?
     @State private var openAIAPIKey = ""
     @State private var openAIKeyStatus = OpenAIAPIKeySource.missing.label
+    @State private var isTestingAISummary = false
+    @State private var aiSummaryTestStatus: String?
 
     var body: some View {
         Form {
@@ -191,20 +193,37 @@ struct AdvancedSettingsView: View {
             }
 
             Section {
-                Toggle("Summarize Issue Navigator PRs", isOn: self.$session.settings.aiSummaries.enabled)
+                Toggle("Summarize Issue Navigator items", isOn: self.$session.settings.aiSummaries.enabled)
                     .onChange(of: self.session.settings.aiSummaries.enabled) { _, _ in
                         self.appState.persistSettings()
                     }
 
                 LabeledContent("Model") {
-                    TextField("", text: self.aiSummaryModelBinding)
-                        .multilineTextAlignment(.trailing)
-                        .frame(width: 170)
+                    Picker("", selection: self.aiSummaryModelBinding) {
+                        ForEach(AISummarySettings.modelOptions) { option in
+                            Text(option.label).tag(option.id)
+                        }
+                    }
+                    .labelsHidden()
+                    .frame(width: 190)
+                }
+
+                LabeledContent("Scope") {
+                    Picker("", selection: self.$session.settings.aiSummaries.scope) {
+                        ForEach(AISummaryScope.allCases, id: \.self) { scope in
+                            Text(scope.label).tag(scope)
+                        }
+                    }
+                    .labelsHidden()
+                    .frame(width: 190)
+                    .onChange(of: self.session.settings.aiSummaries.scope) { _, _ in
+                        self.appState.persistSettings()
+                    }
                 }
 
                 LabeledContent("OpenAI API key") {
                     HStack(spacing: 8) {
-                        SecureField("OPENAI_API_KEY", text: self.$openAIAPIKey)
+                        SecureField("API key", text: self.$openAIAPIKey)
                             .frame(width: 190)
                         Button("Save") {
                             self.saveOpenAIAPIKey()
@@ -216,9 +235,29 @@ struct AdvancedSettingsView: View {
                     }
                 }
 
+                LabeledContent("Connection") {
+                    Button {
+                        Task { await self.testAISummary() }
+                    } label: {
+                        if self.isTestingAISummary {
+                            ProgressView()
+                                .controlSize(.small)
+                                .frame(width: 38)
+                        } else {
+                            Text("Test")
+                        }
+                    }
+                    .disabled(self.isTestingAISummary)
+                }
+
                 Text(self.openAIKeyStatus)
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                if let aiSummaryTestStatus {
+                    Text(aiSummaryTestStatus)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             } header: {
                 Text("AI Summaries")
             } footer: {
@@ -455,10 +494,9 @@ struct AdvancedSettingsView: View {
 
     private var aiSummaryModelBinding: Binding<String> {
         Binding(
-            get: { self.session.settings.aiSummaries.model },
+            get: { AISummarySettings.normalizedModel(self.session.settings.aiSummaries.model) },
             set: { newValue in
-                let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
-                self.session.settings.aiSummaries.model = trimmed.isEmpty ? AISummarySettings.defaultModel : trimmed
+                self.session.settings.aiSummaries.model = AISummarySettings.normalizedModel(newValue)
                 self.appState.persistSettings()
             }
         )
@@ -482,6 +520,25 @@ struct AdvancedSettingsView: View {
         self.appState.clearOpenAIAPIKey()
         self.openAIAPIKey = ""
         self.refreshOpenAIKeyStatus()
+    }
+
+    private func testAISummary() async {
+        self.isTestingAISummary = true
+        self.aiSummaryTestStatus = nil
+        defer { self.isTestingAISummary = false }
+
+        do {
+            let typedKey = self.openAIAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
+            let keyOverride = typedKey.isEmpty ? nil : typedKey
+            let summary = try await PullRequestAISummarizer().test(
+                settings: self.session.settings.aiSummaries,
+                apiKeyOverride: keyOverride
+            )
+            let suffix = typedKey.isEmpty ? "" : " Typed key was not saved."
+            self.aiSummaryTestStatus = "Test passed: \(summary)\(suffix)"
+        } catch {
+            self.aiSummaryTestStatus = "Test failed: \(error.localizedDescription)"
+        }
     }
 
     private func pickProjectFolder() {

--- a/Sources/RepoBar/Views/IssueNavigatorView.swift
+++ b/Sources/RepoBar/Views/IssueNavigatorView.swift
@@ -562,7 +562,9 @@ struct IssueNavigatorView: View {
         }
 
         let pending = matches.filter {
-            $0.kind == .pullRequest && self.aiSummariesByURL[$0.url]?.signature != Self.aiSummarySignature(for: $0, settings: settings)
+            $0.isResolved
+                && settings.includes(kind: $0.kind)
+                && self.aiSummariesByURL[$0.url]?.signature != Self.aiSummarySignature(for: $0, settings: settings)
         }
         guard pending.isEmpty == false else { return }
 
@@ -609,6 +611,7 @@ struct IssueNavigatorView: View {
     private static func aiSummarySignature(for match: GitHubReferenceMatch, settings: AISummarySettings) -> String {
         [
             settings.model,
+            settings.scope.rawValue,
             match.updatedAt.timeIntervalSinceReferenceDate.description,
             match.title,
             match.bodyPreview ?? "",

--- a/Sources/RepoBarCore/Settings/UserSettings.swift
+++ b/Sources/RepoBarCore/Settings/UserSettings.swift
@@ -299,23 +299,71 @@ public struct GitHubReferenceMonitorSettings: Equatable, Codable, Sendable {
 
 public struct AISummarySettings: Equatable, Codable, Sendable {
     public static let defaultModel = "chat-latest"
+    public static let modelOptions: [AISummaryModelOption] = [
+        AISummaryModelOption(id: "chat-latest", label: "Chat latest"),
+        AISummaryModelOption(id: "gpt-5.5", label: "GPT-5.5"),
+        AISummaryModelOption(id: "gpt-5.4", label: "GPT-5.4"),
+        AISummaryModelOption(id: "gpt-5.4-mini", label: "GPT-5.4 mini")
+    ]
 
     public var enabled = false
     public var model = defaultModel
+    public var scope = AISummaryScope.allItems
 
     public init() {}
+
+    public static func normalizedModel(_ model: String) -> String {
+        let trimmed = model.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.isEmpty == false else { return Self.defaultModel }
+
+        return Self.modelOptions.first { $0.id == trimmed }?.id ?? Self.defaultModel
+    }
 
     enum CodingKeys: String, CodingKey {
         case enabled
         case model
+        case scope
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
         let decodedModel = try container.decodeIfPresent(String.self, forKey: .model) ?? Self.defaultModel
-        let trimmed = decodedModel.trimmingCharacters(in: .whitespacesAndNewlines)
-        self.model = trimmed.isEmpty ? Self.defaultModel : trimmed
+        self.model = Self.normalizedModel(decodedModel)
+        self.scope = try container.decodeIfPresent(AISummaryScope.self, forKey: .scope) ?? (self.enabled ? .pullRequests : .allItems)
+    }
+
+    public func includes(kind: GitHubReferenceKind) -> Bool {
+        switch self.scope {
+        case .pullRequests:
+            kind == .pullRequest
+        case .allItems:
+            true
+        }
+    }
+}
+
+public enum AISummaryScope: String, CaseIterable, Codable, Sendable {
+    case pullRequests = "pull-requests"
+    case allItems = "all-items"
+
+    public var label: String {
+        switch self {
+        case .pullRequests:
+            "Pull requests"
+        case .allItems:
+            "All items"
+        }
+    }
+}
+
+public struct AISummaryModelOption: Equatable, Identifiable, Sendable {
+    public let id: String
+    public let label: String
+
+    public init(id: String, label: String) {
+        self.id = id
+        self.label = label
     }
 }
 

--- a/Sources/RepoBarCore/Support/PullRequestAISummarizer.swift
+++ b/Sources/RepoBarCore/Support/PullRequestAISummarizer.swift
@@ -4,7 +4,7 @@ import Tachikoma
 public struct PullRequestAISummarizer: Sendable {
     static let maximumSummaryCharacters = 280
     private static let systemPrompt = [
-        "You write pull request summaries for a macOS sidebar.",
+        "You write GitHub item summaries for a macOS sidebar.",
         "Return one complete sentence, 24-34 words, no more than 280 characters, ending with punctuation.",
         "Use no markdown and no labels.",
         "Prefer concrete implementation details over generic phrasing."
@@ -16,9 +16,9 @@ public struct PullRequestAISummarizer: Sendable {
         self.keyStore = keyStore
     }
 
-    public func summarize(_ match: GitHubReferenceMatch, settings: AISummarySettings) async throws -> String? {
-        guard settings.enabled, match.kind == .pullRequest else { return nil }
-        guard let key = self.keyStore.resolve().key else { return nil }
+    public func summarize(_ match: GitHubReferenceMatch, settings: AISummarySettings, apiKeyOverride: String? = nil) async throws -> String? {
+        guard settings.enabled, match.isResolved else { return nil }
+        guard let key = Self.resolvedAPIKey(apiKeyOverride: apiKeyOverride, keyStore: self.keyStore) else { return nil }
 
         let model = Self.openAIModel(from: settings.model)
         let configuration = TachikomaConfiguration(loadFromEnvironment: false)
@@ -35,6 +35,30 @@ public struct PullRequestAISummarizer: Sendable {
         return Self.clean(summary)
     }
 
+    public func test(settings: AISummarySettings, apiKeyOverride: String? = nil) async throws -> String {
+        guard let key = Self.resolvedAPIKey(apiKeyOverride: apiKeyOverride, keyStore: self.keyStore) else {
+            throw AISummaryTestError.missingAPIKey
+        }
+
+        let model = Self.openAIModel(from: settings.model)
+        let configuration = TachikomaConfiguration(loadFromEnvironment: false)
+        configuration.setAPIKey(key, for: .openai)
+
+        let rawSummary = try await generate(
+            "Return one short sentence confirming RepoBar AI summaries are ready.",
+            using: model,
+            system: "You test a macOS app AI summary connection. Return one plain sentence, no markdown.",
+            maxTokens: 60,
+            configuration: configuration
+        )
+
+        guard let summary = Self.clean(rawSummary) else {
+            throw AISummaryTestError.missingSummary
+        }
+
+        return summary
+    }
+
     private static func openAIModel(from modelID: String) -> LanguageModel {
         let trimmed = modelID.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmed.isEmpty == false else { return .openai(.chatLatest) }
@@ -46,10 +70,20 @@ public struct PullRequestAISummarizer: Sendable {
         return .openai(.custom(trimmed))
     }
 
+    private static func resolvedAPIKey(apiKeyOverride: String?, keyStore: OpenAIAPIKeyStore) -> String? {
+        let override = apiKeyOverride?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let override, override.isEmpty == false {
+            return override
+        }
+
+        return keyStore.resolve().key
+    }
+
     private static func prompt(for match: GitHubReferenceMatch) -> String {
         var parts = [
             "Repository: \(match.repositoryFullName)",
-            "PR: \(match.query.displayText)",
+            "Kind: \(match.kind.label)",
+            "Item: \(match.query.displayText)",
             "Title: \(match.title)"
         ]
         if let author = match.authorLogin, author.isEmpty == false {
@@ -58,7 +92,7 @@ public struct PullRequestAISummarizer: Sendable {
         if let body = match.bodyPreview, body.isEmpty == false {
             parts.append("Body preview: \(body)")
         }
-        parts.append("Summarize what this pull request changes and why it matters in one sidebar-sized sentence.")
+        parts.append("Summarize what this GitHub item changes, reports, or shows in one sidebar-sized sentence.")
         return parts.joined(separator: "\n")
     }
 
@@ -82,5 +116,19 @@ public struct PullRequestAISummarizer: Sendable {
             }
         }
         return "\(prefix)..."
+    }
+}
+
+enum AISummaryTestError: LocalizedError {
+    case missingAPIKey
+    case missingSummary
+
+    var errorDescription: String? {
+        switch self {
+        case .missingAPIKey:
+            "No OpenAI API key configured."
+        case .missingSummary:
+            "The model did not return a summary."
+        }
     }
 }

--- a/Sources/repobarcli/SettingsSupport.swift
+++ b/Sources/repobarcli/SettingsSupport.swift
@@ -38,6 +38,7 @@ enum SettingsKey: String, CaseIterable {
     case localShowDirtyFiles = "local-show-dirty-files"
     case aiSummaries = "ai-summaries"
     case aiSummaryModel = "ai-summary-model"
+    case aiSummaryScope = "ai-summary-scope"
     case launchAtLogin = "launch-at-login"
 
     init?(argument: String) {
@@ -105,6 +106,8 @@ enum SettingsKey: String, CaseIterable {
             self = .aiSummaries
         case "ai-summary-model", "ai-model", "summary-model":
             self = .aiSummaryModel
+        case "ai-summary-scope", "ai-scope", "summary-scope":
+            self = .aiSummaryScope
         case "launch-at-login":
             self = .launchAtLogin
         default:
@@ -266,9 +269,20 @@ func applySetting(_ key: SettingsKey, value: String, settings: inout UserSetting
         settings.aiSummaries.enabled = flag
         return flag ? "on" : "off"
     case .aiSummaryModel:
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        settings.aiSummaries.model = trimmed.isEmpty ? AISummarySettings.defaultModel : trimmed
+        settings.aiSummaries.model = AISummarySettings.normalizedModel(value)
         return settings.aiSummaries.model
+    case .aiSummaryScope:
+        let scope: AISummaryScope
+        switch value.lowercased() {
+        case "pull-requests", "pullrequests", "prs", "pr":
+            scope = .pullRequests
+        case "all-items", "allitems", "items", "all":
+            scope = .allItems
+        default:
+            throw ValidationError("Invalid ai-summary-scope value: \(value)")
+        }
+        settings.aiSummaries.scope = scope
+        return scope.label
     case .launchAtLogin:
         let flag = try parseBool(value)
         settings.launchAtLogin = flag
@@ -310,6 +324,7 @@ func settingsSummaryLines(settings: UserSettings) -> [String] {
         "Local show dirty files: \(settings.localProjects.showDirtyFilesInMenu ? "on" : "off")",
         "AI summaries: \(settings.aiSummaries.enabled ? "on" : "off")",
         "AI summary model: \(settings.aiSummaries.model)",
+        "AI summary scope: \(settings.aiSummaries.scope.label)",
         "GitHub archives: \(archives.isEmpty ? "-" : archives.map(\.name).joined(separator: ", "))",
         "Archive fallback on rate limit: \(settings.githubArchives.preferArchiveWhenRateLimited ? "on" : "off")",
         "Launch at login: \(settings.launchAtLogin ? "on" : "off")",

--- a/Tests/RepoBarTests/PullRequestAISummarizerTests.swift
+++ b/Tests/RepoBarTests/PullRequestAISummarizerTests.swift
@@ -1,7 +1,41 @@
+import Foundation
 @testable import RepoBarCore
 import Testing
 
 struct PullRequestAISummarizerTests {
+    @Test
+    func `AI summary model options include supported OpenAI ids`() {
+        #expect(AISummarySettings.modelOptions.map(\.id) == ["chat-latest", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini"])
+    }
+
+    @Test
+    func `AI summary model normalization keeps selector values`() {
+        #expect(AISummarySettings.normalizedModel("gpt-5.4-mini") == "gpt-5.4-mini")
+        #expect(AISummarySettings.normalizedModel("gpd-5.5") == AISummarySettings.defaultModel)
+        #expect(AISummarySettings.normalizedModel("") == AISummarySettings.defaultModel)
+    }
+
+    @Test
+    func `legacy enabled AI summary settings stay pull request scoped`() throws {
+        let data = try JSONEncoder().encode(LegacyAISummarySettings(enabled: true, model: "chat-latest"))
+
+        let settings = try JSONDecoder().decode(AISummarySettings.self, from: data)
+
+        #expect(settings.scope == .pullRequests)
+        #expect(settings.includes(kind: .pullRequest))
+        #expect(settings.includes(kind: .issue) == false)
+    }
+
+    @Test
+    func `legacy disabled AI summary settings default to all items for later opt in`() throws {
+        let data = try JSONEncoder().encode(LegacyAISummarySettings(enabled: false, model: "chat-latest"))
+
+        let settings = try JSONDecoder().decode(AISummarySettings.self, from: data)
+
+        #expect(settings.scope == .allItems)
+        #expect(settings.includes(kind: .issue))
+    }
+
     @Test
     func `cleaned summary fits sidebar character budget`() throws {
         let raw = String(repeating: "This summary explains a concrete pull request change with enough detail to overflow the sidebar. ", count: 8)
@@ -18,4 +52,9 @@ struct PullRequestAISummarizerTests {
 
         #expect(summary == "First line. Second line.")
     }
+}
+
+private struct LegacyAISummarySettings: Encodable {
+    let enabled: Bool
+    let model: String
 }

--- a/Tests/repobarcliTests/SettingsCommandTests.swift
+++ b/Tests/repobarcliTests/SettingsCommandTests.swift
@@ -23,6 +23,7 @@ struct SettingsCommandTests {
         #expect(lines.contains("PR notification click: Issue Navigator"))
         #expect(lines.contains("AI summaries: on"))
         #expect(lines.contains("AI summary model: chat-latest"))
+        #expect(lines.contains("AI summary scope: All items"))
     }
 
     @Test
@@ -51,10 +52,29 @@ struct SettingsCommandTests {
         var settings = UserSettings()
 
         #expect(try applySetting(.aiSummaries, value: "on", settings: &settings) == "on")
-        #expect(try applySetting(.aiSummaryModel, value: "chat-latest", settings: &settings) == "chat-latest")
+        #expect(try applySetting(.aiSummaryModel, value: "gpt-5.5", settings: &settings) == "gpt-5.5")
+        #expect(try applySetting(.aiSummaryScope, value: "all-items", settings: &settings) == "All items")
 
         #expect(settings.aiSummaries.enabled)
-        #expect(settings.aiSummaries.model == "chat-latest")
+        #expect(settings.aiSummaries.model == "gpt-5.5")
+        #expect(settings.aiSummaries.scope == .allItems)
+    }
+
+    @Test
+    func `AI summary model setting normalizes unsupported values`() throws {
+        var settings = UserSettings()
+
+        #expect(try applySetting(.aiSummaryModel, value: "custom-model", settings: &settings) == "chat-latest")
+        #expect(settings.aiSummaries.model == AISummarySettings.defaultModel)
+    }
+
+    @Test
+    func `AI summary scope setting rejects unknown values`() {
+        var settings = UserSettings()
+
+        #expect(throws: ValidationError.self) {
+            _ = try applySetting(.aiSummaryScope, value: "everything-private", settings: &settings)
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- summarize resolved Issue Navigator issues, commits, workflow runs, and PRs when AI summary scope is set to All items
- add AI summary model/scope pickers and a live Test button in Advanced settings
- preserve old PR-only AI-summary opt-ins by migrating enabled legacy configs to Pull requests scope

## Proof
- `pnpm check`
- `pnpm restart`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local`
- Peekaboo settings proof: `/tmp/repobar-ai-settings-scope-final.png`
- Peekaboo Issue Navigator proof: `/tmp/repobar-final-allitems-nav.png`
