### PR TITLE
chore: update SwiftPM dependency pins

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apollographql/apollo-ios",
       "state" : {
-        "revision" : "38c202227d0f09508e573dcf22f54885cfb0c5d4",
-        "version" : "2.1.2"
+        "revision" : "5a8d18cc239dd3c4b31c9e13e671dbcef5e4072a",
+        "version" : "2.2.0"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log",
       "state" : {
-        "revision" : "92448c359f00ebe36ae97d3bd9086f13c7692b5a",
-        "version" : "1.13.2"
+        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
+        "version" : "1.14.0"
       }
     },
     {


### PR DESCRIPTION
## Summary

- Update Apollo iOS from 2.1.2 to 2.2.0.
- Update swift-log from 1.13.2 to 1.14.0.

## Notes

Apollo 2.2.0 contains Swift/Xcode compatibility fixes plus runtime crash/retain-cycle fixes. swift-log 1.14.0 adds the task-local logger implementation. No manifest bounds changed; this is a lockfile-only SwiftPM pin refresh.

## Verification

- `./Scripts/test.sh` passed after linking the generated Sparkle framework into SwiftPM's searched `PackageFrameworks` build-output path for this local checkout: 76 tests in 10 suites, then 584 tests in 98 suites.
- `pnpm test` did not reach the Swift test script in this fresh checkout because pnpm 11 stopped during install with `ERR_PNPM_IGNORED_BUILDS` for `esbuild`; no package files were kept from that generated approval stub.
