### PR TITLE
feat: metadata-enhanced repo search and double-click to open in browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,5 +82,3 @@ DerivedData/
 *.swp
 *.swo
 *.idea/
-node_modules/
-node_modules/.pnpm/

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,5 @@ DerivedData/
 *.swp
 *.swo
 *.idea/
+node_modules/
+node_modules/.pnpm/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.8.3 - Unreleased
 
+- Search accessible repositories by description, language, and topics, and open repository rows on the configured GitHub host with a double-click (thanks @udiedrichsen). (#80)
+
 ## 0.8.2 - 2026-06-12
 
 - Streamline the GitHub API submenu by showing sample age once, while moving shared-budget guidance into a dedicated API settings tab.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Each repository has a rich submenu:
 
 Preferences > Repositories is a real repository browser. It searches repositories RepoBar can access and lets you choose what appears in the menu:
 
+- Search matches repository names, descriptions, languages, and topics.
+- Double-click any non-control area of a repository row to open it on the configured GitHub host.
 - `Visible` keeps the repo available through normal sorting and filtering.
 - `Pinned` keeps the repo near the top.
 - `Hidden` removes it from the menu.

--- a/Sources/RepoBar/Settings/RepoAutocompleteWindowView.swift
+++ b/Sources/RepoBar/Settings/RepoAutocompleteWindowView.swift
@@ -270,13 +270,22 @@ private struct RepoAutocompleteRow: View {
                             if self.repo.isFork { Badge(text: "Fork") }
                             if self.repo.isArchived { Badge(text: "Archived") }
                             if self.repo.discussionsEnabled == true { Badge(text: "Discussions") }
+                            if let lang = self.repo.language, !lang.isEmpty { Badge(text: lang) }
                         }
                     }
 
-                    Text(self.subtitleText)
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
+                    if let description = self.repo.description, !description.isEmpty {
+                        Text(description)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    } else {
+                        Text(self.subtitleText)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
                 }
 
                 Spacer()

