### PR TITLE
feat: add opt-in release notifications for pinned repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.8.3 - Unreleased
 
+- Add opt-in release notifications for pinned repositories that post a notification when a repository publishes a new release, with a separate toggle to include pre-releases (off by default). The first refresh records existing releases without notifying. (#82)
+
 ## 0.8.2 - 2026-06-12
 
 - Streamline the GitHub API submenu by showing sample age once, while moving shared-budget guidance into a dedicated API settings tab.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.8.3 - Unreleased
 
-- Add opt-in release notifications for pinned repositories that post a notification when a repository publishes a new release, with a separate toggle to include pre-releases (off by default). The first refresh records existing releases without notifying. (#82)
+- Add opt-in release notifications for pinned repositories, including an optional pre-release toggle, first-refresh backlog protection, and rate-conscious polling at most every 15 minutes (thanks @LeoLin990405). (#82)
 
 ## 0.8.2 - 2026-06-12
 

--- a/Sources/RepoBar/App/AppState+GitHubNotifications.swift
+++ b/Sources/RepoBar/App/AppState+GitHubNotifications.swift
@@ -13,4 +13,17 @@ extension AppState {
     func resetGitHubPullRequestNotificationSnapshots() {
         self.gitHubPullRequestNotificationRunner.resetSnapshots()
     }
+
+    func processGitHubReleaseNotifications() async {
+        await self.gitHubReleaseNotificationRunner.process(
+            settings: self.session.settings.gitHubReleaseNotifications,
+            pinnedRepositories: self.session.settings.repoList.pinnedRepositories,
+            github: self.github,
+            concurrencyLimit: self.hydrateConcurrencyLimit
+        )
+    }
+
+    func resetGitHubReleaseNotificationSnapshots() {
+        self.gitHubReleaseNotificationRunner.resetSnapshots()
+    }
 }

--- a/Sources/RepoBar/App/AppState+Refresh.swift
+++ b/Sources/RepoBar/App/AppState+Refresh.swift
@@ -65,6 +65,7 @@ extension AppState {
                 }
             }
             await self.processGitHubPullRequestNotifications()
+            await self.processGitHubReleaseNotifications()
             let repos = try await self.fetchActivityRepos()
             try Task.checkCancellation()
             await self.updateAccessibleRepositories(repos)

--- a/Sources/RepoBar/App/AppState.swift
+++ b/Sources/RepoBar/App/AppState.swift
@@ -17,6 +17,7 @@ final class AppState {
     let refreshScheduler = RefreshScheduler()
     let settingsStore = SettingsStore()
     let gitHubPullRequestNotificationRunner = GitHubPullRequestNotificationRunner()
+    let gitHubReleaseNotificationRunner = GitHubReleaseNotificationRunner()
     let localRepoManager = LocalRepoManager()
     let menuRefreshInterval: TimeInterval = 30
     var refreshTask: Task<Void, Never>?

--- a/Sources/RepoBar/Settings/NotificationSettingsView.swift
+++ b/Sources/RepoBar/Settings/NotificationSettingsView.swift
@@ -50,6 +50,26 @@ struct NotificationSettingsView: View {
             } footer: {
                 Text("Scoped to pinned repositories. The first refresh records the current state without sending notifications.")
             }
+
+            Section {
+                Toggle("Release notifications", isOn: self.$session.settings.gitHubReleaseNotifications.enabled)
+                    .onChange(of: self.session.settings.gitHubReleaseNotifications.enabled) { _, enabled in
+                        if enabled {
+                            self.appState.resetGitHubReleaseNotificationSnapshots()
+                            self.appState.requestRefresh(cancelInFlight: true)
+                        }
+                        self.appState.persistSettings()
+                    }
+
+                if self.session.settings.gitHubReleaseNotifications.enabled {
+                    Toggle("Include pre-releases", isOn: self.$session.settings.gitHubReleaseNotifications.includePrereleases)
+                        .onChange(of: self.session.settings.gitHubReleaseNotifications.includePrereleases) { _, _ in
+                            self.appState.persistSettings()
+                        }
+                }
+            } footer: {
+                Text("Notifies when a pinned repository publishes a new release.")
+            }
         }
         .formStyle(.grouped)
         .padding()

--- a/Sources/RepoBar/Settings/NotificationSettingsView.swift
+++ b/Sources/RepoBar/Settings/NotificationSettingsView.swift
@@ -68,7 +68,7 @@ struct NotificationSettingsView: View {
                         }
                 }
             } footer: {
-                Text("Notifies when a pinned repository publishes a new release.")
+                Text("Notifies when a pinned repository publishes a new release. Checks at most every 15 minutes and uses GitHub's conditional request cache.")
             }
         }
         .formStyle(.grouped)

