### PR TITLE
docs: define provider support boundary

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,16 @@
+# RepoBar Vision
+
+RepoBar is a fast native maintainer cockpit. It should make repository pressure, CI, releases, and local checkout state legible without becoming a browser replacement.
+
+## Provider rule
+
+GitHub remains the full-featured default. Another provider belongs in core only when one bounded maintainer can keep it trustworthy:
+
+- provider-owned API client in `RepoBarCore`, behind shared capability protocols;
+- HTTPS with platform trust; no ATS exceptions, HTTP fallback, redirect token forwarding, or self-signed bypass;
+- account-scoped credentials and caches; no token mirroring or cross-provider fallback;
+- provider-correct repository identity, subgroup paths, web links, and checkout URLs;
+- unsupported features hidden or rejected explicitly;
+- regression tests plus live app and CLI proof for that provider and GitHub.
+
+If those conditions cannot stay true, prefer a maintained fork or external integration over a partial compatibility layer in RepoBar.


### PR DESCRIPTION
## Summary

- define RepoBar as a fast native maintainer cockpit rather than a browser replacement
- keep GitHub as the full-featured default
- require provider ownership, HTTPS, credential isolation, explicit capability boundaries, regression coverage, and live app/CLI proof before another provider belongs in core

## Context

This extracts the durable provider policy from the repaired but intentionally held #85 branch so the project rule can land independently of the GitLab product and live-proof decision.

## Proof

- `git diff --check`
- `pnpm -s check` — 660 tests in 108 suites
- `pnpm -s build`
- structured Codex autoreview — clean, no accepted/actionable findings (0.94)

No changelog entry: this is maintainer policy documentation and changes no shipped behavior.