--- a/Sources/RepoBar/Settings/RepoBrowserRows.swift
+++ b/Sources/RepoBar/Settings/RepoBrowserRows.swift
@@ -6,6 +6,9 @@ struct RepoBrowserRow: Identifiable, Hashable {
     let fullName: String
     let owner: String
     let name: String
+    let description: String?
+    let language: String?
+    let topics: [String]
     let visibility: RepoVisibility
     let isFork: Bool
     let isArchived: Bool
@@ -60,15 +63,19 @@ struct RepoBrowserRow: Identifiable, Hashable {
             .map { String($0).lowercased() }
         guard !terms.isEmpty else { return true }
 
-        let haystack = [
-            self.fullName,
-            self.owner,
-            self.name,
-            self.visibility.label,
-            self.isFork ? "fork" : "",
-            self.isArchived ? "archived" : "",
-            self.isManual ? "manual" : ""
-        ]
+        let haystack = (
+            [
+                self.fullName,
+                self.owner,
+                self.name,
+                self.description ?? "",
+                self.language ?? "",
+                self.visibility.label,
+                self.isFork ? "fork" : "",
+                self.isArchived ? "archived" : "",
+                self.isManual ? "manual" : ""
+            ] + self.topics
+        )
         .joined(separator: " ")
         .lowercased()
         return terms.allSatisfy { haystack.contains($0) }
@@ -100,6 +107,9 @@ enum RepoBrowserRows {
                 fullName: repo.fullName,
                 owner: repo.owner,
                 name: repo.name,
+                description: repo.description,
+                language: repo.language,
+                topics: repo.topics,
                 visibility: visibility,
                 isFork: repo.isFork,
                 isArchived: repo.isArchived,
@@ -169,6 +179,9 @@ enum RepoBrowserRows {
             fullName: trimmed,
             owner: owner,
             name: name,
+            description: nil,
+            language: nil,
+            topics: [],
             visibility: visibility,
             isFork: false,
             isArchived: false,

--- a/Sources/RepoBar/Settings/RepoSettingsView.swift
+++ b/Sources/RepoBar/Settings/RepoSettingsView.swift
@@ -79,10 +79,6 @@ struct RepoSettingsView: View {
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                     }
-                    .help("Double-click to open in GitHub")
-                    .onTapGesture(count: 2) {
-                        self.openInGitHub(fullName: row.fullName)
-                    }
                 }
                 .width(min: 300, ideal: 420, max: .infinity)
 
@@ -126,9 +122,13 @@ struct RepoSettingsView: View {
             .frame(minHeight: 280)
             .onDeleteCommand { self.deleteSelection() }
             .contextMenu(forSelectionType: String.self) { selection in
+                Button("Open in GitHub") { self.openInGitHub(selection: selection) }
+                Divider()
                 Button("Pin") { Task { await self.bulkSet(selection, to: .pinned) } }
                 Button("Hide") { Task { await self.bulkSet(selection, to: .hidden) } }
                 Button("Set Visible") { Task { await self.bulkSet(selection, to: .visible) } }
+            } primaryAction: { selection in
+                self.openInGitHub(selection: selection)
             }
 
             HStack(spacing: 10) {
@@ -183,9 +183,12 @@ struct RepoSettingsView: View {
         RepoWebURLBuilder(host: self.session.settings.githubHost)
     }
 
-    private func openInGitHub(fullName: String) {
-        guard let url = self.webURLBuilder.repoURL(fullName: fullName) else { return }
-        NSWorkspace.shared.open(url)
+    private func openInGitHub(selection: Set<String>) {
+        for row in self.filteredRows where selection.contains(row.id) {
+            guard let url = self.webURLBuilder.repoURL(fullName: row.fullName) else { continue }
+
+            NSWorkspace.shared.open(url)
+        }
     }
 
     private func addNewRepo(_ value: String) {

--- a/Sources/RepoBar/Settings/RepoSettingsView.swift
+++ b/Sources/RepoBar/Settings/RepoSettingsView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import RepoBarCore
 import SwiftUI
 
@@ -77,6 +78,10 @@ struct RepoSettingsView: View {
                         }
                         .font(.caption2)
                         .foregroundStyle(.secondary)
+                    }
+                    .help("Double-click to open in GitHub")
+                    .onTapGesture(count: 2) {
+                        self.openInGitHub(fullName: row.fullName)
                     }
                 }
                 .width(min: 300, ideal: 420, max: .infinity)
@@ -172,6 +177,15 @@ struct RepoSettingsView: View {
             return snapshotRepos
         }
         return self.session.repositories
+    }
+
+    private var webURLBuilder: RepoWebURLBuilder {
+        RepoWebURLBuilder(host: self.session.settings.githubHost)
+    }
+
+    private func openInGitHub(fullName: String) {
+        guard let url = self.webURLBuilder.repoURL(fullName: fullName) else { return }
+        NSWorkspace.shared.open(url)
     }
 
     private func addNewRepo(_ value: String) {

--- a/Sources/RepoBar/Support/RepoWebURLBuilder.swift
+++ b/Sources/RepoBar/Support/RepoWebURLBuilder.swift
@@ -4,8 +4,8 @@ struct RepoWebURLBuilder {
     let host: URL
 
     func repoURL(fullName: String) -> URL? {
-        let parts = fullName.split(separator: "/", maxSplits: 1)
-        guard parts.count == 2 else { return nil }
+        let parts = fullName.split(separator: "/", omittingEmptySubsequences: false)
+        guard parts.count == 2, parts.allSatisfy({ !$0.isEmpty }) else { return nil }
 
         return self.repoPathURL(components: [String(parts[0]), String(parts[1])])
     }

--- a/Sources/RepoBar/Views/AddRepoView.swift
+++ b/Sources/RepoBar/Views/AddRepoView.swift
@@ -27,10 +27,20 @@ struct AddRepoView: View {
                     self.onSelect(repo)
                     self.isPresented = false
                 } label: {
-                    VStack(alignment: .leading) {
-                        Text(repo.fullName).bold()
-                        if let release = repo.latestRelease {
-                            Text("Latest: \(release.name)").font(.caption)
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack(spacing: 6) {
+                            Text(repo.fullName).bold()
+                            if let lang = repo.language, !lang.isEmpty {
+                                Badge(text: lang)
+                            }
+                            if repo.isFork { Badge(text: "Fork") }
+                            if repo.isArchived { Badge(text: "Archived") }
+                        }
+                        if let description = repo.description, !description.isEmpty {
+                            Text(description)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
                         } else {
                             Text("Issues: \(repo.stats.openIssues) • Owner: \(repo.owner)")
                                 .font(.caption)
@@ -71,5 +81,19 @@ struct AddRepoView: View {
         } catch {
             // Ignored; UI stays empty
         }
+    }
+}
+
+private struct Badge: View {
+    let text: String
+
+    var body: some View {
+        Text(self.text)
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Color.primary.opacity(0.06), in: Capsule())
+            .overlay(Capsule().stroke(Color.primary.opacity(0.08), lineWidth: 1))
     }
 }

--- a/Sources/RepoBarCore/API/GitHubRestAPI.swift
+++ b/Sources/RepoBarCore/API/GitHubRestAPI.swift
@@ -12,6 +12,9 @@ struct GitHubRestAPI {
     let diag: DiagnosticsLogger
     let responseDiskCache: HTTPResponseDiskCache?
 
+    /// Accept header that includes the mercy-preview for topics support.
+    static let repoAcceptHeader = "application/vnd.github.mercy-preview+json"
+
     init(
         apiHost: @escaping @Sendable () async -> URL,
         tokenProvider: @escaping @Sendable () async throws -> String,
@@ -40,7 +43,7 @@ struct GitHubRestAPI {
         let baseURL = await apiHost()
         var components = URLComponents(url: baseURL.appending(path: "/user/repos"), resolvingAgainstBaseURL: false)!
         components.queryItems = [URLQueryItem(name: "per_page", value: "\(limit)")] + Self.userReposQueryItems()
-        let (data, _) = try await authorizedGet(url: components.url!, token: token)
+        let (data, _) = try await authorizedGet(url: components.url!, token: token, headers: ["Accept": Self.repoAcceptHeader])
         return try GitHubDecoding.decode([RepoItem].self, from: data)
     }
 
@@ -50,6 +53,7 @@ struct GitHubRestAPI {
             path: "/user/repos",
             queryItems: Self.userReposQueryItems(),
             limit: limit,
+            headers: ["Accept": Self.repoAcceptHeader],
             decode: { try GitHubDecoding.decode([RepoItem].self, from: $0) }
         )
     }
@@ -160,7 +164,7 @@ struct GitHubRestAPI {
             URLQueryItem(name: "q", value: Self.repoSearchQuery(from: trimmed)),
             URLQueryItem(name: "per_page", value: "8")
         ]
-        let (data, _) = try await authorizedGet(url: components.url!, token: token)
+        let (data, _) = try await authorizedGet(url: components.url!, token: token, headers: ["Accept": Self.repoAcceptHeader])
         let decoded = try GitHubDecoding.decode(SearchResponse.self, from: data)
         return decoded.items
     }
@@ -673,6 +677,7 @@ struct GitHubRestAPI {
         path: String,
         queryItems: [URLQueryItem],
         limit: Int?,
+        headers: [String: String] = [:],
         decode: @escaping (Data) throws -> [T]
     ) async throws -> [T] {
         let pageSize = 100 // GitHub maximum.
@@ -688,7 +693,7 @@ struct GitHubRestAPI {
             items.append(URLQueryItem(name: "per_page", value: "\(pageSize)"))
             items.append(URLQueryItem(name: "page", value: "\(page)"))
             components.queryItems = items
-            let (data, _) = try await authorizedGet(url: components.url!, token: token)
+            let (data, _) = try await authorizedGet(url: components.url!, token: token, headers: headers)
             let itemsPage = try decode(data)
             collected.append(contentsOf: itemsPage)
 

--- a/Sources/RepoBarCore/API/GitHubRestAPI.swift
+++ b/Sources/RepoBarCore/API/GitHubRestAPI.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+private let repositoryTopicsAcceptHeader = "application/vnd.github.mercy-preview+json"
+
 struct ActivitySnapshot {
     let events: [ActivityEvent]
     let latest: ActivityEvent?
@@ -11,9 +13,6 @@ struct GitHubRestAPI {
     let requestRunner: GitHubRequestRunner
     let diag: DiagnosticsLogger
     let responseDiskCache: HTTPResponseDiskCache?
-
-    /// Accept header that includes the mercy-preview for topics support.
-    static let repoAcceptHeader = "application/vnd.github.mercy-preview+json"
 
     init(
         apiHost: @escaping @Sendable () async -> URL,
@@ -43,7 +42,7 @@ struct GitHubRestAPI {
         let baseURL = await apiHost()
         var components = URLComponents(url: baseURL.appending(path: "/user/repos"), resolvingAgainstBaseURL: false)!
         components.queryItems = [URLQueryItem(name: "per_page", value: "\(limit)")] + Self.userReposQueryItems()
-        let (data, _) = try await authorizedGet(url: components.url!, token: token, headers: ["Accept": Self.repoAcceptHeader])
+        let (data, _) = try await authorizedGet(url: components.url!, token: token, headers: ["Accept": repositoryTopicsAcceptHeader])
         return try GitHubDecoding.decode([RepoItem].self, from: data)
     }
 
@@ -53,7 +52,7 @@ struct GitHubRestAPI {
             path: "/user/repos",
             queryItems: Self.userReposQueryItems(),
             limit: limit,
-            headers: ["Accept": Self.repoAcceptHeader],
+            headers: ["Accept": repositoryTopicsAcceptHeader],
             decode: { try GitHubDecoding.decode([RepoItem].self, from: $0) }
         )
     }
@@ -164,7 +163,7 @@ struct GitHubRestAPI {
             URLQueryItem(name: "q", value: Self.repoSearchQuery(from: trimmed)),
             URLQueryItem(name: "per_page", value: "8")
         ]
-        let (data, _) = try await authorizedGet(url: components.url!, token: token, headers: ["Accept": Self.repoAcceptHeader])
+        let (data, _) = try await authorizedGet(url: components.url!, token: token, headers: ["Accept": repositoryTopicsAcceptHeader])
         let decoded = try GitHubDecoding.decode(SearchResponse.self, from: data)
         return decoded.items
     }

--- a/Sources/RepoBarCore/API/GitHubSearchModels.swift
+++ b/Sources/RepoBarCore/API/GitHubSearchModels.swift
@@ -8,6 +8,9 @@ struct RepoItem: Decodable {
     let id: Int
     let name: String
     let fullName: String
+    let description: String?
+    let language: String?
+    let topics: [String]?
     let fork: Bool
     let archived: Bool
     let hasDiscussions: Bool?
@@ -21,7 +24,7 @@ struct RepoItem: Decodable {
     struct Owner: Decodable { let login: String }
 
     enum CodingKeys: String, CodingKey {
-        case id, name
+        case id, name, description, language, topics
         case fullName = "full_name"
         case fork
         case archived

--- a/Sources/RepoBarCore/Models/Repository+Factory.swift
+++ b/Sources/RepoBarCore/Models/Repository+Factory.swift
@@ -50,7 +50,6 @@ extension Repository {
     static func placeholder(
         owner: String,
         name: String,
-        description: String? = nil,
         error: String?,
         rateLimitedUntil: Date?
     ) -> Repository {
@@ -58,7 +57,6 @@ extension Repository {
             id: "\(owner)/\(name)",
             name: name,
             owner: owner,
-            description: description,
             sortOrder: nil,
             error: error,
             rateLimitedUntil: rateLimitedUntil,

--- a/Sources/RepoBarCore/Models/Repository+Factory.swift
+++ b/Sources/RepoBarCore/Models/Repository+Factory.swift
@@ -21,6 +21,9 @@ extension Repository {
             id: item.id.description,
             name: item.name,
             owner: item.owner.login,
+            description: item.description,
+            language: item.language,
+            topics: item.topics ?? [],
             isFork: item.fork,
             isArchived: item.archived,
             viewerCanRead: item.permissions?.hasReadAccess ?? true,
@@ -47,6 +50,7 @@ extension Repository {
     static func placeholder(
         owner: String,
         name: String,
+        description: String? = nil,
         error: String?,
         rateLimitedUntil: Date?
     ) -> Repository {
@@ -54,6 +58,7 @@ extension Repository {
             id: "\(owner)/\(name)",
             name: name,
             owner: owner,
+            description: description,
             sortOrder: nil,
             error: error,
             rateLimitedUntil: rateLimitedUntil,

--- a/Sources/RepoBarCore/Models/Repository.swift
+++ b/Sources/RepoBarCore/Models/Repository.swift
@@ -4,6 +4,9 @@ public struct Repository: Identifiable, Equatable, Sendable {
     public let id: String
     public let name: String
     public let owner: String
+    public let description: String?
+    public let language: String?
+    public let topics: [String]
     public let isFork: Bool
     public let isArchived: Bool
     public let viewerCanRead: Bool
@@ -25,6 +28,9 @@ public struct Repository: Identifiable, Equatable, Sendable {
         id: String,
         name: String,
         owner: String,
+        description: String? = nil,
+        language: String? = nil,
+        topics: [String] = [],
         isFork: Bool = false,
         isArchived: Bool = false,
         viewerCanRead: Bool = true,
@@ -49,6 +55,9 @@ public struct Repository: Identifiable, Equatable, Sendable {
         self.id = id
         self.name = name
         self.owner = owner
+        self.description = description
+        self.language = language
+        self.topics = topics
         self.isFork = isFork
         self.isArchived = isArchived
         self.viewerCanRead = viewerCanRead
@@ -82,6 +91,9 @@ public struct Repository: Identifiable, Equatable, Sendable {
             id: self.id,
             name: self.name,
             owner: self.owner,
+            description: self.description,
+            language: self.language,
+            topics: self.topics,
             isFork: self.isFork,
             isArchived: self.isArchived,
             viewerCanRead: self.viewerCanRead,

--- a/Sources/RepoBarCore/Support/RepoAutocompleteScoring.swift
+++ b/Sources/RepoBarCore/Support/RepoAutocompleteScoring.swift
@@ -142,15 +142,20 @@ public enum RepoAutocompleteScoring {
         var best = 0
         for topic in topics {
             let lower = topic.lowercased()
-            if lower == query { best = max(best, 400) }
-            else if lower.hasPrefix(query) { best = max(best, 300) }
-            else if lower.contains(query) { best = max(best, 200) }
+            if lower == query {
+                best = max(best, 400)
+            } else if lower.hasPrefix(query) {
+                best = max(best, 300)
+            } else if lower.contains(query) {
+                best = max(best, 200)
+            }
         }
         return best
     }
 
     private static func languageScore(query: String, language: String?) -> Int {
         guard let language, !language.isEmpty else { return 0 }
+
         let lower = language.lowercased()
         if lower == query { return 150 }
         if lower.hasPrefix(query) { return 100 }
@@ -160,6 +165,7 @@ public enum RepoAutocompleteScoring {
 
     private static func descriptionScore(query: String, description: String?) -> Int {
         guard let description, !description.isEmpty else { return 0 }
+
         let lower = description.lowercased()
         if lower.contains(query) { return 60 }
         if query.count <= 3, Self.isSubsequence(query, of: lower) { return 30 }

--- a/Sources/RepoBarCore/Support/RepoAutocompleteScoring.swift
+++ b/Sources/RepoBarCore/Support/RepoAutocompleteScoring.swift
@@ -96,15 +96,19 @@ public enum RepoAutocompleteScoring {
         )
 
         var score = 0
+        var anyNameOrOwnerMatch = false
+
         if let ownerScore, ownerQuery != nil {
             score += ownerScore
+            anyNameOrOwnerMatch = true
         }
         if let repoScore {
             score += repoScore
+            anyNameOrOwnerMatch = true
         }
 
-        if ownerQuery == nil {
-            if repoScore == nil {
+        if !anyNameOrOwnerMatch {
+            if ownerQuery == nil {
                 let ownerFallback = Self.componentScore(
                     query: lowerQuery,
                     target: repo.owner,
@@ -115,18 +119,51 @@ public enum RepoAutocompleteScoring {
                         subsequence: 30
                     )
                 )
-                guard let ownerFallback else { return nil }
-
-                score += ownerFallback
+                if let ownerFallback {
+                    score += ownerFallback
+                    anyNameOrOwnerMatch = true
+                }
             }
-        } else if ownerScore == nil, repoScore == nil {
-            return nil
         }
 
         if ownerScore != nil, repoScore != nil {
             score += 40
         }
+
+        // Metadata-enhanced scoring: topics, language, description
+        score += Self.topicsScore(query: lowerQuery, topics: repo.topics)
+        score += Self.languageScore(query: lowerQuery, language: repo.language)
+        score += Self.descriptionScore(query: lowerQuery, description: repo.description)
+
         return score == 0 ? nil : score
+    }
+
+    private static func topicsScore(query: String, topics: [String]) -> Int {
+        var best = 0
+        for topic in topics {
+            let lower = topic.lowercased()
+            if lower == query { best = max(best, 400) }
+            else if lower.hasPrefix(query) { best = max(best, 300) }
+            else if lower.contains(query) { best = max(best, 200) }
+        }
+        return best
+    }
+
+    private static func languageScore(query: String, language: String?) -> Int {
+        guard let language, !language.isEmpty else { return 0 }
+        let lower = language.lowercased()
+        if lower == query { return 150 }
+        if lower.hasPrefix(query) { return 100 }
+        if lower.contains(query) { return 60 }
+        return 0
+    }
+
+    private static func descriptionScore(query: String, description: String?) -> Int {
+        guard let description, !description.isEmpty else { return 0 }
+        let lower = description.lowercased()
+        if lower.contains(query) { return 60 }
+        if query.count <= 3, Self.isSubsequence(query, of: lower) { return 30 }
+        return 0
     }
 
     private static func componentScore(

--- a/Tests/RepoBarTests/RepoAutocompleteScoringTests.swift
+++ b/Tests/RepoBarTests/RepoAutocompleteScoringTests.swift
@@ -53,35 +53,35 @@ struct RepoAutocompleteScoringTests {
     }
 
     @Test
-    func `topic exact match boosts score`() {
+    func `topic exact match boosts score`() throws {
         let repo = Self.repo(owner: "swiftlang", name: "indexstore-db", topics: ["swift"])
 
         let score = RepoAutocompleteScoring.score(repo: repo, query: "swift")
         // Should match via topic "swift" even though neither owner nor name contain "swift"
         #expect(score != nil)
-        #expect(score! >= 400, "Topic exact match should contribute at least 400")
+        #expect(try #require(score) >= 400, "Topic exact match should contribute at least 400")
     }
 
     @Test
-    func `topic prefix match works`() {
+    func `topic prefix match works`() throws {
         let repo = Self.repo(owner: "apple", name: "some-tool", topics: ["machine-learning"])
 
         let score = RepoAutocompleteScoring.score(repo: repo, query: "machine")
         #expect(score != nil)
-        #expect(score! >= 300, "Topic prefix match should contribute at least 300")
+        #expect(try #require(score) >= 300, "Topic prefix match should contribute at least 300")
     }
 
     @Test
-    func `language exact match works`() {
+    func `language exact match works`() throws {
         let repo = Self.repo(owner: "openclaw", name: "clawbook", language: "Ruby")
 
         let score = RepoAutocompleteScoring.score(repo: repo, query: "ruby")
         #expect(score != nil)
-        #expect(score! >= 150, "Language exact match should contribute at least 150")
+        #expect(try #require(score) >= 150, "Language exact match should contribute at least 150")
     }
 
     @Test
-    func `description substring match works`() {
+    func `description substring match works`() throws {
         let repo = Self.repo(
             owner: "someorg",
             name: "cool-tool",
@@ -90,7 +90,7 @@ struct RepoAutocompleteScoringTests {
 
         let score = RepoAutocompleteScoring.score(repo: repo, query: "declarative")
         #expect(score != nil)
-        #expect(score! >= 60, "Description substring should contribute at least 60")
+        #expect(try #require(score) >= 60, "Description substring should contribute at least 60")
     }
 
     @Test

--- a/Tests/RepoBarTests/RepoAutocompleteScoringTests.swift
+++ b/Tests/RepoBarTests/RepoAutocompleteScoringTests.swift
@@ -51,14 +51,81 @@ struct RepoAutocompleteScoringTests {
         let sorted = RepoAutocompleteScoring.sort(scored)
         #expect(sorted.first?.repo.fullName == "steipete/repo")
     }
+
+    @Test
+    func `topic exact match boosts score`() {
+        let repo = Self.repo(owner: "swiftlang", name: "indexstore-db", topics: ["swift"])
+
+        let score = RepoAutocompleteScoring.score(repo: repo, query: "swift")
+        // Should match via topic "swift" even though neither owner nor name contain "swift"
+        #expect(score != nil)
+        #expect(score! >= 400, "Topic exact match should contribute at least 400")
+    }
+
+    @Test
+    func `topic prefix match works`() {
+        let repo = Self.repo(owner: "apple", name: "some-tool", topics: ["machine-learning"])
+
+        let score = RepoAutocompleteScoring.score(repo: repo, query: "machine")
+        #expect(score != nil)
+        #expect(score! >= 300, "Topic prefix match should contribute at least 300")
+    }
+
+    @Test
+    func `language exact match works`() {
+        let repo = Self.repo(owner: "openclaw", name: "clawbook", language: "Ruby")
+
+        let score = RepoAutocompleteScoring.score(repo: repo, query: "ruby")
+        #expect(score != nil)
+        #expect(score! >= 150, "Language exact match should contribute at least 150")
+    }
+
+    @Test
+    func `description substring match works`() {
+        let repo = Self.repo(
+            owner: "someorg",
+            name: "cool-tool",
+            description: "A declarative UI framework for building iOS apps"
+        )
+
+        let score = RepoAutocompleteScoring.score(repo: repo, query: "declarative")
+        #expect(score != nil)
+        #expect(score! >= 60, "Description substring should contribute at least 60")
+    }
+
+    @Test
+    func `metadata match shows repo when name doesnt match`() {
+        let repo = Self.repo(owner: "someone", name: "unrelated", description: "iOS utility library", language: "Swift", topics: ["swift"])
+
+        // Query "swift" matches topic "swift" — repo should appear even though name is "unrelated"
+        let scored = RepoAutocompleteScoring.scored(repos: [repo], query: "swift", sourceRank: 0)
+        #expect(scored.isEmpty == false)
+        #expect(scored.first?.repo.fullName == "someone/unrelated")
+    }
+
+    @Test
+    func `no match returns nil with metadata fields`() {
+        let repo = Self.repo(owner: "me", name: "alpha", description: "some project", language: "Swift", topics: ["ios"])
+
+        #expect(RepoAutocompleteScoring.score(repo: repo, query: "zzzzz") == nil)
+    }
 }
 
 private extension RepoAutocompleteScoringTests {
-    static func repo(owner: String, name: String) -> Repository {
+    static func repo(
+        owner: String,
+        name: String,
+        description: String? = nil,
+        language: String? = nil,
+        topics: [String] = []
+    ) -> Repository {
         Repository(
             id: UUID().uuidString,
             name: name,
             owner: owner,
+            description: description,
+            language: language,
+            topics: topics,
             sortOrder: nil,
             error: nil,
             rateLimitedUntil: nil,

--- a/Tests/RepoBarTests/RepoBrowserRowsTests.swift
+++ b/Tests/RepoBarTests/RepoBrowserRowsTests.swift
@@ -130,11 +130,37 @@ struct RepoBrowserRowsTests {
         #expect(row?.matches("amantus sweetis") == true)
         #expect(row?.matches("steipete") == false)
     }
+
+    @Test
+    func `matches repository metadata`() throws {
+        let row = try #require(RepoBrowserRows.make(
+            repositories: [
+                Self.makeRepo(
+                    "example/utility",
+                    description: "Desktop notifications for release automation",
+                    language: "Swift",
+                    topics: ["macos", "developer-tools"]
+                )
+            ],
+            pinnedRepositories: [],
+            hiddenRepositories: [],
+            now: Date(timeIntervalSinceReferenceDate: 1000)
+        ).first)
+
+        #expect(row.matches("notifications") == true)
+        #expect(row.matches("swift") == true)
+        #expect(row.matches("developer-tools") == true)
+        #expect(row.matches("swift macos") == true)
+        #expect(row.matches("kotlin") == false)
+    }
 }
 
 private extension RepoBrowserRowsTests {
     static func makeRepo(
         _ fullName: String,
+        description: String? = nil,
+        language: String? = nil,
+        topics: [String] = [],
         issues: Int = 0,
         pulls: Int = 0,
         stars: Int = 0
@@ -144,6 +170,9 @@ private extension RepoBrowserRowsTests {
             id: fullName,
             name: parts[1],
             owner: parts[0],
+            description: description,
+            language: language,
+            topics: topics,
             sortOrder: nil,
             error: nil,
             rateLimitedUntil: nil,

--- a/Tests/RepoBarTests/RepoWebURLBuilderTests.swift
+++ b/Tests/RepoBarTests/RepoWebURLBuilderTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+@testable import RepoBar
+import Testing
+
+struct RepoWebURLBuilderTests {
+    @Test
+    func `repo URL uses configured GitHub host`() throws {
+        let host = try #require(URL(string: "https://github.example.com"))
+        let builder = RepoWebURLBuilder(host: host)
+
+        #expect(builder.repoURL(fullName: "acme/widget")?.absoluteString == "https://github.example.com/acme/widget")
+    }
+
+    @Test
+    func `repo URL rejects malformed repository names`() throws {
+        let host = try #require(URL(string: "https://github.com"))
+        let builder = RepoWebURLBuilder(host: host)
+
+        #expect(builder.repoURL(fullName: "widget") == nil)
+        #expect(builder.repoURL(fullName: "acme/widget/extra") == nil)
+    }
+}

--- a/Tests/RepoBarTests/RepositoryFactoryTests.swift
+++ b/Tests/RepoBarTests/RepositoryFactoryTests.swift
@@ -10,6 +10,9 @@ struct RepositoryFactoryTests {
           "id": 42,
           "name": "RepoBar",
           "full_name": "steipete/RepoBar",
+          "description": "A macOS GitHub menu bar app",
+          "language": "Swift",
+          "topics": ["macos", "github"],
           "fork": true,
           "archived": true,
           "open_issues_count": 7,
@@ -44,6 +47,9 @@ struct RepositoryFactoryTests {
         #expect(repo.id == "42")
         #expect(repo.name == "RepoBar")
         #expect(repo.owner == "steipete")
+        #expect(repo.description == "A macOS GitHub menu bar app")
+        #expect(repo.language == "Swift")
+        #expect(repo.topics == ["macos", "github"])
         #expect(repo.isFork == true)
         #expect(repo.isArchived == true)
         #expect(repo.viewerCanRead == true)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -87,7 +87,7 @@ _Last updated: 2025-11-24_
 
 ## Repo Selection
 - Default view: last 5 active repos (recent pushes/issues/PRs) for the authenticated user (across orgs user can access).
-- Settings > Repositories: searchable browser of repositories the authenticated account can access. The browser shows visibility state per repo and lets the user switch each repo between Visible, Pinned, and Hidden.
+- Settings > Repositories: searchable browser of repositories the authenticated account can access. Search includes repository names, descriptions, languages, and topics. Double-clicking a row opens the repository on the configured GitHub host, while the browser shows visibility state per repo and lets the user switch each repo between Visible, Pinned, and Hidden.
 - Pinning: stored per account. Unpin via card overflow menu or set the repo back to Visible in Settings.
 - Display limit configurable in Settings.
 


### PR DESCRIPTION
## Summary

Enhances repository discovery in Settings with metadata-aware search and consistent browser opening.

## Changes

- Fetches and stores repository description, primary language, and topics.
- Uses metadata for repository autocomplete scoring and Settings table filtering.
- Shows language and description details in repository suggestions.
- Opens a repository through the configured GitHub or GitHub Enterprise host when the table primary action is invoked from any non-control row cell.
- Keeps the Visibility control independently interactive.
- Adds focused metadata filtering, mapping, scoring, and URL validation coverage.
- Updates repository browser documentation and credits @udiedrichsen in the changelog.

## Verification

- `pnpm check` (SwiftFormat, SwiftLint, 607 tests across 102 suites)
- `pnpm build`
- `pnpm restart`
- Exact packaged app: searching `swift` returned metadata matches including `openclaw/Peekaboo`, whose repository name does not contain the query.
- Double-clicking the Stars cell opened `https://github.com/openclaw/Peekaboo` in the existing browser profile.
- The Visibility menu remained independently interactive.
- Structured autoreview: no actionable findings.
- Public Model Identifier Gate: PASS.

## Risk

Low. The change extends existing REST models and search paths, uses the existing host-aware URL builder, and adds regression coverage around the new behavior.
