### PR TITLE
chore: refresh maintenance metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Useful docs:
 
 ## Status
 
-RepoBar is early and moving quickly. The latest released version is 0.5.0, with smarter persistent caching, archive-backed fallback paths, rate-limit visibility, GitHub reference previews, and more robust menu behavior.
+RepoBar is early and moving quickly. See the [latest release](https://github.com/steipete/RepoBar/releases/latest) and [changelog](CHANGELOG.md) for current shipped behavior.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "graphql": "^17.0.1"
   },
   "devDependencies": {
-    "@octokit/request": "^10.0.10",
+    "@octokit/request": "^10.0.11",
     "chalk": "^5.6.2",
     "commander": "^15.0.0",
     "dotenv-cli": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
         version: 17.0.1
     devDependencies:
       '@octokit/request':
-        specifier: ^10.0.10
-        version: 10.0.10
+        specifier: ^10.0.11
+        version: 10.0.11
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -203,8 +203,8 @@ packages:
     resolution: {integrity: sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==}
     engines: {node: '>= 20'}
 
-  '@octokit/request@10.0.10':
-    resolution: {integrity: sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==}
+  '@octokit/request@10.0.11':
+    resolution: {integrity: sha512-+s7HUxjfFqOMS9VlIwDffq0MikjSAK0gSpG73W+meAvVAvX4MBrHYTK5Bj3Uot55qFT4gzUtfzE4mGWY4Br8/Q==}
     engines: {node: '>= 20'}
 
   '@octokit/types@16.0.0':
@@ -448,7 +448,7 @@ snapshots:
     dependencies:
       '@octokit/types': 16.0.0
 
-  '@octokit/request@10.0.10':
+  '@octokit/request@10.0.11':
     dependencies:
       '@octokit/endpoint': 11.0.3
       '@octokit/request-error': 7.1.0


### PR DESCRIPTION
## Summary

- update `@octokit/request` from 10.0.10 to 10.0.11
- replace the stale hardcoded README release version with durable latest-release and changelog links

## Proof

- `pnpm check` — 660 tests in 108 suites passed
- `pnpm outdated --long` — no remaining outdated npm packages
- `pnpm audit --audit-level moderate` — no known vulnerabilities
- `swift package update --dry-run` — 0 dependencies would change
- structured Codex autoreview — clean, no accepted/actionable findings
