### PR TITLE
Polish AI summary settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Add optional OpenAI-powered PR summaries to the Issue Navigator sidebar using Tachikoma `chat-latest`, with settings for model and API key storage.
 - Give AI PR summaries more Issue Navigator sidebar room and tune generated summary length to the visible row budget.
-- Summarize all resolved Issue Navigator items with AI, add an AI settings test button, and replace the model text field with a fixed OpenAI model selector.
+- Summarize all resolved Issue Navigator items with AI, add compact settings controls for model selection, API key testing, saving, and clearing.
 - Keep the separate Issue Navigator window from auto-scrolling embedded GitHub issue previews while preserving the menu dropdown preview scroll offset.
 - Keep Issue Navigator reference clicks from being overwritten by clipboard seeding, and show unresolved GitHub metadata as the reference label instead of "preview unavailable."
 - Keep the Repositories settings table from rendering duplicate rows when the same repository is both pinned and hidden (thanks @devYRPauli). (#73)

--- a/Sources/RepoBar/Settings/AdvancedSettingsView.swift
+++ b/Sources/RepoBar/Settings/AdvancedSettingsView.swift
@@ -198,56 +198,54 @@ struct AdvancedSettingsView: View {
                         self.appState.persistSettings()
                     }
 
-                LabeledContent("Model") {
+                HStack {
+                    Text("Model")
+                    Spacer()
                     Picker("", selection: self.aiSummaryModelBinding) {
                         ForEach(AISummarySettings.modelOptions) { option in
                             Text(option.label).tag(option.id)
                         }
                     }
+                    .pickerStyle(.menu)
                     .labelsHidden()
-                    .frame(width: 190)
                 }
 
-                LabeledContent("Scope") {
-                    Picker("", selection: self.$session.settings.aiSummaries.scope) {
-                        ForEach(AISummaryScope.allCases, id: \.self) { scope in
-                            Text(scope.label).tag(scope)
-                        }
+                HStack(spacing: 8) {
+                    Text("OpenAI API key")
+                        .fixedSize()
+                    Spacer(minLength: 12)
+                    SecureField("API key", text: self.$openAIAPIKey)
+                        .frame(width: 240)
+                        .layoutPriority(1)
+                    Button {
+                        self.saveOpenAIAPIKey()
+                    } label: {
+                        Image(systemName: "tray.and.arrow.down")
                     }
-                    .labelsHidden()
-                    .frame(width: 190)
-                    .onChange(of: self.session.settings.aiSummaries.scope) { _, _ in
-                        self.appState.persistSettings()
-                    }
-                }
-
-                LabeledContent("OpenAI API key") {
-                    HStack(spacing: 8) {
-                        SecureField("API key", text: self.$openAIAPIKey)
-                            .frame(width: 190)
-                        Button("Save") {
-                            self.saveOpenAIAPIKey()
-                        }
-                        .disabled(self.openAIAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                        Button("Clear") {
-                            self.clearOpenAIAPIKey()
-                        }
-                    }
-                }
-
-                LabeledContent("Connection") {
+                    .buttonStyle(.borderless)
+                    .disabled(self.openAIAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .help("Save API key")
                     Button {
                         Task { await self.testAISummary() }
                     } label: {
                         if self.isTestingAISummary {
                             ProgressView()
                                 .controlSize(.small)
-                                .frame(width: 38)
+                                .frame(width: 16, height: 16)
                         } else {
-                            Text("Test")
+                            Image(systemName: "play.fill")
                         }
                     }
+                    .buttonStyle(.borderless)
                     .disabled(self.isTestingAISummary)
+                    .help("Test AI summaries")
+                    Button {
+                        self.clearOpenAIAPIKey()
+                    } label: {
+                        Image(systemName: "trash")
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Clear stored API key")
                 }
 
                 Text(self.openAIKeyStatus)

--- a/Sources/RepoBar/Views/IssueNavigatorView.swift
+++ b/Sources/RepoBar/Views/IssueNavigatorView.swift
@@ -563,7 +563,6 @@ struct IssueNavigatorView: View {
 
         let pending = matches.filter {
             $0.isResolved
-                && settings.includes(kind: $0.kind)
                 && self.aiSummariesByURL[$0.url]?.signature != Self.aiSummarySignature(for: $0, settings: settings)
         }
         guard pending.isEmpty == false else { return }
@@ -611,7 +610,6 @@ struct IssueNavigatorView: View {
     private static func aiSummarySignature(for match: GitHubReferenceMatch, settings: AISummarySettings) -> String {
         [
             settings.model,
-            settings.scope.rawValue,
             match.updatedAt.timeIntervalSinceReferenceDate.description,
             match.title,
             match.bodyPreview ?? "",

--- a/Sources/RepoBarCore/Settings/UserSettings.swift
+++ b/Sources/RepoBarCore/Settings/UserSettings.swift
@@ -308,7 +308,6 @@ public struct AISummarySettings: Equatable, Codable, Sendable {
 
     public var enabled = false
     public var model = defaultModel
-    public var scope = AISummaryScope.allItems
 
     public init() {}
 
@@ -322,7 +321,6 @@ public struct AISummarySettings: Equatable, Codable, Sendable {
     enum CodingKeys: String, CodingKey {
         case enabled
         case model
-        case scope
     }
 
     public init(from decoder: Decoder) throws {
@@ -330,30 +328,6 @@ public struct AISummarySettings: Equatable, Codable, Sendable {
         self.enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
         let decodedModel = try container.decodeIfPresent(String.self, forKey: .model) ?? Self.defaultModel
         self.model = Self.normalizedModel(decodedModel)
-        self.scope = try container.decodeIfPresent(AISummaryScope.self, forKey: .scope) ?? (self.enabled ? .pullRequests : .allItems)
-    }
-
-    public func includes(kind: GitHubReferenceKind) -> Bool {
-        switch self.scope {
-        case .pullRequests:
-            kind == .pullRequest
-        case .allItems:
-            true
-        }
-    }
-}
-
-public enum AISummaryScope: String, CaseIterable, Codable, Sendable {
-    case pullRequests = "pull-requests"
-    case allItems = "all-items"
-
-    public var label: String {
-        switch self {
-        case .pullRequests:
-            "Pull requests"
-        case .allItems:
-            "All items"
-        }
     }
 }
 

--- a/Sources/repobarcli/SettingsSupport.swift
+++ b/Sources/repobarcli/SettingsSupport.swift
@@ -38,7 +38,6 @@ enum SettingsKey: String, CaseIterable {
     case localShowDirtyFiles = "local-show-dirty-files"
     case aiSummaries = "ai-summaries"
     case aiSummaryModel = "ai-summary-model"
-    case aiSummaryScope = "ai-summary-scope"
     case launchAtLogin = "launch-at-login"
 
     init?(argument: String) {
@@ -106,8 +105,6 @@ enum SettingsKey: String, CaseIterable {
             self = .aiSummaries
         case "ai-summary-model", "ai-model", "summary-model":
             self = .aiSummaryModel
-        case "ai-summary-scope", "ai-scope", "summary-scope":
-            self = .aiSummaryScope
         case "launch-at-login":
             self = .launchAtLogin
         default:
@@ -271,18 +268,6 @@ func applySetting(_ key: SettingsKey, value: String, settings: inout UserSetting
     case .aiSummaryModel:
         settings.aiSummaries.model = AISummarySettings.normalizedModel(value)
         return settings.aiSummaries.model
-    case .aiSummaryScope:
-        let scope: AISummaryScope
-        switch value.lowercased() {
-        case "pull-requests", "pullrequests", "prs", "pr":
-            scope = .pullRequests
-        case "all-items", "allitems", "items", "all":
-            scope = .allItems
-        default:
-            throw ValidationError("Invalid ai-summary-scope value: \(value)")
-        }
-        settings.aiSummaries.scope = scope
-        return scope.label
     case .launchAtLogin:
         let flag = try parseBool(value)
         settings.launchAtLogin = flag
@@ -324,7 +309,6 @@ func settingsSummaryLines(settings: UserSettings) -> [String] {
         "Local show dirty files: \(settings.localProjects.showDirtyFilesInMenu ? "on" : "off")",
         "AI summaries: \(settings.aiSummaries.enabled ? "on" : "off")",
         "AI summary model: \(settings.aiSummaries.model)",
-        "AI summary scope: \(settings.aiSummaries.scope.label)",
         "GitHub archives: \(archives.isEmpty ? "-" : archives.map(\.name).joined(separator: ", "))",
         "Archive fallback on rate limit: \(settings.githubArchives.preferArchiveWhenRateLimited ? "on" : "off")",
         "Launch at login: \(settings.launchAtLogin ? "on" : "off")",

--- a/Tests/RepoBarTests/PullRequestAISummarizerTests.swift
+++ b/Tests/RepoBarTests/PullRequestAISummarizerTests.swift
@@ -16,24 +16,23 @@ struct PullRequestAISummarizerTests {
     }
 
     @Test
-    func `legacy enabled AI summary settings stay pull request scoped`() throws {
+    func `legacy enabled AI summary settings decode without scope`() throws {
         let data = try JSONEncoder().encode(LegacyAISummarySettings(enabled: true, model: "chat-latest"))
 
         let settings = try JSONDecoder().decode(AISummarySettings.self, from: data)
 
-        #expect(settings.scope == .pullRequests)
-        #expect(settings.includes(kind: .pullRequest))
-        #expect(settings.includes(kind: .issue) == false)
+        #expect(settings.enabled)
+        #expect(settings.model == "chat-latest")
     }
 
     @Test
-    func `legacy disabled AI summary settings default to all items for later opt in`() throws {
+    func `legacy disabled AI summary settings decode without scope`() throws {
         let data = try JSONEncoder().encode(LegacyAISummarySettings(enabled: false, model: "chat-latest"))
 
         let settings = try JSONDecoder().decode(AISummarySettings.self, from: data)
 
-        #expect(settings.scope == .allItems)
-        #expect(settings.includes(kind: .issue))
+        #expect(settings.enabled == false)
+        #expect(settings.model == "chat-latest")
     }
 
     @Test

--- a/Tests/repobarcliTests/SettingsCommandTests.swift
+++ b/Tests/repobarcliTests/SettingsCommandTests.swift
@@ -23,7 +23,6 @@ struct SettingsCommandTests {
         #expect(lines.contains("PR notification click: Issue Navigator"))
         #expect(lines.contains("AI summaries: on"))
         #expect(lines.contains("AI summary model: chat-latest"))
-        #expect(lines.contains("AI summary scope: All items"))
     }
 
     @Test
@@ -53,11 +52,9 @@ struct SettingsCommandTests {
 
         #expect(try applySetting(.aiSummaries, value: "on", settings: &settings) == "on")
         #expect(try applySetting(.aiSummaryModel, value: "gpt-5.5", settings: &settings) == "gpt-5.5")
-        #expect(try applySetting(.aiSummaryScope, value: "all-items", settings: &settings) == "All items")
 
         #expect(settings.aiSummaries.enabled)
         #expect(settings.aiSummaries.model == "gpt-5.5")
-        #expect(settings.aiSummaries.scope == .allItems)
     }
 
     @Test
@@ -66,15 +63,6 @@ struct SettingsCommandTests {
 
         #expect(try applySetting(.aiSummaryModel, value: "custom-model", settings: &settings) == "chat-latest")
         #expect(settings.aiSummaries.model == AISummarySettings.defaultModel)
-    }
-
-    @Test
-    func `AI summary scope setting rejects unknown values`() {
-        var settings = UserSettings()
-
-        #expect(throws: ValidationError.self) {
-            _ = try applySetting(.aiSummaryScope, value: "everything-private", settings: &settings)
-        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- align the AI summary model picker with the other Advanced settings menu pickers
- collapse API key save, test, and clear into one compact row with icon buttons
- remove the AI summary scope setting so summaries always apply to all resolved Issue Navigator items

## Proof
- `pnpm check`
- `pnpm restart`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local`
- Peekaboo layout proof: `/tmp/repobar-ai-settings-visible-final-2.png`
- Peekaboo live test proof: `/tmp/repobar-ai-settings-test-click-final-2.png`
