### PR TITLE
fix: ignore prereleases for latest release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.8.1 - Unreleased
 
+- Fix latest release metadata so stable releases still appear when many newer drafts or prereleases exist (thanks @vincentkoc). (#79)
+
 ## 0.8.0 - 2026-06-07
 
 - Add optional OpenAI-powered PR summaries to the Issue Navigator sidebar using Tachikoma `chat-latest`, with settings for model and API key storage.

--- a/GraphQL/RepoSnapshot.graphql
+++ b/GraphQL/RepoSnapshot.graphql
@@ -1,16 +1,15 @@
 query RepoSnapshot($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
     name
-    releases(first: 20, orderBy: { field: CREATED_AT, direction: DESC }) {
-      nodes {
-        name
-        tagName
-        publishedAt
-        createdAt
-        url
-        isDraft
-        isPrerelease
-      }
+    latestRelease {
+      name
+      tagName
+      publishedAt
+      createdAt
+      url
+      isDraft
+      isPrerelease
+      isLatest
     }
     issues(states: OPEN) { totalCount }
     pullRequests(states: OPEN) { totalCount }

--- a/GraphQL/RepoSnapshot.graphql
+++ b/GraphQL/RepoSnapshot.graphql
@@ -1,12 +1,15 @@
 query RepoSnapshot($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
     name
-    releases(last: 1, orderBy: { field: CREATED_AT, direction: DESC }) {
+    releases(first: 20, orderBy: { field: CREATED_AT, direction: DESC }) {
       nodes {
         name
         tagName
         publishedAt
+        createdAt
         url
+        isDraft
+        isPrerelease
       }
     }
     issues(states: OPEN) { totalCount }

--- a/Scripts/ghql.ts
+++ b/Scripts/ghql.ts
@@ -113,17 +113,16 @@ program
       const { data, rateLimitReset } = await fetchGraphQL<{
         repository: {
           name: string;
-          releases: {
-            nodes?: {
-              name?: string | null;
-              tagName: string;
-              publishedAt?: string | null;
-              createdAt?: string | null;
-              url: string;
-              isDraft: boolean;
-              isPrerelease: boolean;
-            }[];
-          };
+          latestRelease?: {
+            name?: string | null;
+            tagName: string;
+            publishedAt?: string | null;
+            createdAt?: string | null;
+            url: string;
+            isDraft: boolean;
+            isPrerelease: boolean;
+            isLatest: boolean;
+          } | null;
           issues: { totalCount: number };
           pullRequests: { totalCount: number };
         } | null;
@@ -141,13 +140,9 @@ program
 
       const repo = data.repository;
       if (!repo) throw new Error('Repository not found');
-      const release = repo.releases.nodes
-        ?.filter((node) => !node.isDraft && !node.isPrerelease)
-        .sort((lhs, rhs) => {
-          const lhsDate = lhs.publishedAt ?? lhs.createdAt ?? '0001-01-01T00:00:00Z';
-          const rhsDate = rhs.publishedAt ?? rhs.createdAt ?? '0001-01-01T00:00:00Z';
-          return rhsDate.localeCompare(lhsDate);
-        })[0];
+      const release = repo.latestRelease?.isLatest && !repo.latestRelease.isDraft && !repo.latestRelease.isPrerelease
+        ? repo.latestRelease
+        : undefined;
       const releaseLine = release
         ? `${release.name ?? release.tagName} (${new Date(release.publishedAt ?? release.createdAt ?? 0).toLocaleDateString()})`
         : 'none';

--- a/Scripts/ghql.ts
+++ b/Scripts/ghql.ts
@@ -96,7 +96,7 @@ const program = new Command()
 program
   .command('repo')
   .argument('<owner/repo>', 'Repository in owner/name form')
-  .description('Run RepoSnapshot query to fetch issues, PRs, and latest release')
+  .description('Run RepoSnapshot query to fetch issues, PRs, and latest stable release')
   .action(async (slug: string, opts: Record<string, unknown>, cmd: Command) => {
     const spinner = ora('Fetching repo snapshot').start();
     try {
@@ -113,7 +113,17 @@ program
       const { data, rateLimitReset } = await fetchGraphQL<{
         repository: {
           name: string;
-          releases: { nodes?: { name?: string | null; tagName: string; publishedAt: string; url: string }[] };
+          releases: {
+            nodes?: {
+              name?: string | null;
+              tagName: string;
+              publishedAt?: string | null;
+              createdAt?: string | null;
+              url: string;
+              isDraft: boolean;
+              isPrerelease: boolean;
+            }[];
+          };
           issues: { totalCount: number };
           pullRequests: { totalCount: number };
         } | null;
@@ -131,9 +141,15 @@ program
 
       const repo = data.repository;
       if (!repo) throw new Error('Repository not found');
-      const release = repo.releases.nodes?.[0];
+      const release = repo.releases.nodes
+        ?.filter((node) => !node.isDraft && !node.isPrerelease)
+        .sort((lhs, rhs) => {
+          const lhsDate = lhs.publishedAt ?? lhs.createdAt ?? '0001-01-01T00:00:00Z';
+          const rhsDate = rhs.publishedAt ?? rhs.createdAt ?? '0001-01-01T00:00:00Z';
+          return rhsDate.localeCompare(lhsDate);
+        })[0];
       const releaseLine = release
-        ? `${release.name ?? release.tagName} (${new Date(release.publishedAt).toLocaleDateString()})`
+        ? `${release.name ?? release.tagName} (${new Date(release.publishedAt ?? release.createdAt ?? 0).toLocaleDateString()})`
         : 'none';
 
       console.log(
@@ -141,7 +157,7 @@ program
           chalk.bold(`${owner}/${name}`),
           `Issues: ${repo.issues.totalCount}`,
           `PRs: ${repo.pullRequests.totalCount}`,
-          `Latest release: ${releaseLine}`,
+          `Latest stable release: ${releaseLine}`,
         ].join('\n')
       );
       const rl = formatRateLimit(rateLimitReset);

--- a/Sources/RepoBarCore/API/GitHubClient.swift
+++ b/Sources/RepoBarCore/API/GitHubClient.swift
@@ -206,7 +206,7 @@ public actor GitHubClient {
         return Array(commits.prefix(max(limit, 0)))
     }
 
-    /// Latest release (including prereleases). Returns `nil` if the repo has no releases.
+    /// Latest release, excluding drafts and prereleases. Returns `nil` if the repo has no releases.
     public func latestRelease(owner: String, name: String) async throws -> Release? {
         do {
             return try await self.restAPI.latestReleaseAny(owner: owner, name: name)

--- a/Sources/RepoBarCore/API/GitHubReleasePicker.swift
+++ b/Sources/RepoBarCore/API/GitHubReleasePicker.swift
@@ -1,10 +1,10 @@
 import Foundation
 
 enum GitHubReleasePicker {
-    /// Pick the newest non-draft release, preferring publishedAt over createdAt.
+    /// Pick the newest stable release, preferring publishedAt over createdAt.
     static func latestRelease(from responses: [ReleaseResponse]) -> Release? {
         let candidates = responses
-            .filter { $0.draft != true }
+            .filter { $0.draft != true && $0.prerelease != true }
             .sorted {
                 let lhsDate = $0.publishedAt ?? $0.createdAt ?? .distantPast
                 let rhsDate = $1.publishedAt ?? $1.createdAt ?? .distantPast

--- a/Sources/RepoBarCore/API/GitHubRequestRunner.swift
+++ b/Sources/RepoBarCore/API/GitHubRequestRunner.swift
@@ -126,7 +126,7 @@ actor GitHubRequestRunner {
             )
         }
 
-        if useETag, let etag = response.value(forHTTPHeaderField: "ETag") {
+        if useETag, Self.shouldCacheETagResponse(statusCode: status), let etag = response.value(forHTTPHeaderField: "ETag") {
             await self.etagCache.save(url: url, etag: etag, data: data, response: response)
             await self.diag.message("Cached ETag for \(url.lastPathComponent)")
         }
@@ -153,6 +153,10 @@ actor GitHubRequestRunner {
             request.addValue(value, forHTTPHeaderField: header)
         }
         return request
+    }
+
+    static func shouldCacheETagResponse(statusCode: Int) -> Bool {
+        statusCode == 200
     }
 
     private func data(for request: URLRequest, url: URL) async throws -> (Data, URLResponse) {

--- a/Sources/RepoBarCore/API/GitHubRestAPI.swift
+++ b/Sources/RepoBarCore/API/GitHubRestAPI.swift
@@ -630,21 +630,21 @@ struct GitHubRestAPI {
         )
     }
 
-    /// Most recent stable release ordered by creation date; skips drafts and prereleases.
+    /// Most recent stable release ordered by GitHub's latest-release rules; skips drafts and prereleases.
     /// Returns `nil` if the repository has no releases.
     func latestReleaseAny(owner: String, name: String) async throws -> Release? {
         let token = try await tokenProvider()
         let baseURL = await apiHost()
-        var components = URLComponents(
-            url: baseURL.appending(path: "/repos/\(owner)/\(name)/releases"),
-            resolvingAgainstBaseURL: false
-        )!
-        components.queryItems = [URLQueryItem(name: "per_page", value: "20")]
-        let (data, response) = try await authorizedGet(url: components.url!, token: token, allowedStatuses: [200, 304, 404])
+        let url = baseURL.appending(path: "/repos/\(owner)/\(name)/releases/latest")
+        let (data, response) = try await authorizedGet(url: url, token: token, allowedStatuses: [200, 304, 404])
+        return try Self.latestRelease(from: data, response: response)
+    }
+
+    static func latestRelease(from data: Data, response: HTTPURLResponse) throws -> Release? {
         guard response.statusCode != 404 else { return nil }
 
-        let releases = try GitHubDecoding.decode([ReleaseResponse].self, from: data)
-        return GitHubReleasePicker.latestRelease(from: releases)
+        let release = try GitHubDecoding.decode(ReleaseResponse.self, from: data)
+        return GitHubReleasePicker.latestRelease(from: [release])
     }
 
     func recentList<T>(

--- a/Sources/RepoBarCore/API/GitHubRestAPI.swift
+++ b/Sources/RepoBarCore/API/GitHubRestAPI.swift
@@ -630,7 +630,7 @@ struct GitHubRestAPI {
         )
     }
 
-    /// Most recent release (including prereleases) ordered by creation date; skips drafts.
+    /// Most recent stable release ordered by creation date; skips drafts and prereleases.
     /// Returns `nil` if the repository has no releases.
     func latestReleaseAny(owner: String, name: String) async throws -> Release? {
         let token = try await tokenProvider()

--- a/Sources/RepoBarCore/API/GraphQLClient.swift
+++ b/Sources/RepoBarCore/API/GraphQLClient.swift
@@ -46,9 +46,7 @@ actor GraphQLClient {
             query RepoSummary($owner: String!, $name: String!) {
               repository(owner: $owner, name: $name) {
                 name
-                releases(first: 20, orderBy: {field: CREATED_AT, direction: DESC}) {
-                  nodes { name tagName publishedAt createdAt url isDraft isPrerelease }
-                }
+                latestRelease { name tagName publishedAt createdAt url isDraft isPrerelease isLatest }
                 issues(states: OPEN) { totalCount }
                 pullRequests(states: OPEN) { totalCount }
               }
@@ -111,7 +109,7 @@ actor GraphQLClient {
             throw URLError(.cannotParseResponse)
         }
 
-        let release = Self.latestRelease(from: repo.releases.nodes ?? [])
+        let release = Self.latestRelease(from: repo.latestRelease)
 
         return RepoSummary(
             openIssues: repo.issues.totalCount,
@@ -120,15 +118,8 @@ actor GraphQLClient {
         )
     }
 
-    private nonisolated static func latestRelease(from nodes: [ReleaseNode]) -> Release? {
-        let candidates = nodes
-            .filter { !$0.isDraft && !$0.isPrerelease }
-            .sorted {
-                let lhsDate = $0.publishedAt ?? $0.createdAt ?? .distantPast
-                let rhsDate = $1.publishedAt ?? $1.createdAt ?? .distantPast
-                return lhsDate > rhsDate
-            }
-        guard let release = candidates.first else { return nil }
+    private nonisolated static func latestRelease(from release: ReleaseNode?) -> Release? {
+        guard let release, release.isLatest, release.isDraft == false, release.isPrerelease == false else { return nil }
 
         let date = release.publishedAt ?? release.createdAt ?? Date.distantPast
         return Release(name: release.name ?? release.tagName, tag: release.tagName, publishedAt: date, url: release.url)
@@ -307,13 +298,9 @@ private struct RepoSummaryData: Decodable {
 }
 
 private struct RepoSummaryNode: Decodable {
-    let releases: ReleaseConnection
+    let latestRelease: ReleaseNode?
     let issues: CountContainer
     let pullRequests: CountContainer
-}
-
-private struct ReleaseConnection: Decodable {
-    let nodes: [ReleaseNode]?
 }
 
 private struct ReleaseNode: Decodable {
@@ -324,6 +311,7 @@ private struct ReleaseNode: Decodable {
     let url: URL
     let isDraft: Bool
     let isPrerelease: Bool
+    let isLatest: Bool
 }
 
 private struct CountContainer: Decodable {

--- a/Sources/RepoBarCore/API/GraphQLClient.swift
+++ b/Sources/RepoBarCore/API/GraphQLClient.swift
@@ -47,7 +47,7 @@ actor GraphQLClient {
               repository(owner: $owner, name: $name) {
                 name
                 releases(first: 20, orderBy: {field: CREATED_AT, direction: DESC}) {
-                  nodes { name tagName publishedAt createdAt url isDraft }
+                  nodes { name tagName publishedAt createdAt url isDraft isPrerelease }
                 }
                 issues(states: OPEN) { totalCount }
                 pullRequests(states: OPEN) { totalCount }
@@ -122,7 +122,7 @@ actor GraphQLClient {
 
     private nonisolated static func latestRelease(from nodes: [ReleaseNode]) -> Release? {
         let candidates = nodes
-            .filter { !$0.isDraft }
+            .filter { !$0.isDraft && !$0.isPrerelease }
             .sorted {
                 let lhsDate = $0.publishedAt ?? $0.createdAt ?? .distantPast
                 let rhsDate = $1.publishedAt ?? $1.createdAt ?? .distantPast
@@ -323,6 +323,7 @@ private struct ReleaseNode: Decodable {
     let createdAt: Date?
     let url: URL
     let isDraft: Bool
+    let isPrerelease: Bool
 }
 
 private struct CountContainer: Decodable {

--- a/Tests/RepoBarTests/GitHubRequestRunnerTests.swift
+++ b/Tests/RepoBarTests/GitHubRequestRunnerTests.swift
@@ -16,6 +16,13 @@ struct GitHubRequestRunnerTests {
     }
 
     @Test
+    func `etag body cache stores only successful responses`() {
+        #expect(GitHubRequestRunner.shouldCacheETagResponse(statusCode: 200))
+        #expect(GitHubRequestRunner.shouldCacheETagResponse(statusCode: 304) == false)
+        #expect(GitHubRequestRunner.shouldCacheETagResponse(statusCode: 404) == false)
+    }
+
+    @Test
     func `cooldown message names endpoint`() async throws {
         let url = try #require(URL(string: "https://api.github.com/repos/owner/repo/stats/commit_activity"))
         let backoff = BackoffTracker()

--- a/Tests/RepoBarTests/GitHubRestAPITests.swift
+++ b/Tests/RepoBarTests/GitHubRestAPITests.swift
@@ -41,6 +41,68 @@ struct GitHubRestAPITests {
     }
 
     @Test
+    func `latest release endpoint 404 means no stable release`() throws {
+        let url = try #require(URL(string: "https://api.github.com/repos/acme/docs/releases/latest"))
+        let response = try #require(HTTPURLResponse(
+            url: url,
+            statusCode: 404,
+            httpVersion: nil,
+            headerFields: ["ETag": "\"missing-stable\""]
+        ))
+
+        let release = try GitHubRestAPI.latestRelease(from: Data(#"{"message":"Not Found"}"#.utf8), response: response)
+
+        #expect(release == nil)
+    }
+
+    @Test
+    func `latest release endpoint decodes published date`() throws {
+        let url = try #require(URL(string: "https://api.github.com/repos/acme/docs/releases/latest"))
+        let response = try #require(HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil))
+        let data = Data("""
+        {
+          "name": "Stable",
+          "tag_name": "v1.0.0",
+          "published_at": "2026-01-04T12:30:00Z",
+          "created_at": "2026-01-01T00:00:00Z",
+          "draft": false,
+          "prerelease": false,
+          "html_url": "https://github.com/acme/docs/releases/tag/v1.0.0"
+        }
+        """.utf8)
+
+        let decoded = try GitHubRestAPI.latestRelease(from: data, response: response)
+        let release = try #require(decoded)
+        let expected = try iso8601Date("2026-01-04T12:30:00Z")
+
+        #expect(release.tag == "v1.0.0")
+        #expect(release.publishedAt == expected)
+    }
+
+    @Test
+    func `latest release endpoint falls back to created date`() throws {
+        let url = try #require(URL(string: "https://api.github.com/repos/acme/docs/releases/latest"))
+        let response = try #require(HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil))
+        let data = Data("""
+        {
+          "name": "Stable",
+          "tag_name": "v1.0.0",
+          "published_at": null,
+          "created_at": "2026-01-01T00:00:00Z",
+          "draft": false,
+          "prerelease": false,
+          "html_url": "https://github.com/acme/docs/releases/tag/v1.0.0"
+        }
+        """.utf8)
+
+        let decoded = try GitHubRestAPI.latestRelease(from: data, response: response)
+        let release = try #require(decoded)
+        let expected = try iso8601Date("2026-01-01T00:00:00Z")
+
+        #expect(release.publishedAt == expected)
+    }
+
+    @Test
     func `self hosted runner urls request full pages`() throws {
         let baseURL = try #require(URL(string: "https://api.github.com"))
         let orgURL = GitHubRestAPI.selfHostedRunnersURL(baseURL: baseURL, owner: "acme", repo: nil, page: 2)
@@ -149,4 +211,8 @@ struct GitHubRestAPITests {
         #expect(match.kind == .pullRequest)
         #expect(match.state == .merged)
     }
+}
+
+private func iso8601Date(_ raw: String) throws -> Date {
+    try #require(ISO8601DateFormatter().date(from: raw))
 }

--- a/Tests/RepoBarTests/GraphQLRepoSummaryParsingTests.swift
+++ b/Tests/RepoBarTests/GraphQLRepoSummaryParsingTests.swift
@@ -4,11 +4,21 @@ import Testing
 
 struct GraphQLRepoSummaryParsingTests {
     @Test
-    func `repo summary uses newest non draft release`() throws {
+    func `repo summary uses latest stable release field`() throws {
         let data = Data("""
         {
           "data": {
             "repository": {
+              "latestRelease": {
+                "name": "Published Later",
+                "tagName": "v2.0.0",
+                "publishedAt": "2026-01-04T00:00:00Z",
+                "createdAt": "2026-01-01T00:00:00Z",
+                "url": "https://example.com/v2",
+                "isDraft": false,
+                "isPrerelease": false,
+                "isLatest": true
+              },
               "releases": {
                 "nodes": [
                   {
@@ -18,7 +28,8 @@ struct GraphQLRepoSummaryParsingTests {
                     "createdAt": "2026-01-03T00:00:00Z",
                     "url": "https://example.com/v3",
                     "isDraft": true,
-                    "isPrerelease": false
+                    "isPrerelease": false,
+                    "isLatest": false
                   },
                   {
                     "name": "Prerelease",
@@ -27,7 +38,8 @@ struct GraphQLRepoSummaryParsingTests {
                     "createdAt": "2026-01-05T00:00:00Z",
                     "url": "https://example.com/v2-beta",
                     "isDraft": false,
-                    "isPrerelease": true
+                    "isPrerelease": true,
+                    "isLatest": false
                   },
                   {
                     "name": "Created Later",
@@ -36,7 +48,8 @@ struct GraphQLRepoSummaryParsingTests {
                     "createdAt": "2026-01-02T00:00:00Z",
                     "url": "https://example.com/v2-created",
                     "isDraft": false,
-                    "isPrerelease": false
+                    "isPrerelease": false,
+                    "isLatest": false
                   },
                   {
                     "name": "Published Later",
@@ -45,7 +58,8 @@ struct GraphQLRepoSummaryParsingTests {
                     "createdAt": "2026-01-01T00:00:00Z",
                     "url": "https://example.com/v2",
                     "isDraft": false,
-                    "isPrerelease": false
+                    "isPrerelease": false,
+                    "isLatest": true
                   },
                   {
                     "name": "Old",
@@ -54,7 +68,8 @@ struct GraphQLRepoSummaryParsingTests {
                     "createdAt": "2026-01-01T00:00:00Z",
                     "url": "https://example.com/v1",
                     "isDraft": false,
-                    "isPrerelease": false
+                    "isPrerelease": false,
+                    "isLatest": false
                   }
                 ]
               },
@@ -70,5 +85,78 @@ struct GraphQLRepoSummaryParsingTests {
         #expect(summary.openIssues == 4)
         #expect(summary.openPulls == 2)
         #expect(summary.release?.tag == "v2.0.0")
+        let expectedDate = try graphQLSummaryISO8601Date("2026-01-04T00:00:00Z")
+        #expect(summary.release?.publishedAt == expectedDate)
     }
+
+    @Test
+    func `repo summary is not bounded by newer prerelease nodes`() throws {
+        let prereleases = (0 ..< 25)
+            .map { index in
+                """
+                {
+                  "name": "Prerelease \(index)",
+                  "tagName": "v2.0.0-beta.\(index)",
+                  "publishedAt": "2026-02-\(String(format: "%02d", index % 20 + 1))T00:00:00Z",
+                  "createdAt": "2026-02-\(String(format: "%02d", index % 20 + 1))T00:00:00Z",
+                  "url": "https://example.com/v2-beta-\(index)",
+                  "isDraft": false,
+                  "isPrerelease": true,
+                  "isLatest": false
+                }
+                """
+            }
+            .joined(separator: ",")
+
+        let data = Data("""
+        {
+          "data": {
+            "repository": {
+              "latestRelease": {
+                "name": "Stable",
+                "tagName": "v1.0.0",
+                "publishedAt": "2026-01-01T00:00:00Z",
+                "createdAt": "2026-01-01T00:00:00Z",
+                "url": "https://example.com/v1",
+                "isDraft": false,
+                "isPrerelease": false,
+                "isLatest": true
+              },
+              "releases": { "nodes": [\(prereleases)] },
+              "issues": { "totalCount": 4 },
+              "pullRequests": { "totalCount": 2 }
+            }
+          }
+        }
+        """.utf8)
+
+        let summary = try GraphQLClient.decodeRepoSummary(from: data, owner: "owner", name: "repo")
+
+        #expect(summary.release?.tag == "v1.0.0")
+    }
+
+    @Test
+    func `repo summary preserves repositories with no stable release`() throws {
+        let data = Data("""
+        {
+          "data": {
+            "repository": {
+              "latestRelease": null,
+              "issues": { "totalCount": 4 },
+              "pullRequests": { "totalCount": 2 }
+            }
+          }
+        }
+        """.utf8)
+
+        let summary = try GraphQLClient.decodeRepoSummary(from: data, owner: "owner", name: "repo")
+
+        #expect(summary.openIssues == 4)
+        #expect(summary.openPulls == 2)
+        #expect(summary.release == nil)
+    }
+}
+
+private func graphQLSummaryISO8601Date(_ raw: String) throws -> Date {
+    try #require(ISO8601DateFormatter().date(from: raw))
 }

--- a/Tests/RepoBarTests/GraphQLRepoSummaryParsingTests.swift
+++ b/Tests/RepoBarTests/GraphQLRepoSummaryParsingTests.swift
@@ -17,7 +17,17 @@ struct GraphQLRepoSummaryParsingTests {
                     "publishedAt": null,
                     "createdAt": "2026-01-03T00:00:00Z",
                     "url": "https://example.com/v3",
-                    "isDraft": true
+                    "isDraft": true,
+                    "isPrerelease": false
+                  },
+                  {
+                    "name": "Prerelease",
+                    "tagName": "v2.1.0-beta",
+                    "publishedAt": "2026-01-05T00:00:00Z",
+                    "createdAt": "2026-01-05T00:00:00Z",
+                    "url": "https://example.com/v2-beta",
+                    "isDraft": false,
+                    "isPrerelease": true
                   },
                   {
                     "name": "Created Later",
@@ -25,7 +35,8 @@ struct GraphQLRepoSummaryParsingTests {
                     "publishedAt": "2026-01-02T00:00:00Z",
                     "createdAt": "2026-01-02T00:00:00Z",
                     "url": "https://example.com/v2-created",
-                    "isDraft": false
+                    "isDraft": false,
+                    "isPrerelease": false
                   },
                   {
                     "name": "Published Later",
@@ -33,7 +44,8 @@ struct GraphQLRepoSummaryParsingTests {
                     "publishedAt": "2026-01-04T00:00:00Z",
                     "createdAt": "2026-01-01T00:00:00Z",
                     "url": "https://example.com/v2",
-                    "isDraft": false
+                    "isDraft": false,
+                    "isPrerelease": false
                   },
                   {
                     "name": "Old",
@@ -41,7 +53,8 @@ struct GraphQLRepoSummaryParsingTests {
                     "publishedAt": "2026-01-01T00:00:00Z",
                     "createdAt": "2026-01-01T00:00:00Z",
                     "url": "https://example.com/v1",
-                    "isDraft": false
+                    "isDraft": false,
+                    "isPrerelease": false
                   }
                 ]
               },

--- a/Tests/RepoBarTests/ReleaseSelectionTests.swift
+++ b/Tests/RepoBarTests/ReleaseSelectionTests.swift
@@ -77,6 +77,38 @@ struct ReleaseSelectionTests {
     }
 
     @Test
+    func `skips more than twenty newer drafts and prereleases`() throws {
+        var releases = try (0 ..< 24).map { index in
+            try releaseResponse(
+                name: "v2.0.0-beta.\(index)",
+                tagName: "v2.0.0-beta.\(index)",
+                publishedAt: Date(timeIntervalSince1970: 1_701_000_000 + TimeInterval(index)),
+                createdAt: Date(timeIntervalSince1970: 1_700_900_000 + TimeInterval(index)),
+                prerelease: true,
+                url: "https://example.com/2.0.0-beta.\(index)"
+            )
+        }
+        try releases.append(releaseResponse(
+            name: "draft",
+            tagName: "draft",
+            publishedAt: nil,
+            createdAt: Date(timeIntervalSince1970: 1_702_000_000),
+            draft: true,
+            url: "https://example.com/draft"
+        ))
+        try releases.append(releaseResponse(
+            name: "v1.0.0",
+            tagName: "v1.0.0",
+            publishedAt: Date(timeIntervalSince1970: 1_700_100_000),
+            createdAt: Date(timeIntervalSince1970: 1_700_050_000),
+            url: "https://example.com/1.0.0"
+        ))
+
+        let picked = GitHubClient.latestRelease(from: releases)
+        #expect(picked?.tag == "v1.0.0")
+    }
+
+    @Test
     func `returns nil when no releases`() {
         let picked = GitHubClient.latestRelease(from: [])
         #expect(picked == nil)

--- a/Tests/RepoBarTests/ReleaseSelectionTests.swift
+++ b/Tests/RepoBarTests/ReleaseSelectionTests.swift
@@ -53,6 +53,30 @@ struct ReleaseSelectionTests {
     }
 
     @Test
+    func `skips prereleases`() throws {
+        let releases = try [
+            releaseResponse(
+                name: "v1.1.0-beta",
+                tagName: "v1.1.0-beta",
+                publishedAt: Date(timeIntervalSince1970: 1_700_300_000),
+                createdAt: Date(timeIntervalSince1970: 1_700_250_000),
+                prerelease: true,
+                url: "https://example.com/1.1.0-beta"
+            ),
+            releaseResponse(
+                name: "v1.0.0",
+                tagName: "v1.0.0",
+                publishedAt: Date(timeIntervalSince1970: 1_700_100_000),
+                createdAt: Date(timeIntervalSince1970: 1_700_050_000),
+                url: "https://example.com/1.0.0"
+            )
+        ]
+
+        let picked = GitHubClient.latestRelease(from: releases)
+        #expect(picked?.tag == "v1.0.0")
+    }
+
+    @Test
     func `returns nil when no releases`() {
         let picked = GitHubClient.latestRelease(from: [])
         #expect(picked == nil)

--- a/docs/ghql.md
+++ b/docs/ghql.md
@@ -14,7 +14,7 @@ Developer-only CLI to hit GitHub GraphQL quickly without touching the app.
 - Optional overrides: `GITHUB_GRAPHQL` for custom endpoints (e.g. GHE).
 
 ## Commands
-- `pnpm ghql repo <owner/repo>` – runs `GraphQL/RepoSnapshot.graphql`, prints issues/PRs/release.
+- `pnpm ghql repo <owner/repo>` – runs `GraphQL/RepoSnapshot.graphql`, prints issues/PRs/latest stable release.
 - `pnpm ghql contrib <login>` – flattens contribution calendar to day counts (heatmap helper).
 - `pnpm ghql run <file.graphql> --vars '{...}'` – run any query file with JSON vars.
 


### PR DESCRIPTION
## Summary
- Exclude draft and prerelease releases when computing the latest release for REST-backed repository details.
- Fetch and filter `isPrerelease` in the GraphQL repository summary path.
- Update the `ghql repo` snapshot helper and docs so the debug command reports the latest stable release too.

## Why
Repos with newer prereleases, such as openclaw/openclaw, could show a beta release as the latest release date even when the latest stable release was older.

## Validation
- `git diff --check`
- `swift build --target RepoBarCore`
- `swift build --target repobarcli`
- `GITHUB_TOKEN=... npx --yes pnpm@10.33.2 -s ghql repo openclaw/openclaw` prints `Latest stable release: openclaw 2026.6.1` while newer beta releases exist.

## Not Run
- `pnpm check`: local environment lacks `swiftformat`/`swiftlint`.
- `./Scripts/test.sh --filter ReleaseSelectionTests --filter GraphQLRepoSummaryParsingTests`: local Swift test target compilation failed with `no such module Testing`.
- `./Scripts/build.sh`: local app build failed before this change path on `SwiftUI.Entry` macro plugin resolution in `Sources/RepoBar/Support/MenuHighlighting.swift`.
