### PR TITLE
settings: clamp Settings window to visible frame and allow user resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.8.4 - Unreleased
 
+- Keep every Settings tab inside the visible display frame, allow bounded manual resizing, and prevent the Repositories table from forcing the window under the Dock (thanks @Yuxin-Qiao). (#84)
 - Update Kingfisher to 8.10.0 for safer asynchronous image cancellation and macOS image decoding.
 - Update esbuild to 0.28.1 to address upstream development-tool security advisories.
 

--- a/Sources/RepoBar/App/RepoBarApp.swift
+++ b/Sources/RepoBar/App/RepoBarApp.swift
@@ -31,7 +31,11 @@ struct RepoBarApp: App {
             SettingsView(session: self.appState.session, appState: self.appState)
         }
         .defaultSize(width: SettingsTab.general.preferredWidth, height: SettingsTab.general.preferredHeight)
-        .windowResizability(.contentSize)
+        // Use contentMinSize (not contentSize) so the window uses the per-tab preferred
+        // size from `resizeSettingsWindow` as its initial size and only grows if the user
+        // drags it. Without this, an unbounded table (Repositories tab) would expand the
+        // window to fill the entire screen.
+        .windowResizability(.contentMinSize)
     }
 }
 

--- a/Sources/RepoBar/Settings/RepoSettingsView.swift
+++ b/Sources/RepoBar/Settings/RepoSettingsView.swift
@@ -119,11 +119,10 @@ struct RepoSettingsView: View {
                 .width(min: 128, ideal: 136, max: 144)
             }
             .tableStyle(.inset(alternatesRowBackgrounds: true))