--- a/Sources/RepoBar/Support/GitHubReleaseNotificationRunner.swift
+++ b/Sources/RepoBar/Support/GitHubReleaseNotificationRunner.swift
@@ -4,6 +4,8 @@ import RepoBarCore
 
 @MainActor
 final class GitHubReleaseNotificationRunner {
+    private static let minimumPollInterval: TimeInterval = 15 * 60
+
     private let snapshotStore: GitHubReleaseNotificationSnapshotStore
     private let logger = RepoBarLogging.logger("GitHubNotifications")
 
@@ -26,13 +28,22 @@ final class GitHubReleaseNotificationRunner {
         }
 
         let refreshStartedAt = Date()
+        let previousState = self.snapshotStore.load()
+        guard GitHubReleaseNotificationDetector.shouldPoll(
+            previousState: previousState,
+            now: refreshStartedAt,
+            minimumInterval: Self.minimumPollInterval
+        ) else {
+            self.logger.debug("Skipping GitHub release notification refresh; last poll is still fresh")
+            return
+        }
+
         let releasesByRepository = await self.fetchPinnedReleases(
             for: pinnedRepositories,
             github: github,
             concurrencyLimit: concurrencyLimit
         )
 
-        let previousState = self.snapshotStore.load()
         let result = GitHubReleaseNotificationDetector.events(
             for: releasesByRepository,
             previousState: previousState,
@@ -40,7 +51,9 @@ final class GitHubReleaseNotificationRunner {
             trackedRepositoryFullNames: pinnedRepositories,
             observedAt: refreshStartedAt
         )
-        self.snapshotStore.save(result.state)
+        var nextState = result.state
+        nextState.lastCheckedAt = refreshStartedAt
+        self.snapshotStore.save(nextState)
 
         self.logger.debug(
             "GitHub release notification refresh: repos=\(releasesByRepository.count), previousRepos=\(previousState.repositories.count), events=\(result.events.count)"

--- a/Sources/RepoBar/Support/GitHubReleaseNotificationRunner.swift
+++ b/Sources/RepoBar/Support/GitHubReleaseNotificationRunner.swift
@@ -1,0 +1,141 @@
+import Algorithms
+import Foundation
+import RepoBarCore
+
+@MainActor
+final class GitHubReleaseNotificationRunner {
+    private let snapshotStore: GitHubReleaseNotificationSnapshotStore
+    private let logger = RepoBarLogging.logger("GitHubNotifications")
+
+    init(snapshotStore: GitHubReleaseNotificationSnapshotStore = GitHubReleaseNotificationSnapshotStore()) {
+        self.snapshotStore = snapshotStore
+    }
+
+    func process(
+        settings: GitHubReleaseNotificationSettings,
+        pinnedRepositories: [String],
+        github: GitHubClient,
+        concurrencyLimit: Int
+    ) async {
+        guard settings.enabled else { return }
+
+        let pinnedRepositories = Self.uniqueRepositoryFullNames(pinnedRepositories)
+        guard pinnedRepositories.isEmpty == false else {
+            self.snapshotStore.save(GitHubReleaseNotificationSnapshotState())
+            return
+        }
+
+        let refreshStartedAt = Date()
+        let releasesByRepository = await self.fetchPinnedReleases(
+            for: pinnedRepositories,
+            github: github,
+            concurrencyLimit: concurrencyLimit
+        )
+
+        let previousState = self.snapshotStore.load()
+        let result = GitHubReleaseNotificationDetector.events(
+            for: releasesByRepository,
+            previousState: previousState,
+            settings: settings,
+            trackedRepositoryFullNames: pinnedRepositories,
+            observedAt: refreshStartedAt
+        )
+        self.snapshotStore.save(result.state)
+
+        self.logger.debug(
+            "GitHub release notification refresh: repos=\(releasesByRepository.count), previousRepos=\(previousState.repositories.count), events=\(result.events.count)"
+        )
+        if result.events.isEmpty == false {
+            self.logger.info("GitHub release notification events detected: \(result.events.count)")
+        }
+
+        for event in result.events {
+            await RepoBarNotifier.shared.notify(Self.notification(for: event))
+        }
+    }
+
+    func resetSnapshots() {
+        self.snapshotStore.clear()
+    }
+
+    private func fetchPinnedReleases(
+        for fullNames: [String],
+        github: GitHubClient,
+        concurrencyLimit: Int
+    ) async -> [String: [RepoReleaseSummary]] {
+        var result: [String: [RepoReleaseSummary]] = [:]
+        for chunk in fullNames.chunks(ofCount: max(1, concurrencyLimit)) {
+            await withTaskGroup(of: (String, [RepoReleaseSummary])?.self) { group in
+                for fullName in chunk {
+                    guard let parts = Self.repositoryParts(from: fullName) else { continue }
+
+                    group.addTask {
+                        do {
+                            let releases = try await github.recentReleases(
+                                owner: parts.owner,
+                                name: parts.name,
+                                limit: 20
+                            )
+                            return (fullName, releases)
+                        } catch {
+                            return nil
+                        }
+                    }
+                }
+
+                for await entry in group {
+                    guard let (fullName, releases) = entry else { continue }
+
+                    result[fullName] = releases
+                }
+            }
+        }
+
+        return result
+    }
+
+    private static func notification(for event: GitHubReleaseNotificationEvent) -> RepoBarNotification {
+        RepoBarNotification(
+            identifier: event.id,
+            title: self.notificationTitle(for: event),
+            body: self.notificationBody(for: event),
+            url: event.url,
+            clickAction: .openInBrowser
+        )
+    }
+
+    private static func notificationTitle(for event: GitHubReleaseNotificationEvent) -> String {
+        event.isPrerelease
+            ? "New pre-release in \(event.repositoryFullName)"
+            : "New release in \(event.repositoryFullName)"
+    }
+
+    private static func notificationBody(for event: GitHubReleaseNotificationEvent) -> String {
+        let trimmedName = event.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmedName.isEmpty == false, trimmedName != event.tag else {
+            return event.tag
+        }
+
+        return "\(trimmedName) (\(event.tag))"
+    }
+
+    private nonisolated static func uniqueRepositoryFullNames(_ fullNames: [String]) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        for fullName in fullNames {
+            let trimmed = fullName.trimmingCharacters(in: .whitespacesAndNewlines)
+            let key = trimmed.lowercased()
+            guard trimmed.isEmpty == false, seen.insert(key).inserted else { continue }
+
+            result.append(trimmed)
+        }
+        return result
+    }
+
+    private nonisolated static func repositoryParts(from fullName: String) -> (owner: String, name: String)? {
+        let parts = fullName.split(separator: "/", maxSplits: 1).map(String.init)
+        guard parts.count == 2, parts[0].isEmpty == false, parts[1].isEmpty == false else { return nil }
+
+        return (parts[0], parts[1])
+    }
+}

--- a/Sources/RepoBarCore/Notifications/GitHubReleaseNotificationDetector.swift
+++ b/Sources/RepoBarCore/Notifications/GitHubReleaseNotificationDetector.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+public struct GitHubReleaseNotificationEvent: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let repositoryFullName: String
+    public let tag: String
+    public let name: String
+    public let url: URL
+    public let isPrerelease: Bool
+
+    public init(
+        id: String,
+        repositoryFullName: String,
+        tag: String,
+        name: String,
+        url: URL,
+        isPrerelease: Bool
+    ) {
+        self.id = id
+        self.repositoryFullName = repositoryFullName
+        self.tag = tag
+        self.name = name
+        self.url = url
+        self.isPrerelease = isPrerelease
+    }
+}
+
+public struct GitHubReleaseNotificationSnapshotState: Equatable, Codable, Sendable {
+    public var repositories: [String: [String: Date]]
+    public var repositoryBaselines: [String: Date]
+
+    public init(
+        repositories: [String: [String: Date]] = [:],
+        repositoryBaselines: [String: Date] = [:]
+    ) {
+        self.repositories = repositories
+        self.repositoryBaselines = repositoryBaselines
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case repositories
+        case repositoryBaselines
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.repositories = try container.decodeIfPresent([String: [String: Date]].self, forKey: .repositories) ?? [:]
+        self.repositoryBaselines = try container.decodeIfPresent([String: Date].self, forKey: .repositoryBaselines) ?? [:]
+    }
+}
+
+public enum GitHubReleaseNotificationDetector {
+    public static func events(
+        for currentReleases: [String: [RepoReleaseSummary]],
+        previousState: GitHubReleaseNotificationSnapshotState,
+        settings: GitHubReleaseNotificationSettings,
+        trackedRepositoryFullNames: [String]? = nil,
+        observedAt: Date = Date()
+    ) -> (events: [GitHubReleaseNotificationEvent], state: GitHubReleaseNotificationSnapshotState) {
+        guard settings.enabled else {
+            return ([], previousState)
+        }
+
+        let trackedRepositoryKeys = Set((trackedRepositoryFullNames ?? Array(currentReleases.keys)).map(Self.repositoryKey))
+        let previousRepositories = previousState.repositories.filter { trackedRepositoryKeys.contains($0.key) }
+        let previousBaselines = previousState.repositoryBaselines.filter { trackedRepositoryKeys.contains($0.key) }
+        var nextState = GitHubReleaseNotificationSnapshotState(
+            repositories: previousRepositories,
+            repositoryBaselines: previousBaselines
+        )
+        var events: [GitHubReleaseNotificationEvent] = []
+
+        for (repositoryFullName, releases) in currentReleases {
+            let repositoryKey = Self.repositoryKey(repositoryFullName)
+            guard trackedRepositoryKeys.contains(repositoryKey) else { continue }
+
+            let previousReleases = previousRepositories[repositoryKey]
+            let previousBaseline = previousBaselines[repositoryKey]
+                ?? previousReleases?.values.max()
+            nextState.repositories[repositoryKey] = Dictionary(
+                releases.map { ($0.tag, $0.publishedAt) },
+                uniquingKeysWith: { first, _ in first }
+            )
+            nextState.repositoryBaselines[repositoryKey] = max(previousBaseline ?? observedAt, observedAt)
+
+            guard let previousReleases else {
+                continue
+            }
+
+            for release in releases {
+                guard previousReleases[release.tag] == nil else { continue }
+
+                if release.isPrerelease, settings.includePrereleases == false { continue }
+
+                let isNewAfterBaseline = previousBaseline.map { release.publishedAt > $0 } ?? false
+                guard isNewAfterBaseline else { continue }
+
+                events.append(Self.event(repositoryFullName: repositoryFullName, release: release))
+            }
+        }
+
+        return (events, nextState)
+    }
+
+    private static func event(
+        repositoryFullName: String,
+        release: RepoReleaseSummary
+    ) -> GitHubReleaseNotificationEvent {
+        let id = [
+            "github-release",
+            Self.repositoryKey(repositoryFullName).replacingOccurrences(of: "/", with: "-"),
+            Self.tagMarker(release.tag),
+            Self.dateMarker(release.publishedAt)
+        ].joined(separator: "-")
+
+        return GitHubReleaseNotificationEvent(
+            id: id,
+            repositoryFullName: repositoryFullName,
+            tag: release.tag,
+            name: release.name,
+            url: release.url,
+            isPrerelease: release.isPrerelease
+        )
+    }
+
+    private static func repositoryKey(_ repositoryFullName: String) -> String {
+        repositoryFullName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private static func tagMarker(_ tag: String) -> String {
+        let trimmed = tag.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "untagged" : trimmed
+    }
+
+    private static func dateMarker(_ date: Date) -> String {
+        String(Int(date.timeIntervalSince1970))
+    }
+}

--- a/Sources/RepoBarCore/Notifications/GitHubReleaseNotificationDetector.swift
+++ b/Sources/RepoBarCore/Notifications/GitHubReleaseNotificationDetector.swift
@@ -28,28 +28,44 @@ public struct GitHubReleaseNotificationEvent: Identifiable, Equatable, Sendable 
 public struct GitHubReleaseNotificationSnapshotState: Equatable, Codable, Sendable {
     public var repositories: [String: [String: Date]]
     public var repositoryBaselines: [String: Date]
+    public var lastCheckedAt: Date?
 
     public init(
         repositories: [String: [String: Date]] = [:],
-        repositoryBaselines: [String: Date] = [:]
+        repositoryBaselines: [String: Date] = [:],
+        lastCheckedAt: Date? = nil
     ) {
         self.repositories = repositories
         self.repositoryBaselines = repositoryBaselines
+        self.lastCheckedAt = lastCheckedAt
     }
 
     private enum CodingKeys: String, CodingKey {
         case repositories
         case repositoryBaselines
+        case lastCheckedAt
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.repositories = try container.decodeIfPresent([String: [String: Date]].self, forKey: .repositories) ?? [:]
         self.repositoryBaselines = try container.decodeIfPresent([String: Date].self, forKey: .repositoryBaselines) ?? [:]
+        self.lastCheckedAt = try container.decodeIfPresent(Date.self, forKey: .lastCheckedAt)
     }
 }
 
 public enum GitHubReleaseNotificationDetector {
+    public static func shouldPoll(
+        previousState: GitHubReleaseNotificationSnapshotState,
+        now: Date = Date(),
+        minimumInterval: TimeInterval
+    ) -> Bool {
+        guard minimumInterval > 0, let lastCheckedAt = previousState.lastCheckedAt else { return true }
+
+        let elapsed = now.timeIntervalSince(lastCheckedAt)
+        return elapsed < 0 || elapsed >= minimumInterval
+    }
+
     public static func events(
         for currentReleases: [String: [RepoReleaseSummary]],
         previousState: GitHubReleaseNotificationSnapshotState,
@@ -66,7 +82,8 @@ public enum GitHubReleaseNotificationDetector {
         let previousBaselines = previousState.repositoryBaselines.filter { trackedRepositoryKeys.contains($0.key) }
         var nextState = GitHubReleaseNotificationSnapshotState(
             repositories: previousRepositories,
-            repositoryBaselines: previousBaselines
+            repositoryBaselines: previousBaselines,
+            lastCheckedAt: previousState.lastCheckedAt
         )
         var events: [GitHubReleaseNotificationEvent] = []
 

--- a/Sources/RepoBarCore/Notifications/GitHubReleaseNotificationDetector.swift
+++ b/Sources/RepoBarCore/Notifications/GitHubReleaseNotificationDetector.swift
@@ -26,12 +26,12 @@ public struct GitHubReleaseNotificationEvent: Identifiable, Equatable, Sendable 
 }
 
 public struct GitHubReleaseNotificationSnapshotState: Equatable, Codable, Sendable {
-    public var repositories: [String: [String: Date]]
+    public var repositories: [String: [String: GitHubReleaseNotificationSnapshot]]
     public var repositoryBaselines: [String: Date]
     public var lastCheckedAt: Date?
 
     public init(
-        repositories: [String: [String: Date]] = [:],
+        repositories: [String: [String: GitHubReleaseNotificationSnapshot]] = [:],
         repositoryBaselines: [String: Date] = [:],
         lastCheckedAt: Date? = nil
     ) {
@@ -48,9 +48,22 @@ public struct GitHubReleaseNotificationSnapshotState: Equatable, Codable, Sendab
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.repositories = try container.decodeIfPresent([String: [String: Date]].self, forKey: .repositories) ?? [:]
+        self.repositories = try container.decodeIfPresent(
+            [String: [String: GitHubReleaseNotificationSnapshot]].self,
+            forKey: .repositories
+        ) ?? [:]
         self.repositoryBaselines = try container.decodeIfPresent([String: Date].self, forKey: .repositoryBaselines) ?? [:]
         self.lastCheckedAt = try container.decodeIfPresent(Date.self, forKey: .lastCheckedAt)
+    }
+}
+
+public struct GitHubReleaseNotificationSnapshot: Equatable, Codable, Sendable {
+    public let publishedAt: Date
+    public let isPrerelease: Bool
+
+    public init(publishedAt: Date, isPrerelease: Bool) {
+        self.publishedAt = publishedAt
+        self.isPrerelease = isPrerelease
     }
 }
 
@@ -93,9 +106,17 @@ public enum GitHubReleaseNotificationDetector {
 
             let previousReleases = previousRepositories[repositoryKey]
             let previousBaseline = previousBaselines[repositoryKey]
-                ?? previousReleases?.values.max()
+                ?? previousReleases?.values.map(\.publishedAt).max()
             nextState.repositories[repositoryKey] = Dictionary(
-                releases.map { ($0.tag, $0.publishedAt) },
+                releases.map {
+                    (
+                        $0.tag,
+                        GitHubReleaseNotificationSnapshot(
+                            publishedAt: $0.publishedAt,
+                            isPrerelease: $0.isPrerelease
+                        )
+                    )
+                },
                 uniquingKeysWith: { first, _ in first }
             )
             nextState.repositoryBaselines[repositoryKey] = max(previousBaseline ?? observedAt, observedAt)
@@ -105,12 +126,14 @@ public enum GitHubReleaseNotificationDetector {
             }
 
             for release in releases {
-                guard previousReleases[release.tag] == nil else { continue }
+                let previousRelease = previousReleases[release.tag]
+                let wasPromotedToStable = previousRelease?.isPrerelease == true && release.isPrerelease == false
+                guard previousRelease == nil || wasPromotedToStable else { continue }
 
                 if release.isPrerelease, settings.includePrereleases == false { continue }
 
                 let isNewAfterBaseline = previousBaseline.map { release.publishedAt > $0 } ?? false
-                guard isNewAfterBaseline else { continue }
+                guard isNewAfterBaseline || wasPromotedToStable else { continue }
 
                 events.append(Self.event(repositoryFullName: repositoryFullName, release: release))
             }
@@ -127,6 +150,7 @@ public enum GitHubReleaseNotificationDetector {
             "github-release",
             Self.repositoryKey(repositoryFullName).replacingOccurrences(of: "/", with: "-"),
             Self.tagMarker(release.tag),
+            release.isPrerelease ? "prerelease" : "release",
             Self.dateMarker(release.publishedAt)
         ].joined(separator: "-")
 

--- a/Sources/RepoBarCore/Notifications/GitHubReleaseNotificationSnapshotStore.swift
+++ b/Sources/RepoBarCore/Notifications/GitHubReleaseNotificationSnapshotStore.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+public struct GitHubReleaseNotificationSnapshotStore {
+    public static let storageKey = "com.steipete.repobar.github-release-notification-snapshots"
+
+    private let defaults: UserDefaults
+    private let key: String
+
+    public init(defaults: UserDefaults = .standard, key: String = Self.storageKey) {
+        self.defaults = defaults
+        self.key = key
+    }
+
+    public func load() -> GitHubReleaseNotificationSnapshotState {
+        guard let data = self.defaults.data(forKey: self.key) else {
+            return GitHubReleaseNotificationSnapshotState()
+        }
+
+        return (try? JSONDecoder().decode(GitHubReleaseNotificationSnapshotState.self, from: data))
+            ?? GitHubReleaseNotificationSnapshotState()
+    }
+
+    public func save(_ state: GitHubReleaseNotificationSnapshotState) {
+        guard let data = try? JSONEncoder().encode(state) else { return }
+
+        self.defaults.set(data, forKey: self.key)
+    }
+
+    public func clear() {
+        self.defaults.removeObject(forKey: self.key)
+    }
+}

--- a/Sources/RepoBarCore/Settings/UserSettings.swift
+++ b/Sources/RepoBarCore/Settings/UserSettings.swift
@@ -8,6 +8,7 @@ public struct UserSettings: Equatable, Codable {
     public var gitHubReferenceMonitor = GitHubReferenceMonitorSettings()
     public var aiSummaries = AISummarySettings()
     public var gitHubPullRequestNotifications = GitHubPullRequestNotificationSettings()
+    public var gitHubReleaseNotifications = GitHubReleaseNotificationSettings()
     public var githubArchives = GitHubArchiveSettings()
     public var menuCustomization = MenuCustomization()
     public var refreshInterval: RefreshInterval = .fiveMinutes
@@ -39,6 +40,7 @@ public struct UserSettings: Equatable, Codable {
         case gitHubReferenceMonitor
         case aiSummaries
         case gitHubPullRequestNotifications
+        case gitHubReleaseNotifications
         case legacyIssueNumberMonitor = "issueNumberMonitor"
         case githubArchives
         case menuCustomization
@@ -74,6 +76,10 @@ public struct UserSettings: Equatable, Codable {
             GitHubPullRequestNotificationSettings.self,
             forKey: .gitHubPullRequestNotifications
         ) ?? GitHubPullRequestNotificationSettings()
+        self.gitHubReleaseNotifications = try container.decodeIfPresent(
+            GitHubReleaseNotificationSettings.self,
+            forKey: .gitHubReleaseNotifications
+        ) ?? GitHubReleaseNotificationSettings()
         self.githubArchives = try container.decodeIfPresent(GitHubArchiveSettings.self, forKey: .githubArchives) ?? GitHubArchiveSettings()
         self.menuCustomization = try container.decodeIfPresent(MenuCustomization.self, forKey: .menuCustomization) ?? MenuCustomization()
         self.refreshInterval = try container.decodeIfPresent(RefreshInterval.self, forKey: .refreshInterval) ?? .fiveMinutes
@@ -117,6 +123,7 @@ public struct UserSettings: Equatable, Codable {
         try container.encode(self.gitHubReferenceMonitor, forKey: .gitHubReferenceMonitor)
         try container.encode(self.aiSummaries, forKey: .aiSummaries)
         try container.encode(self.gitHubPullRequestNotifications, forKey: .gitHubPullRequestNotifications)
+        try container.encode(self.gitHubReleaseNotifications, forKey: .gitHubReleaseNotifications)
         try container.encode(self.githubArchives, forKey: .githubArchives)
         try container.encode(self.menuCustomization, forKey: .menuCustomization)
         try container.encode(self.refreshInterval, forKey: .refreshInterval)
@@ -383,6 +390,24 @@ public enum GitHubPullRequestNotificationClickAction: String, CaseIterable, Hash
         case .openInBrowser: "Default browser"
         case .openIssueNavigator: "Issue Navigator"
         }
+    }
+}
+
+public struct GitHubReleaseNotificationSettings: Equatable, Codable, Sendable {
+    public var enabled = false
+    public var includePrereleases = false
+
+    public init() {}
+
+    enum CodingKeys: String, CodingKey {
+        case enabled
+        case includePrereleases
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
+        self.includePrereleases = try container.decodeIfPresent(Bool.self, forKey: .includePrereleases) ?? false
     }
 }
 

--- a/Sources/repobarcli/SettingsSupport.swift
+++ b/Sources/repobarcli/SettingsSupport.swift
@@ -24,6 +24,8 @@ enum SettingsKey: String, CaseIterable {
     case pullRequestNotificationReviews = "pull-request-notification-reviews"
     case pullRequestNotificationComments = "pull-request-notification-comments"
     case pullRequestNotificationClick = "pull-request-notification-click"
+    case releaseNotifications = "release-notifications"
+    case releaseNotificationPrereleases = "release-notification-prereleases"
     case cardDensity = "card-density"
     case accentTone = "accent-tone"
     case activityScope = "activity-scope"
@@ -77,6 +79,10 @@ enum SettingsKey: String, CaseIterable {
             self = .pullRequestNotificationComments
         case "pull-request-notification-click", "pr-notification-click", "notification-click":
             self = .pullRequestNotificationClick
+        case "release-notifications", "github-release-notifications", "new-release-notifications":
+            self = .releaseNotifications
+        case "release-notification-prereleases", "release-notification-prerelease", "release-prereleases", "include-prereleases":
+            self = .releaseNotificationPrereleases
         case "card-density", "density":
             self = .cardDensity
         case "accent-tone", "accent":
@@ -194,6 +200,14 @@ func applySetting(_ key: SettingsKey, value: String, settings: inout UserSetting
         let action = try parsePullRequestNotificationClickAction(value)
         settings.gitHubPullRequestNotifications.clickAction = action
         return action.label
+    case .releaseNotifications:
+        let flag = try parseBool(value)
+        settings.gitHubReleaseNotifications.enabled = flag
+        return flag ? "on" : "off"
+    case .releaseNotificationPrereleases:
+        let flag = try parseBool(value)
+        settings.gitHubReleaseNotifications.includePrereleases = flag
+        return flag ? "on" : "off"
     case .cardDensity:
         guard let density = CardDensity(rawValue: value.lowercased()) else {
             throw ValidationError("Invalid card-density value: \(value)")
@@ -295,6 +309,8 @@ func settingsSummaryLines(settings: UserSettings) -> [String] {
         "PR notifications: \(settings.gitHubPullRequestNotifications.enabled ? "on" : "off")",
         "PR notification events: \(pullRequestNotificationEventsLabel(settings.gitHubPullRequestNotifications))",
         "PR notification click: \(settings.gitHubPullRequestNotifications.clickAction.label)",
+        "Release notifications: \(settings.gitHubReleaseNotifications.enabled ? "on" : "off")",
+        "Release notification pre-releases: \(settings.gitHubReleaseNotifications.includePrereleases ? "on" : "off")",
         "Card density: \(settings.appearance.cardDensity.rawValue)",
         "Accent tone: \(settings.appearance.accentTone.rawValue)",
         "Activity scope: \(settings.appearance.activityScope.rawValue)",

--- a/Tests/RepoBarTests/GitHubReleaseNotificationDetectorTests.swift
+++ b/Tests/RepoBarTests/GitHubReleaseNotificationDetectorTests.swift
@@ -1,0 +1,194 @@
+import Foundation
+@testable import RepoBarCore
+import Testing
+
+struct GitHubReleaseNotificationDetectorTests {
+    @Test
+    func `first snapshot does not emit backlog`() {
+        let result = GitHubReleaseNotificationDetector.events(
+            for: ["steipete/RepoBar": [Self.release(tag: "v1.0.0", publishedAt: Self.date(100))]],
+            previousState: GitHubReleaseNotificationSnapshotState(),
+            settings: Self.enabledSettings(),
+            observedAt: Self.date(150)
+        )
+
+        #expect(result.events.isEmpty)
+        #expect(result.state.repositories["steipete/repobar"]?["v1.0.0"] == Self.date(100))
+        #expect(result.state.repositoryBaselines["steipete/repobar"] == Self.date(150))
+    }
+
+    @Test
+    func `new release emits after initial snapshot`() {
+        let first = GitHubReleaseNotificationDetector.events(
+            for: ["steipete/RepoBar": [Self.release(tag: "v1.0.0", publishedAt: Self.date(100))]],
+            previousState: GitHubReleaseNotificationSnapshotState(),
+            settings: Self.enabledSettings(),
+            observedAt: Self.date(150)
+        )
+
+        let second = GitHubReleaseNotificationDetector.events(
+            for: [
+                "steipete/RepoBar": [
+                    Self.release(tag: "v1.1.0", publishedAt: Self.date(200)),
+                    Self.release(tag: "v1.0.0", publishedAt: Self.date(100))
+                ]
+            ],
+            previousState: first.state,
+            settings: Self.enabledSettings(),
+            observedAt: Self.date(250)
+        )
+
+        #expect(second.events.count == 1)
+        #expect(second.events.first?.tag == "v1.1.0")
+        #expect(second.events.first?.repositoryFullName == "steipete/RepoBar")
+    }
+
+    @Test
+    func `pre-release is suppressed by default`() {
+        let first = GitHubReleaseNotificationDetector.events(
+            for: ["steipete/RepoBar": [Self.release(tag: "v1.0.0", publishedAt: Self.date(100))]],
+            previousState: GitHubReleaseNotificationSnapshotState(),
+            settings: Self.enabledSettings(),
+            observedAt: Self.date(150)
+        )
+
+        let second = GitHubReleaseNotificationDetector.events(
+            for: [
+                "steipete/RepoBar": [
+                    Self.release(tag: "v1.1.0-rc1", publishedAt: Self.date(200), isPrerelease: true),
+                    Self.release(tag: "v1.0.0", publishedAt: Self.date(100))
+                ]
+            ],
+            previousState: first.state,
+            settings: Self.enabledSettings(),
+            observedAt: Self.date(250)
+        )
+
+        #expect(second.events.isEmpty)
+    }
+
+    @Test
+    func `pre-release emits when included`() {
+        var settings = Self.enabledSettings()
+        settings.includePrereleases = true
+        let first = GitHubReleaseNotificationDetector.events(
+            for: ["steipete/RepoBar": [Self.release(tag: "v1.0.0", publishedAt: Self.date(100))]],
+            previousState: GitHubReleaseNotificationSnapshotState(),
+            settings: settings,
+            observedAt: Self.date(150)
+        )
+
+        let second = GitHubReleaseNotificationDetector.events(
+            for: [
+                "steipete/RepoBar": [
+                    Self.release(tag: "v1.1.0-rc1", publishedAt: Self.date(200), isPrerelease: true),
+                    Self.release(tag: "v1.0.0", publishedAt: Self.date(100))
+                ]
+            ],
+            previousState: first.state,
+            settings: settings,
+            observedAt: Self.date(250)
+        )
+
+        #expect(second.events.count == 1)
+        #expect(second.events.first?.tag == "v1.1.0-rc1")
+        #expect(second.events.first?.isPrerelease == true)
+    }
+
+    @Test
+    func `older release re-entering window does not emit as new`() {
+        let first = GitHubReleaseNotificationDetector.events(
+            for: ["steipete/RepoBar": [Self.release(tag: "v2.0.0", publishedAt: Self.date(200))]],
+            previousState: GitHubReleaseNotificationSnapshotState(),
+            settings: Self.enabledSettings(),
+            observedAt: Self.date(150)
+        )
+
+        let second = GitHubReleaseNotificationDetector.events(
+            for: [
+                "steipete/RepoBar": [
+                    Self.release(tag: "v2.0.0", publishedAt: Self.date(200)),
+                    Self.release(tag: "v1.0.0", publishedAt: Self.date(100))
+                ]
+            ],
+            previousState: first.state,
+            settings: Self.enabledSettings(),
+            observedAt: Self.date(250)
+        )
+
+        #expect(second.events.isEmpty)
+    }
+
+    @Test
+    func `disabled settings emit nothing and preserve state`() {
+        let previous = GitHubReleaseNotificationSnapshotState(
+            repositories: ["steipete/repobar": ["v1.0.0": Self.date(100)]],
+            repositoryBaselines: ["steipete/repobar": Self.date(150)]
+        )
+
+        let result = GitHubReleaseNotificationDetector.events(
+            for: ["steipete/RepoBar": [Self.release(tag: "v2.0.0", publishedAt: Self.date(300))]],
+            previousState: previous,
+            settings: GitHubReleaseNotificationSettings(),
+            observedAt: Self.date(350)
+        )
+
+        #expect(result.events.isEmpty)
+        #expect(result.state == previous)
+    }
+
+    @Test
+    func `untracked repository is ignored`() {
+        let first = GitHubReleaseNotificationDetector.events(
+            for: ["steipete/RepoBar": [Self.release(tag: "v1.0.0", publishedAt: Self.date(100))]],
+            previousState: GitHubReleaseNotificationSnapshotState(),
+            settings: Self.enabledSettings(),
+            trackedRepositoryFullNames: ["steipete/RepoBar"],
+            observedAt: Self.date(150)
+        )
+
+        let second = GitHubReleaseNotificationDetector.events(
+            for: [
+                "steipete/RepoBar": [Self.release(tag: "v1.0.0", publishedAt: Self.date(100))],
+                "other/repo": [Self.release(tag: "v9.9.9", publishedAt: Self.date(400))]
+            ],
+            previousState: first.state,
+            settings: Self.enabledSettings(),
+            trackedRepositoryFullNames: ["steipete/RepoBar"],
+            observedAt: Self.date(450)
+        )
+
+        #expect(second.events.isEmpty)
+        #expect(second.state.repositories["other/repo"] == nil)
+    }
+
+    private static func enabledSettings() -> GitHubReleaseNotificationSettings {
+        var settings = GitHubReleaseNotificationSettings()
+        settings.enabled = true
+        return settings
+    }
+
+    private static func release(
+        tag: String,
+        publishedAt: Date,
+        isPrerelease: Bool = false,
+        name: String? = nil
+    ) -> RepoReleaseSummary {
+        RepoReleaseSummary(
+            name: name ?? tag,
+            tag: tag,
+            url: URL(string: "https://github.com/steipete/RepoBar/releases/tag/\(tag)")!,
+            publishedAt: publishedAt,
+            isPrerelease: isPrerelease,
+            authorLogin: nil,
+            authorAvatarURL: nil,
+            assetCount: 0,
+            downloadCount: 0,
+            assets: []
+        )
+    }
+
+    private static func date(_ seconds: TimeInterval) -> Date {
+        Date(timeIntervalSince1970: seconds)
+    }
+}

--- a/Tests/RepoBarTests/GitHubReleaseNotificationDetectorTests.swift
+++ b/Tests/RepoBarTests/GitHubReleaseNotificationDetectorTests.swift
@@ -4,6 +4,42 @@ import Testing
 
 struct GitHubReleaseNotificationDetectorTests {
     @Test
+    func `polls when no previous check exists`() {
+        #expect(GitHubReleaseNotificationDetector.shouldPoll(
+            previousState: GitHubReleaseNotificationSnapshotState(),
+            now: Self.date(1000),
+            minimumInterval: 900
+        ))
+    }
+
+    @Test
+    func `skips polling until minimum interval elapses`() {
+        let state = GitHubReleaseNotificationSnapshotState(lastCheckedAt: Self.date(1000))
+
+        #expect(GitHubReleaseNotificationDetector.shouldPoll(
+            previousState: state,
+            now: Self.date(1899),
+            minimumInterval: 900
+        ) == false)
+        #expect(GitHubReleaseNotificationDetector.shouldPoll(
+            previousState: state,
+            now: Self.date(1900),
+            minimumInterval: 900
+        ))
+    }
+
+    @Test
+    func `polls after clock moves backwards`() {
+        let state = GitHubReleaseNotificationSnapshotState(lastCheckedAt: Self.date(1000))
+
+        #expect(GitHubReleaseNotificationDetector.shouldPoll(
+            previousState: state,
+            now: Self.date(900),
+            minimumInterval: 900
+        ))
+    }
+
+    @Test
     func `first snapshot does not emit backlog`() {
         let result = GitHubReleaseNotificationDetector.events(
             for: ["steipete/RepoBar": [Self.release(tag: "v1.0.0", publishedAt: Self.date(100))]],

--- a/Tests/RepoBarTests/GitHubReleaseNotificationDetectorTests.swift
+++ b/Tests/RepoBarTests/GitHubReleaseNotificationDetectorTests.swift
@@ -49,7 +49,10 @@ struct GitHubReleaseNotificationDetectorTests {
         )
 
         #expect(result.events.isEmpty)
-        #expect(result.state.repositories["steipete/repobar"]?["v1.0.0"] == Self.date(100))
+        #expect(
+            result.state.repositories["steipete/repobar"]?["v1.0.0"]
+                == GitHubReleaseNotificationSnapshot(publishedAt: Self.date(100), isPrerelease: false)
+        )
         #expect(result.state.repositoryBaselines["steipete/repobar"] == Self.date(150))
     }
 
@@ -132,6 +135,80 @@ struct GitHubReleaseNotificationDetectorTests {
     }
 
     @Test
+    func `pre-release promoted to stable emits when pre-releases are excluded`() {
+        let first = GitHubReleaseNotificationDetector.events(
+            for: [
+                "steipete/RepoBar": [
+                    Self.release(tag: "v1.1.0", publishedAt: Self.date(200), isPrerelease: true),
+                    Self.release(tag: "v1.0.0", publishedAt: Self.date(100))
+                ]
+            ],
+            previousState: GitHubReleaseNotificationSnapshotState(),
+            settings: Self.enabledSettings(),
+            observedAt: Self.date(250)
+        )
+
+        let second = GitHubReleaseNotificationDetector.events(
+            for: [
+                "steipete/RepoBar": [
+                    Self.release(tag: "v1.1.0", publishedAt: Self.date(200)),
+                    Self.release(tag: "v1.0.0", publishedAt: Self.date(100))
+                ]
+            ],
+            previousState: first.state,
+            settings: Self.enabledSettings(),
+            observedAt: Self.date(300)
+        )
+
+        #expect(second.events.count == 1)
+        #expect(second.events.first?.tag == "v1.1.0")
+        #expect(second.events.first?.isPrerelease == false)
+    }
+
+    @Test
+    func `pre-release and promoted release use distinct notification identifiers`() {
+        var settings = Self.enabledSettings()
+        settings.includePrereleases = true
+        let baseline = GitHubReleaseNotificationSnapshotState(
+            repositories: [
+                "steipete/repobar": [
+                    "v1.0.0": GitHubReleaseNotificationSnapshot(
+                        publishedAt: Self.date(100),
+                        isPrerelease: false
+                    )
+                ]
+            ],
+            repositoryBaselines: ["steipete/repobar": Self.date(150)]
+        )
+        let prerelease = GitHubReleaseNotificationDetector.events(
+            for: [
+                "steipete/RepoBar": [
+                    Self.release(tag: "v1.1.0", publishedAt: Self.date(200), isPrerelease: true),
+                    Self.release(tag: "v1.0.0", publishedAt: Self.date(100))
+                ]
+            ],
+            previousState: baseline,
+            settings: settings,
+            observedAt: Self.date(250)
+        )
+        let stable = GitHubReleaseNotificationDetector.events(
+            for: [
+                "steipete/RepoBar": [
+                    Self.release(tag: "v1.1.0", publishedAt: Self.date(200)),
+                    Self.release(tag: "v1.0.0", publishedAt: Self.date(100))
+                ]
+            ],
+            previousState: prerelease.state,
+            settings: settings,
+            observedAt: Self.date(300)
+        )
+
+        #expect(prerelease.events.count == 1)
+        #expect(stable.events.count == 1)
+        #expect(prerelease.events.first?.id != stable.events.first?.id)
+    }
+
+    @Test
     func `older release re-entering window does not emit as new`() {
         let first = GitHubReleaseNotificationDetector.events(
             for: ["steipete/RepoBar": [Self.release(tag: "v2.0.0", publishedAt: Self.date(200))]],
@@ -158,7 +235,14 @@ struct GitHubReleaseNotificationDetectorTests {
     @Test
     func `disabled settings emit nothing and preserve state`() {
         let previous = GitHubReleaseNotificationSnapshotState(
-            repositories: ["steipete/repobar": ["v1.0.0": Self.date(100)]],
+            repositories: [
+                "steipete/repobar": [
+                    "v1.0.0": GitHubReleaseNotificationSnapshot(
+                        publishedAt: Self.date(100),
+                        isPrerelease: false
+                    )
+                ]
+            ],
             repositoryBaselines: ["steipete/repobar": Self.date(150)]
         )
 

--- a/Tests/RepoBarTests/GitHubReleaseNotificationSnapshotStoreTests.swift
+++ b/Tests/RepoBarTests/GitHubReleaseNotificationSnapshotStoreTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+@testable import RepoBarCore
+import Testing
+
+struct GitHubReleaseNotificationSnapshotStoreTests {
+    @Test
+    func `snapshot store round trips and clears state`() throws {
+        let suiteName = "GitHubReleaseNotificationSnapshotStoreTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let store = GitHubReleaseNotificationSnapshotStore(defaults: defaults)
+        let state = GitHubReleaseNotificationSnapshotState(
+            repositories: ["steipete/repobar": ["v1.0.0": Date(timeIntervalSince1970: 100)]],
+            repositoryBaselines: ["steipete/repobar": Date(timeIntervalSince1970: 150)]
+        )
+
+        store.save(state)
+
+        let loaded = store.load()
+        #expect(loaded == state)
+
+        store.clear()
+
+        #expect(store.load() == GitHubReleaseNotificationSnapshotState())
+    }
+
+    @Test
+    func `snapshot store falls back to empty state for invalid data`() throws {
+        let suiteName = "GitHubReleaseNotificationSnapshotStoreTests.invalid.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults.set(Data([0x00, 0x01]), forKey: GitHubReleaseNotificationSnapshotStore.storageKey)
+        let store = GitHubReleaseNotificationSnapshotStore(defaults: defaults)
+
+        #expect(store.load() == GitHubReleaseNotificationSnapshotState())
+    }
+}

--- a/Tests/RepoBarTests/GitHubReleaseNotificationSnapshotStoreTests.swift
+++ b/Tests/RepoBarTests/GitHubReleaseNotificationSnapshotStoreTests.swift
@@ -10,7 +10,14 @@ struct GitHubReleaseNotificationSnapshotStoreTests {
         defaults.removePersistentDomain(forName: suiteName)
         let store = GitHubReleaseNotificationSnapshotStore(defaults: defaults)
         let state = GitHubReleaseNotificationSnapshotState(
-            repositories: ["steipete/repobar": ["v1.0.0": Date(timeIntervalSince1970: 100)]],
+            repositories: [
+                "steipete/repobar": [
+                    "v1.0.0": GitHubReleaseNotificationSnapshot(
+                        publishedAt: Date(timeIntervalSince1970: 100),
+                        isPrerelease: false
+                    )
+                ]
+            ],
             repositoryBaselines: ["steipete/repobar": Date(timeIntervalSince1970: 150)],
             lastCheckedAt: Date(timeIntervalSince1970: 175)
         )

--- a/Tests/RepoBarTests/GitHubReleaseNotificationSnapshotStoreTests.swift
+++ b/Tests/RepoBarTests/GitHubReleaseNotificationSnapshotStoreTests.swift
@@ -11,7 +11,8 @@ struct GitHubReleaseNotificationSnapshotStoreTests {
         let store = GitHubReleaseNotificationSnapshotStore(defaults: defaults)
         let state = GitHubReleaseNotificationSnapshotState(
             repositories: ["steipete/repobar": ["v1.0.0": Date(timeIntervalSince1970: 100)]],
-            repositoryBaselines: ["steipete/repobar": Date(timeIntervalSince1970: 150)]
+            repositoryBaselines: ["steipete/repobar": Date(timeIntervalSince1970: 150)],
+            lastCheckedAt: Date(timeIntervalSince1970: 175)
         )
 
         store.save(state)
@@ -20,6 +21,27 @@ struct GitHubReleaseNotificationSnapshotStoreTests {
         #expect(loaded == state)
 
         store.clear()
+
+        #expect(store.load() == GitHubReleaseNotificationSnapshotState())
+    }
+
+    @Test
+    func `snapshot store decodes state written before poll tracking`() throws {
+        let suiteName = "GitHubReleaseNotificationSnapshotStoreTests.legacy.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults.set(
+            Data(
+                """
+                {
+                  "repositories": {},
+                  "repositoryBaselines": {}
+                }
+                """.utf8
+            ),
+            forKey: GitHubReleaseNotificationSnapshotStore.storageKey
+        )
+        let store = GitHubReleaseNotificationSnapshotStore(defaults: defaults)
 
         #expect(store.load() == GitHubReleaseNotificationSnapshotState())
     }


### PR DESCRIPTION
## Summary

Adds **opt-in release notifications** for pinned repositories: when a pinned repo publishes a new release, RepoBar posts a notification. This extends the existing GitHub PR notification system to releases, matching the "scoped and opt-in, default off" shape requested in #57.

- **Off by default**, scoped to pinned repositories, same as PR notifications.
- A separate **Include pre-releases** toggle (also off by default) keeps `-rc`/beta tags quiet unless opted in.
- The **first refresh records existing releases without notifying**, so enabling it never dumps a backlog.
- Click opens the release in the browser.

## Implementation

Mirrors the existing PR-notification stack one-to-one, reusing the proven snapshot/baseline + tag-dedup logic so re-fetched or backfilled older releases never fire as "new":

- `RepoBarCore`: `GitHubReleaseNotificationDetector` (events + snapshot state), `GitHubReleaseNotificationSnapshotStore`, and a `GitHubReleaseNotificationSettings` field on `UserSettings` (backward-compatible `decodeIfPresent`).
- `RepoBar`: `GitHubReleaseNotificationRunner` (fetches pinned releases via the existing `recentReleases` API, which already filters drafts), wired into the refresh cycle next to the PR runner; a Release section in `NotificationSettingsView`.
- `repobarcli`: `release-notifications` / `release-notification-prereleases` settings keys + summary lines, mirroring the PR keys.

No new GitHub network surface — it reuses `GitHubClient.recentReleases`.

## Tests

- `GitHubReleaseNotificationDetectorTests` (7): first-snapshot baseline, new release emits, pre-release suppressed/included, older release re-entering the window does not re-fire, disabled no-op, untracked-repo ignored.
- `GitHubReleaseNotificationSnapshotStoreTests` (2): round-trip/clear, invalid-data fallback.

## Commands run

- `swift build` — clean (app + CLI + core)
- `swift test --filter GitHubReleaseNotification` — 9/9 pass
- `swiftformat --lint <changed files>` — 0/11 need formatting
- `swiftlint lint --strict <changed files>` — 0 violations

Refs #57.