-            // Cap the table so the Settings window doesn't grow to fill the screen.
-            // SwiftUI's Table sometimes ignores soft `maxHeight` constraints when there's
-            // available vertical space, so we use a fixed height and rely on the Table's
-            // own internal scrolling once the row count exceeds what fits.
-            .frame(height: 460)
+            // Keep the surrounding controls visible when the window is clamped on a small
+            // display; the table consumes the remaining space and scrolls its own rows.
+            .frame(minHeight: 180, maxHeight: .infinity)
+            .layoutPriority(1)
             .onDeleteCommand { self.deleteSelection() }
             .contextMenu(forSelectionType: String.self) { selection in
                 Button("Open in GitHub") { self.openInGitHub(selection: selection) }

--- a/Sources/RepoBar/Settings/RepoSettingsView.swift
+++ b/Sources/RepoBar/Settings/RepoSettingsView.swift
@@ -119,7 +119,11 @@ struct RepoSettingsView: View {
                 .width(min: 128, ideal: 136, max: 144)
             }
             .tableStyle(.inset(alternatesRowBackgrounds: true))
-            .frame(minHeight: 280)
+            // Cap the table so the Settings window doesn't grow to fill the screen.
+            // SwiftUI's Table sometimes ignores soft `maxHeight` constraints when there's
+            // available vertical space, so we use a fixed height and rely on the Table's
+            // own internal scrolling once the row count exceeds what fits.
+            .frame(height: 460)
             .onDeleteCommand { self.deleteSelection() }
             .contextMenu(forSelectionType: String.self) { selection in
                 Button("Open in GitHub") { self.openInGitHub(selection: selection) }

--- a/Sources/RepoBar/Settings/SettingsTab.swift
+++ b/Sources/RepoBar/Settings/SettingsTab.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import SwiftUI
 
@@ -15,7 +16,12 @@ enum SettingsTab: Hashable {
 
     static let defaultWidth: CGFloat = 540
     static let repositoriesWidth: CGFloat = 980
+    /// Legacy default height retained for callers that still ask for "the" window height.
+    /// Prefer `preferredHeight` per tab and `SettingsWindowSizing.clampedContentSize` to keep
+    /// the window inside the screen's visible frame.
     static let windowHeight: CGFloat = 770
+    /// Absolute minimum content size the Settings window should ever shrink to, regardless of tab.
+    static let minimumContentSize = NSSize(width: 420, height: 360)
 
     var title: String {
         switch self {
@@ -36,7 +42,21 @@ enum SettingsTab: Hashable {
         self == .repositories ? Self.repositoriesWidth : Self.defaultWidth
     }
 
+    /// Per-tab ideal content height. Smaller tabs (e.g. About) get smaller windows so the
+    /// window doesn't sit in the middle of the screen with a lot of dead space and a footer
+    /// that can be hidden by the Dock on small displays.
     var preferredHeight: CGFloat {
-        Self.windowHeight
+        switch self {
+        case .general: 540
+        case .display: 540
+        case .repositories: 770
+        case .accounts: 620
+        case .notifications: 540
+        case .advanced: 600
+        case .about: 560
+        #if DEBUG
+            case .debug: 540
+        #endif
+        }
     }
 }

--- a/Sources/RepoBar/Settings/SettingsTab.swift
+++ b/Sources/RepoBar/Settings/SettingsTab.swift
@@ -49,7 +49,7 @@ enum SettingsTab: Hashable {
         switch self {
         case .general: 540
         case .display: 540
-        case .repositories: 770
+        case .repositories: 660
         case .accounts: 620
         case .notifications: 540
         case .advanced: 600

--- a/Sources/RepoBar/Settings/SettingsView.swift
+++ b/Sources/RepoBar/Settings/SettingsView.swift
@@ -79,6 +79,8 @@ struct SettingsView: View {
             if animate {
                 try? await Task.sleep(for: .milliseconds(100))
             }
+            guard self.session.settingsSelectedTab == tab else { return }
+
             Self.configureSettingsWindow(contentSize: contentSize, previousTopEdge: previousTopEdge)
         }
     }

--- a/Sources/RepoBar/Settings/SettingsView.swift
+++ b/Sources/RepoBar/Settings/SettingsView.swift
@@ -134,6 +134,11 @@ struct SettingsView: View {
             height: contentSize.height + chrome.height
         )
         if let visibleFrame {
+            frame.origin.x = SettingsWindowSizing.clampedWindowOriginX(
+                proposedOriginX: frame.origin.x,
+                windowWidth: frame.width,
+                visibleFrame: visibleFrame
+            )
             frame.origin.y = SettingsWindowSizing.clampedWindowOriginY(
                 proposedOriginY: previousTopEdge.map { $0 - frame.height } ?? frame.origin.y,
                 windowHeight: frame.height,
@@ -194,6 +199,16 @@ enum SettingsWindowSizing {
             width: max(visibleFrame.width - chromeWidth, 1),
             height: max(visibleFrame.height - chromeHeight, 1)
         )
+    }
+
+    static func clampedWindowOriginX(
+        proposedOriginX: CGFloat,
+        windowWidth: CGFloat,
+        visibleFrame: NSRect
+    ) -> CGFloat {
+        let minimumOriginX = visibleFrame.minX
+        let maximumOriginX = max(minimumOriginX, visibleFrame.maxX - max(windowWidth, 0))
+        return min(max(proposedOriginX, minimumOriginX), maximumOriginX)
     }
 
     static func clampedWindowOriginY(

--- a/Sources/RepoBar/Settings/SettingsView.swift
+++ b/Sources/RepoBar/Settings/SettingsView.swift
@@ -119,8 +119,7 @@ struct SettingsView: View {
         // Establish resizability bounds once, derived from the actual chrome so the user
         // can drag the window edge to a sensible size but never past the screen.
         window.contentMinSize = SettingsWindowSizing.minimumContentSize(
-            for: SettingsTab.minimumContentSize,
-            chrome: chrome
+            for: SettingsTab.minimumContentSize
         )
         if let visibleFrame {
             window.contentMaxSize = SettingsWindowSizing.maximumContentSize(
@@ -175,17 +174,11 @@ enum SettingsWindowSizing {
         )
     }
 
-    /// The absolute minimum content size the window should allow. The chrome is added back
-    /// because AppKit's `contentMinSize` is in content coordinates, not window-frame coords.
-    static func minimumContentSize(
-        for minimum: NSSize,
-        chrome: NSSize
-    ) -> NSSize {
-        let chromeWidth = max(0, chrome.width)
-        let chromeHeight = max(0, chrome.height)
+    /// AppKit's `contentMinSize` is already expressed in content coordinates.
+    static func minimumContentSize(for minimum: NSSize) -> NSSize {
         return NSSize(
-            width: max(minimum.width - chromeWidth, 1),
-            height: max(minimum.height - chromeHeight, 1)
+            width: max(minimum.width, 1),
+            height: max(minimum.height, 1)
         )
     }
 

--- a/Sources/RepoBar/Settings/SettingsView.swift
+++ b/Sources/RepoBar/Settings/SettingsView.swift
@@ -57,19 +57,22 @@ struct SettingsView: View {
     }
 
     private func updateLayout(for tab: SettingsTab, animate: Bool) {
-        let contentSize = Self.resizeSettingsWindow(
-            width: tab.preferredWidth,
-            height: tab.preferredHeight,
-            animate: animate
+        let desiredContentSize = NSSize(width: tab.preferredWidth, height: tab.preferredHeight)
+        let contentSize = Self.clampedSettingsContentSize(
+            desired: desiredContentSize
         )
-        let change = {
-            self.contentWidth = contentSize.width
-            self.contentHeight = contentSize.height
-        }
-        if animate {
-            withAnimation(.spring(response: 0.32, dampingFraction: 0.85)) { change() }
-        } else {
-            change()
+        let previousTopEdge = Self.settingsWindow?.frame.maxY
+        self.contentWidth = contentSize.width
+        self.contentHeight = contentSize.height
+
+        // Let SwiftUI finish resizing its Settings window before applying AppKit bounds or
+        // repositioning it. Mutating the frame during that constraint pass can crash AppKit.
+        Task { @MainActor in
+            await Task.yield()
+            if animate {
+                try? await Task.sleep(for: .milliseconds(100))
+            }
+            Self.configureSettingsWindow(contentSize: contentSize, previousTopEdge: previousTopEdge)
         }
     }
 
@@ -91,55 +94,52 @@ struct SettingsView: View {
         return Set(titles)
     }
 
-    private static func resizeSettingsWindow(width: CGFloat, height: CGFloat, animate: Bool) -> NSSize {
-        let desiredContentSize = NSSize(width: width, height: height)
-        guard let window = NSApp.windows.first(where: {
+    private static var settingsWindow: NSWindow? {
+        NSApp.windows.first(where: {
             $0.identifier?.rawValue == self.settingsWindowIdentifier
                 || self.knownTabTitles.contains($0.title)
-        }) else { return desiredContentSize }
+        })
+    }
 
-        let toolbarHeight = window.frame.height - window.contentLayoutRect.height
-        guard toolbarHeight > 0 else { return desiredContentSize }
-
-        let visibleFrame = (window.screen ?? NSScreen.main)?.visibleFrame
-        let contentSize = SettingsWindowSizing.clampedContentSize(
-            desired: desiredContentSize,
-            visibleFrame: visibleFrame,
+    private static func clampedSettingsContentSize(desired: NSSize) -> NSSize {
+        guard let window = self.settingsWindow else { return desired }
+        return SettingsWindowSizing.clampedContentSize(
+            desired: desired,
+            visibleFrame: (window.screen ?? NSScreen.main)?.visibleFrame,
             chrome: window.frameRect(forContentRect: .zero).size
         )
+    }
+
+    private static func configureSettingsWindow(contentSize: NSSize, previousTopEdge: CGFloat?) {
+        guard let window = self.settingsWindow else { return }
+
+        let visibleFrame = (window.screen ?? NSScreen.main)?.visibleFrame
+        let chrome = window.frameRect(forContentRect: .zero).size
 
         // Establish resizability bounds once, derived from the actual chrome so the user
         // can drag the window edge to a sensible size but never past the screen.
         window.contentMinSize = SettingsWindowSizing.minimumContentSize(
             for: SettingsTab.minimumContentSize,
-            chrome: window.frameRect(forContentRect: .zero).size
+            chrome: chrome
         )
         if let visibleFrame {
             window.contentMaxSize = SettingsWindowSizing.maximumContentSize(
                 for: visibleFrame,
-                chrome: window.frameRect(forContentRect: .zero).size
+                chrome: chrome
             )
         }
 
-        let newSize = NSSize(
-            width: contentSize.width,
-            height: contentSize.height + toolbarHeight
-        )
+        let toolbarHeight = max(0, window.frame.height - window.contentLayoutRect.height)
         var frame = window.frame
-        let oldSize = frame.size
-        frame.size = newSize
-        // Anchor the top edge so the title bar doesn't jump when switching tabs, but never
-        // push the bottom below the screen's visible area.
-        frame.origin.y += oldSize.height - newSize.height
+        frame.size = NSSize(width: contentSize.width, height: contentSize.height + toolbarHeight)
         if let visibleFrame {
             frame.origin.y = SettingsWindowSizing.clampedWindowOriginY(
-                proposedOriginY: frame.origin.y,
-                windowHeight: newSize.height,
+                proposedOriginY: previousTopEdge.map { $0 - frame.height } ?? frame.origin.y,
+                windowHeight: frame.height,
                 visibleFrame: visibleFrame
             )
         }
-        window.setFrame(frame, display: true, animate: animate)
-        return contentSize
+        window.setFrame(frame, display: true, animate: false)
     }
 }
 

--- a/Sources/RepoBar/Settings/SettingsView.swift
+++ b/Sources/RepoBar/Settings/SettingsView.swift
@@ -96,10 +96,83 @@ struct SettingsView: View {
         let toolbarHeight = window.frame.height - window.contentLayoutRect.height
         guard toolbarHeight > 0 else { return }
 
-        let newSize = NSSize(width: width, height: height + toolbarHeight)
+        let visibleFrame = (window.screen ?? NSScreen.main)?.visibleFrame
+        let contentSize = SettingsWindowSizing.clampedContentSize(
+            desired: NSSize(width: width, height: height),
+            visibleFrame: visibleFrame,
+            chrome: window.frameRect(forContentRect: .zero).size
+        )
+
+        // Establish resizability bounds once, derived from the actual chrome so the user
+        // can drag the window edge to a sensible size but never past the screen.
+        window.contentMinSize = SettingsWindowSizing.minimumContentSize(
+            for: SettingsTab.minimumContentSize,
+            chrome: window.frameRect(forContentRect: .zero).size
+        )
+        if let visibleFrame {
+            window.contentMaxSize = NSSize(
+                width: max(1, visibleFrame.width),
+                height: max(1, visibleFrame.height)
+            )
+        }
+
+        let newSize = NSSize(
+            width: contentSize.width,
+            height: contentSize.height + toolbarHeight
+        )
         var frame = window.frame
-        frame.origin.y += frame.size.height - newSize.height
+        let oldSize = frame.size
         frame.size = newSize
+        // Anchor the top edge so the title bar doesn't jump when switching tabs, but never
+        // push the bottom below the screen's visible area.
+        frame.origin.y += oldSize.height - newSize.height
+        if let visibleFrame {
+            let maxY = visibleFrame.maxY
+            let minY = visibleFrame.minY + newSize.height
+            if frame.maxY > maxY {
+                frame.origin.y = maxY - newSize.height
+            } else if frame.minY < minY {
+                frame.origin.y = visibleFrame.minY
+            }
+        }
         window.setFrame(frame, display: true, animate: animate)
+    }
+}
+
+/// Pure helpers for sizing the Settings window. Kept AppKit-free at the core so we can unit
+/// test the clamping logic without standing up an `NSWindow` in tests.
+enum SettingsWindowSizing {
+    /// Clamp a desired content size so its enclosing frame (content + chrome) fits inside
+    /// `visibleFrame` (i.e. the screen area not covered by the menu bar or Dock). Returns the
+    /// desired size unchanged when no visible frame is available.
+    static func clampedContentSize(
+        desired: NSSize,
+        visibleFrame: NSRect?,
+        chrome: NSSize = .zero
+    ) -> NSSize {
+        guard let visibleFrame else { return desired }
+
+        let chromeWidth = max(0, chrome.width)
+        let chromeHeight = max(0, chrome.height)
+        let maxWidth = max(1, visibleFrame.width - chromeWidth)
+        let maxHeight = max(1, visibleFrame.height - chromeHeight)
+        return NSSize(
+            width: min(desired.width, maxWidth),
+            height: min(desired.height, maxHeight)
+        )
+    }
+
+    /// The absolute minimum content size the window should allow. The chrome is added back
+    /// because AppKit's `contentMinSize` is in content coordinates, not window-frame coords.
+    static func minimumContentSize(
+        for minimum: NSSize,
+        chrome: NSSize
+    ) -> NSSize {
+        let chromeWidth = max(0, chrome.width)
+        let chromeHeight = max(0, chrome.height)
+        return NSSize(
+            width: max(minimum.width - chromeWidth, 1),
+            height: max(minimum.height - chromeHeight, 1)
+        )
     }
 }

--- a/Sources/RepoBar/Settings/SettingsView.swift
+++ b/Sources/RepoBar/Settings/SettingsView.swift
@@ -110,9 +110,9 @@ struct SettingsView: View {
             chrome: window.frameRect(forContentRect: .zero).size
         )
         if let visibleFrame {
-            window.contentMaxSize = NSSize(
-                width: max(1, visibleFrame.width),
-                height: max(1, visibleFrame.height)
+            window.contentMaxSize = SettingsWindowSizing.maximumContentSize(
+                for: visibleFrame,
+                chrome: window.frameRect(forContentRect: .zero).size
             )
         }
 
@@ -127,13 +127,11 @@ struct SettingsView: View {
         // push the bottom below the screen's visible area.
         frame.origin.y += oldSize.height - newSize.height
         if let visibleFrame {
-            let maxY = visibleFrame.maxY
-            let minY = visibleFrame.minY + newSize.height
-            if frame.maxY > maxY {
-                frame.origin.y = maxY - newSize.height
-            } else if frame.minY < minY {
-                frame.origin.y = visibleFrame.minY
-            }
+            frame.origin.y = SettingsWindowSizing.clampedWindowOriginY(
+                proposedOriginY: frame.origin.y,
+                windowHeight: newSize.height,
+                visibleFrame: visibleFrame
+            )
         }
         window.setFrame(frame, display: true, animate: animate)
     }
@@ -174,5 +172,29 @@ enum SettingsWindowSizing {
             width: max(minimum.width - chromeWidth, 1),
             height: max(minimum.height - chromeHeight, 1)
         )
+    }
+
+    /// AppKit expects `contentMaxSize` in content coordinates, so remove the window chrome
+    /// from the screen's visible frame before applying the resize limit.
+    static func maximumContentSize(
+        for visibleFrame: NSRect,
+        chrome: NSSize
+    ) -> NSSize {
+        let chromeWidth = max(0, chrome.width)
+        let chromeHeight = max(0, chrome.height)
+        return NSSize(
+            width: max(visibleFrame.width - chromeWidth, 1),
+            height: max(visibleFrame.height - chromeHeight, 1)
+        )
+    }
+
+    static func clampedWindowOriginY(
+        proposedOriginY: CGFloat,
+        windowHeight: CGFloat,
+        visibleFrame: NSRect
+    ) -> CGFloat {
+        let minimumOriginY = visibleFrame.minY
+        let maximumOriginY = max(minimumOriginY, visibleFrame.maxY - max(windowHeight, 0))
+        return min(max(proposedOriginY, minimumOriginY), maximumOriginY)
     }
 }

--- a/Sources/RepoBar/Settings/SettingsView.swift
+++ b/Sources/RepoBar/Settings/SettingsView.swift
@@ -106,7 +106,7 @@ struct SettingsView: View {
         return SettingsWindowSizing.clampedContentSize(
             desired: desired,
             visibleFrame: (window.screen ?? NSScreen.main)?.visibleFrame,
-            chrome: window.frameRect(forContentRect: .zero).size
+            chrome: self.settingsWindowChrome(for: window)
         )
     }
 
@@ -114,7 +114,7 @@ struct SettingsView: View {
         guard let window = self.settingsWindow else { return }
 
         let visibleFrame = (window.screen ?? NSScreen.main)?.visibleFrame
-        let chrome = window.frameRect(forContentRect: .zero).size
+        let chrome = self.settingsWindowChrome(for: window)
 
         // Establish resizability bounds once, derived from the actual chrome so the user
         // can drag the window edge to a sensible size but never past the screen.
@@ -129,9 +129,11 @@ struct SettingsView: View {
             )
         }
 
-        let toolbarHeight = max(0, window.frame.height - window.contentLayoutRect.height)
         var frame = window.frame
-        frame.size = NSSize(width: contentSize.width, height: contentSize.height + toolbarHeight)
+        frame.size = NSSize(
+            width: contentSize.width + chrome.width,
+            height: contentSize.height + chrome.height
+        )
         if let visibleFrame {
             frame.origin.y = SettingsWindowSizing.clampedWindowOriginY(
                 proposedOriginY: previousTopEdge.map { $0 - frame.height } ?? frame.origin.y,
@@ -140,6 +142,13 @@ struct SettingsView: View {
             )
         }
         window.setFrame(frame, display: true, animate: false)
+    }
+
+    private static func settingsWindowChrome(for window: NSWindow) -> NSSize {
+        NSSize(
+            width: max(0, window.frame.width - window.contentLayoutRect.width),
+            height: max(0, window.frame.height - window.contentLayoutRect.height)
+        )
     }
 }
 

--- a/Sources/RepoBar/Settings/SettingsView.swift
+++ b/Sources/RepoBar/Settings/SettingsView.swift
@@ -128,13 +128,19 @@ struct SettingsView: View {
 
         // Establish resizability bounds once, derived from the actual chrome so the user
         // can drag the window edge to a sensible size but never past the screen.
-        window.contentMinSize = SettingsWindowSizing.minimumContentSize(
-            for: SettingsTab.minimumContentSize
-        )
         if let visibleFrame {
-            window.contentMaxSize = SettingsWindowSizing.maximumContentSize(
+            let maximumContentSize = SettingsWindowSizing.maximumContentSize(
                 for: visibleFrame,
                 chrome: chrome
+            )
+            window.contentMinSize = SettingsWindowSizing.minimumContentSize(
+                for: SettingsTab.minimumContentSize,
+                maximum: maximumContentSize
+            )
+            window.contentMaxSize = maximumContentSize
+        } else {
+            window.contentMinSize = SettingsWindowSizing.minimumContentSize(
+                for: SettingsTab.minimumContentSize
             )
         }
 
@@ -190,10 +196,16 @@ enum SettingsWindowSizing {
     }
 
     /// AppKit's `contentMinSize` is already expressed in content coordinates.
-    static func minimumContentSize(for minimum: NSSize) -> NSSize {
-        NSSize(
+    static func minimumContentSize(for minimum: NSSize, maximum: NSSize? = nil) -> NSSize {
+        let normalizedMinimum = NSSize(
             width: max(minimum.width, 1),
             height: max(minimum.height, 1)
+        )
+        guard let maximum else { return normalizedMinimum }
+
+        return NSSize(
+            width: min(normalizedMinimum.width, max(maximum.width, 1)),
+            height: min(normalizedMinimum.height, max(maximum.height, 1))
         )
     }
 

--- a/Sources/RepoBar/Settings/SettingsView.swift
+++ b/Sources/RepoBar/Settings/SettingsView.swift
@@ -40,7 +40,14 @@ struct SettingsView: View {
                 .tag(SettingsTab.about)
         }
         .tabViewStyle(.automatic)
-        .frame(width: self.contentWidth, height: self.contentHeight)
+        .frame(
+            minWidth: SettingsTab.minimumContentSize.width,
+            idealWidth: self.contentWidth,
+            maxWidth: .infinity,
+            minHeight: SettingsTab.minimumContentSize.height,
+            idealHeight: self.contentHeight,
+            maxHeight: .infinity
+        )
         .onAppear {
             self.updateLayout(for: self.session.settingsSelectedTab, animate: false)
         }
@@ -103,6 +110,7 @@ struct SettingsView: View {
 
     private static func clampedSettingsContentSize(desired: NSSize) -> NSSize {
         guard let window = self.settingsWindow else { return desired }
+
         return SettingsWindowSizing.clampedContentSize(
             desired: desired,
             visibleFrame: (window.screen ?? NSScreen.main)?.visibleFrame,
@@ -181,7 +189,7 @@ enum SettingsWindowSizing {
 
     /// AppKit's `contentMinSize` is already expressed in content coordinates.
     static func minimumContentSize(for minimum: NSSize) -> NSSize {
-        return NSSize(
+        NSSize(
             width: max(minimum.width, 1),
             height: max(minimum.height, 1)
         )

--- a/Sources/RepoBar/Settings/SettingsView.swift
+++ b/Sources/RepoBar/Settings/SettingsView.swift
@@ -57,16 +57,20 @@ struct SettingsView: View {
     }
 
     private func updateLayout(for tab: SettingsTab, animate: Bool) {
+        let contentSize = Self.resizeSettingsWindow(
+            width: tab.preferredWidth,
+            height: tab.preferredHeight,
+            animate: animate
+        )
         let change = {
-            self.contentWidth = tab.preferredWidth
-            self.contentHeight = tab.preferredHeight
+            self.contentWidth = contentSize.width
+            self.contentHeight = contentSize.height
         }
         if animate {
             withAnimation(.spring(response: 0.32, dampingFraction: 0.85)) { change() }
         } else {
             change()
         }
-        Self.resizeSettingsWindow(width: tab.preferredWidth, height: tab.preferredHeight, animate: animate)
     }
 
     private static let settingsWindowIdentifier = "com_apple_SwiftUI_Settings_window"
@@ -87,18 +91,19 @@ struct SettingsView: View {
         return Set(titles)
     }
 
-    private static func resizeSettingsWindow(width: CGFloat, height: CGFloat, animate: Bool) {
+    private static func resizeSettingsWindow(width: CGFloat, height: CGFloat, animate: Bool) -> NSSize {
+        let desiredContentSize = NSSize(width: width, height: height)
         guard let window = NSApp.windows.first(where: {
             $0.identifier?.rawValue == self.settingsWindowIdentifier
                 || self.knownTabTitles.contains($0.title)
-        }) else { return }
+        }) else { return desiredContentSize }
 
         let toolbarHeight = window.frame.height - window.contentLayoutRect.height
-        guard toolbarHeight > 0 else { return }
+        guard toolbarHeight > 0 else { return desiredContentSize }
 
         let visibleFrame = (window.screen ?? NSScreen.main)?.visibleFrame
         let contentSize = SettingsWindowSizing.clampedContentSize(
-            desired: NSSize(width: width, height: height),
+            desired: desiredContentSize,
             visibleFrame: visibleFrame,
             chrome: window.frameRect(forContentRect: .zero).size
         )
@@ -134,6 +139,7 @@ struct SettingsView: View {
             )
         }
         window.setFrame(frame, display: true, animate: animate)
+        return contentSize
     }
 }
 

--- a/Tests/RepoBarTests/SettingsWindowSizingTests.swift
+++ b/Tests/RepoBarTests/SettingsWindowSizingTests.swift
@@ -98,19 +98,16 @@ struct SettingsWindowSizingTests {
     }
 
     @Test
-    func `minimumContentSize subtracts chrome so AppKit enforces the right window bounds`() {
+    func `minimumContentSize preserves the declared content coordinate floor`() {
         let minimum = NSSize(width: 420, height: 360)
-        let chrome = NSSize(width: 16, height: 28)
-        let result = SettingsWindowSizing.minimumContentSize(for: minimum, chrome: chrome)
-        #expect(result.width == 404)
-        #expect(result.height == 332)
+        let result = SettingsWindowSizing.minimumContentSize(for: minimum)
+        #expect(result == minimum)
     }
 
     @Test
-    func `minimumContentSize never goes below 1 even if chrome exceeds the minimum`() {
+    func `minimumContentSize never goes below 1`() {
         let result = SettingsWindowSizing.minimumContentSize(
-            for: NSSize(width: 20, height: 20),
-            chrome: NSSize(width: 100, height: 100)
+            for: NSSize(width: -20, height: 0)
         )
         #expect(result.width == 1)
         #expect(result.height == 1)

--- a/Tests/RepoBarTests/SettingsWindowSizingTests.swift
+++ b/Tests/RepoBarTests/SettingsWindowSizingTests.swift
@@ -1,0 +1,106 @@
+import AppKit
+@testable import RepoBar
+import Testing
+
+@Suite("SettingsWindowSizing")
+struct SettingsWindowSizingTests {
+    @Test
+    func `returns desired size when no visible frame is available`() {
+        let desired = NSSize(width: 600, height: 800)
+        let result = SettingsWindowSizing.clampedContentSize(
+            desired: desired,
+            visibleFrame: nil,
+            chrome: NSSize(width: 0, height: 28)
+        )
+        #expect(result == desired)
+    }
+
+    @Test
+    func `clamps content width when chrome plus content overflows the screen`() {
+        // A 13" MacBook-ish visible frame (~1440 wide minus sidebars). Window chrome is 16
+        // px wide; desired content (1000) + chrome (16) > visible width (1440) is fine, but
+        // we still want a tight clamp on the next test.
+        let visible = NSRect(x: 0, y: 0, width: 1016, height: 800)
+        let chrome = NSSize(width: 16, height: 28)
+        let result = SettingsWindowSizing.clampedContentSize(
+            desired: NSSize(width: 1000, height: 600),
+            visibleFrame: visible,
+            chrome: chrome
+        )
+        // 1000 + 16 == 1016 fits exactly; no clamping expected.
+        #expect(result.width == 1000)
+        #expect(result.height == 600)
+    }
+
+    @Test
+    func `clamps content height so the window doesn't slide under the Dock`() {
+        // Simulate a small visible area with a chunky Dock at the bottom (height == 600).
+        let visible = NSRect(x: 0, y: 50, width: 1440, height: 600)
+        let chrome = NSSize(width: 0, height: 28)
+        let result = SettingsWindowSizing.clampedContentSize(
+            desired: NSSize(width: 540, height: 770),
+            visibleFrame: visible,
+            chrome: chrome
+        )
+        // 770 > 600 - 28 → content must shrink so the window fits in the visible area.
+        #expect(result.height == 572)
+        #expect(result.width == 540)
+    }
+
+    @Test
+    func `clamps both axes when the desired window is larger than the screen`() {
+        let visible = NSRect(x: 0, y: 0, width: 400, height: 300)
+        let chrome = NSSize(width: 8, height: 24)
+        let result = SettingsWindowSizing.clampedContentSize(
+            desired: NSSize(width: 980, height: 770),
+            visibleFrame: visible,
+            chrome: chrome
+        )
+        #expect(result.width == 392)
+        #expect(result.height == 276)
+    }
+
+    @Test
+    func `never returns a non-positive size even when the visible frame is degenerate`() {
+        let visible = NSRect(x: 0, y: 0, width: 4, height: 4)
+        let chrome = NSSize(width: 16, height: 28)
+        let result = SettingsWindowSizing.clampedContentSize(
+            desired: NSSize(width: 980, height: 770),
+            visibleFrame: visible,
+            chrome: chrome
+        )
+        #expect(result.width >= 1)
+        #expect(result.height >= 1)
+    }
+
+    @Test
+    func `treats negative chrome as zero so external callers can't break the math`() {
+        let visible = NSRect(x: 0, y: 0, width: 1000, height: 800)
+        let result = SettingsWindowSizing.clampedContentSize(
+            desired: NSSize(width: 540, height: 600),
+            visibleFrame: visible,
+            chrome: NSSize(width: -5, height: -10)
+        )
+        #expect(result.width == 540)
+        #expect(result.height == 600)
+    }
+
+    @Test
+    func `minimumContentSize subtracts chrome so AppKit enforces the right window bounds`() {
+        let minimum = NSSize(width: 420, height: 360)
+        let chrome = NSSize(width: 16, height: 28)
+        let result = SettingsWindowSizing.minimumContentSize(for: minimum, chrome: chrome)
+        #expect(result.width == 404)
+        #expect(result.height == 332)
+    }
+
+    @Test
+    func `minimumContentSize never goes below 1 even if chrome exceeds the minimum`() {
+        let result = SettingsWindowSizing.minimumContentSize(
+            for: NSSize(width: 20, height: 20),
+            chrome: NSSize(width: 100, height: 100)
+        )
+        #expect(result.width == 1)
+        #expect(result.height == 1)
+    }
+}

--- a/Tests/RepoBarTests/SettingsWindowSizingTests.swift
+++ b/Tests/RepoBarTests/SettingsWindowSizingTests.swift
@@ -103,4 +103,57 @@ struct SettingsWindowSizingTests {
         #expect(result.width == 1)
         #expect(result.height == 1)
     }
+
+    @Test
+    func `maximumContentSize subtracts chrome from the visible frame`() {
+        let result = SettingsWindowSizing.maximumContentSize(
+            for: NSRect(x: 0, y: 63, width: 1440, height: 807),
+            chrome: NSSize(width: 16, height: 28)
+        )
+        #expect(result.width == 1424)
+        #expect(result.height == 779)
+    }
+
+    @Test
+    func `maximumContentSize never goes below 1 when chrome exceeds the visible frame`() {
+        let result = SettingsWindowSizing.maximumContentSize(
+            for: NSRect(x: 0, y: 0, width: 20, height: 20),
+            chrome: NSSize(width: 100, height: 100)
+        )
+        #expect(result.width == 1)
+        #expect(result.height == 1)
+    }
+
+    @Test
+    func `window origin remains unchanged when the resized frame is already visible`() {
+        let visible = NSRect(x: 0, y: 63, width: 1440, height: 807)
+        let result = SettingsWindowSizing.clampedWindowOriginY(
+            proposedOriginY: 120,
+            windowHeight: 648,
+            visibleFrame: visible
+        )
+        #expect(result == 120)
+    }
+
+    @Test
+    func `window origin clamps to the visible bottom edge`() {
+        let visible = NSRect(x: 0, y: 63, width: 1440, height: 807)
+        let result = SettingsWindowSizing.clampedWindowOriginY(
+            proposedOriginY: 40,
+            windowHeight: 648,
+            visibleFrame: visible
+        )
+        #expect(result == visible.minY)
+    }
+
+    @Test
+    func `window origin clamps to the visible top edge`() {
+        let visible = NSRect(x: 0, y: 63, width: 1440, height: 807)
+        let result = SettingsWindowSizing.clampedWindowOriginY(
+            proposedOriginY: 400,
+            windowHeight: 648,
+            visibleFrame: visible
+        )
+        #expect(result == visible.maxY - 648)
+    }
 }

--- a/Tests/RepoBarTests/SettingsWindowSizingTests.swift
+++ b/Tests/RepoBarTests/SettingsWindowSizingTests.swift
@@ -134,6 +134,28 @@ struct SettingsWindowSizingTests {
     }
 
     @Test
+    func `window origin clamps to the visible right edge after widening`() {
+        let visible = NSRect(x: 100, y: 63, width: 1440, height: 807)
+        let result = SettingsWindowSizing.clampedWindowOriginX(
+            proposedOriginX: 1200,
+            windowWidth: 980,
+            visibleFrame: visible
+        )
+        #expect(result == 560)
+    }
+
+    @Test
+    func `window origin clamps to the visible left edge`() {
+        let visible = NSRect(x: 100, y: 63, width: 1440, height: 807)
+        let result = SettingsWindowSizing.clampedWindowOriginX(
+            proposedOriginX: 20,
+            windowWidth: 540,
+            visibleFrame: visible
+        )
+        #expect(result == 100)
+    }
+
+    @Test
     func `window origin remains unchanged when the resized frame is already visible`() {
         let visible = NSRect(x: 0, y: 63, width: 1440, height: 807)
         let result = SettingsWindowSizing.clampedWindowOriginY(

--- a/Tests/RepoBarTests/SettingsWindowSizingTests.swift
+++ b/Tests/RepoBarTests/SettingsWindowSizingTests.swift
@@ -114,6 +114,16 @@ struct SettingsWindowSizingTests {
     }
 
     @Test
+    func `minimumContentSize does not exceed a smaller screen maximum`() {
+        let result = SettingsWindowSizing.minimumContentSize(
+            for: NSSize(width: 420, height: 360),
+            maximum: NSSize(width: 392, height: 276)
+        )
+        #expect(result.width == 392)
+        #expect(result.height == 276)
+    }
+
+    @Test
     func `maximumContentSize subtracts chrome from the visible frame`() {
         let result = SettingsWindowSizing.maximumContentSize(
             for: NSRect(x: 0, y: 63, width: 1440, height: 807),

--- a/Tests/RepoBarTests/SettingsWindowSizingTests.swift
+++ b/Tests/RepoBarTests/SettingsWindowSizingTests.swift
@@ -48,6 +48,18 @@ struct SettingsWindowSizingTests {
     }
 
     @Test
+    func `clamps content height using the full settings toolbar chrome`() {
+        let visible = NSRect(x: 0, y: 50, width: 1440, height: 600)
+        let result = SettingsWindowSizing.clampedContentSize(
+            desired: NSSize(width: 540, height: 660),
+            visibleFrame: visible,
+            chrome: NSSize(width: 0, height: 88)
+        )
+        #expect(result.height == 512)
+        #expect(result.height + 88 == visible.height)
+    }
+
+    @Test
     func `clamps both axes when the desired window is larger than the screen`() {
         let visible = NSRect(x: 0, y: 0, width: 400, height: 300)
         let chrome = NSSize(width: 8, height: 24)


### PR DESCRIPTION
## Summary

The Settings window had two related issues:

1. **Dock overlap.** It used a hard-coded 770pt height that ignored the host screen's visible frame, so on 13" displays the bottom of the window (e.g. the **About** tab's "Check for Updates…" button, "Copy Update Diagnostics" button, and copyright row) sat under the Dock.
2. **Window was not user-resizable.** `contentMinSize` / `contentMaxSize` were never set, so the user couldn't drag the borders.
3. **Repositories tab grew to the full visible frame** (caught during live verification, fixed in a follow-up commit on this branch) — SwiftUI's `Table` ignored soft `maxHeight` constraints and the original `.windowResizability(.contentSize)` made the window track that unbounded content.

## What changed (2 commits)

### Commit 1 — `659c361`: clamp to visible frame, allow resize

- `Sources/RepoBar/Settings/SettingsTab.swift`
  - Adds per-tab `preferredHeight` (smaller tabs like **About** no longer get stretched to 770pt).
  - Adds `SettingsTab.minimumContentSize` (420×360) — the absolute floor the user can drag to.
- `Sources/RepoBar/Settings/SettingsView.swift`
  - New pure helper `SettingsWindowSizing` (mirrors the existing `IssueNavigatorWindowController.clampedContentSize` pattern) with `clampedContentSize(desired:visibleFrame:chrome:)` and `minimumContentSize(for:chrome:)`.
  - `resizeSettingsWindow` now reads `(window.screen ?? NSScreen.main)?.visibleFrame`, clamps the desired content size, sets `contentMinSize` / `contentMaxSize`, and re-anchors the frame so the title bar doesn't jump when switching tabs.
- `Tests/RepoBarTests/SettingsWindowSizingTests.swift` (new)
  - 8 Swift Testing cases: no visible frame, exact-fit width, Dock-style height clamp, both-axis clamp, degenerate visible frame, negative-chrome safety, `minimumContentSize` chrome subtraction, and lower-bound clamp.

### Commit 2 — `44dee62`: bound the Repositories Table

The first commit alone was not enough for the **Repositories** tab — SwiftUI's `Table` ignored the soft `.frame(maxHeight: 540)` and the window's `.windowResizability(.contentSize)` was still growing it to fit the unbounded content. Live verification showed the Repositories window at 980×858 (bottom y=888) — past the Dock.

- `Sources/RepoBar/Settings/RepoSettingsView.swift`: use a fixed `.frame(height: 460)` for the Table. It has its own internal scrolling, so all rows are still accessible.
- `Sources/RepoBar/App/RepoBarApp.swift`: switch `.windowResizability(.contentSize)` → `.windowResizability(.contentMinSize)` so the per-tab `preferredHeight` is the actual initial size, and the window doesn't grow to fit unbounded content.
- `Sources/RepoBar/Settings/SettingsTab.swift`: tune `repositories` `preferredHeight` to 660 to match the new fixed Table height plus the in-tab UI (tab bar, search, filter row, status bar, padding).

## Live verification (1440×900 screen, menu bar 24pt, Dock 63pt, visibleFrame 1440×807)

All 7 tabs were launched, switched to, and measured via `CGWindowListCopyWindowInfo`. Every window now sits inside the visible frame:

| Tab           | Size       | Bottom  | visibleFrame.maxY |
|---------------|-----------:|--------:|------------------:|
| General       | 540x628    |     748 |               837 |
| Display       | 540x628    |     817 |               837 |
| Repositories  | 980x748    |     778 |               837 |
| Accounts      | 540x708    |     828 |               837 |
| Notifications | 540x628    |     748 |               837 |
| Advanced      | 540x688    |     808 |               837 |
| About         | 540x648    |     837 |               837 |

Screenshots from the running build are in `screenshots/`:
- `screenshots/v2-about.png` — About tab, full content visible, bottom edge stops at the Dock.
- `screenshots/v2-repos.png` — Before the follow-up: Repositories grew to 980×858.
- `screenshots/v3-repos.png` — After the follow-up: Repositories is 980×748, comfortably above the Dock.

The patched binary was launched from `pnpm start` and verified at `/private/tmp/RepoBar/.build/arm64-apple-macosx/debug/RepoBar.app/Contents/MacOS/RepoBar` (not the `/Applications` install).

## Commands run

- `pnpm format` ✅
- `pnpm lint` ✅
- `pnpm test` ✅ — 632 tests, 105 suites (8 new in `SettingsWindowSizingTests`)
- `pnpm start` ✅ — all 7 tabs verified visually + via `CGWindowList` bounds