### PR TITLE
fix: restore login after restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.8.5 - Unreleased
 
+- Restore the signed-in account immediately after restarting RepoBar when its persisted credentials are still available.
+
 ## 0.8.4 - 2026-07-02
 
 - Coalesce concurrent OAuth token refreshes per account so rotating refresh tokens cannot race or overwrite newer credentials.

--- a/Sources/RepoBar/App/AppState+Accounts.swift
+++ b/Sources/RepoBar/App/AppState+Accounts.swift
@@ -23,6 +23,13 @@ extension AppState {
         await manager.bootstrap(from: self.session.settings)
         await self.syncPrimaryGitHubClientToActiveAccount()
         self.session.activeAccountID = manager.activeAccountID
+        if let active = manager.activeAccount(), manager.hasStoredCredentials(accountID: active.id) {
+            self.session.account = .loggedIn(UserIdentity(username: active.username, host: active.host))
+            self.session.hasStoredTokens = true
+        } else {
+            self.session.account = .loggedOut
+            self.session.hasStoredTokens = false
+        }
         self.session.accountSessions = self.session.settings.accounts.map { account in
             AccountSession(account: account)
         }

--- a/Sources/RepoBar/App/AppState.swift
+++ b/Sources/RepoBar/App/AppState.swift
@@ -13,7 +13,7 @@ final class AppState {
     let patAuth = PATAuthenticator()
     let legacyGitHub: GitHubClient
     var github: GitHubClient
-    let accountManager = AccountManager()
+    let accountManager: AccountManager
     let refreshScheduler = RefreshScheduler()
     let settingsStore: SettingsStore
     let gitHubPullRequestNotificationRunner = GitHubPullRequestNotificationRunner()
@@ -43,11 +43,15 @@ final class AppState {
     let defaultGitHubHost = RepoBarAuthDefaults.githubHost
     let defaultAPIHost = RepoBarAuthDefaults.apiHost
 
-    init(settingsStore: SettingsStore = SettingsStore()) {
+    init(
+        settingsStore: SettingsStore = SettingsStore(),
+        accountManager: AccountManager? = nil
+    ) {
         let legacyGitHub = GitHubClient()
         self.legacyGitHub = legacyGitHub
         self.github = legacyGitHub
         self.settingsStore = settingsStore
+        self.accountManager = accountManager ?? AccountManager()
         self.session.settings = self.settingsStore.load()
         self.reloadRateLimitCacheSummary()
         RepoBarLogging.bootstrapIfNeeded()

--- a/Sources/RepoBar/Auth/AccountManager.swift
+++ b/Sources/RepoBar/Auth/AccountManager.swift
@@ -55,6 +55,17 @@ final class AccountManager {
         return self.accounts.first(where: { $0.id == activeAccountID })
     }
 
+    func hasStoredCredentials(accountID: String) -> Bool {
+        guard let account = self.accounts.first(where: { $0.id == accountID }) else { return false }
+
+        switch account.authMethod {
+        case .oauth:
+            return (try? self.tokenStore.loadTokens(accountID: accountID)) != nil
+        case .pat:
+            return (try? self.tokenStore.loadPAT(accountID: accountID)) != nil
+        }
+    }
+
     /// Sets the active account by ID. Returns whether the change took effect.
     @discardableResult
     func setActive(accountID: String?) -> Bool {

--- a/Tests/RepoBarTests/AppStateSettingsTests.swift
+++ b/Tests/RepoBarTests/AppStateSettingsTests.swift
@@ -33,4 +33,40 @@ struct AppStateSettingsTests {
         #expect(appState.session.heatmapRange != previousRange)
         #expect(appState.session.settings.heatmap.span == .oneMonth)
     }
+
+    @Test
+    func `bootstrap restores persisted login after restart`() async throws {
+        let suiteName = "com.steipete.repobar.login-restore-tests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let authDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("repobar-login-restore-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: authDirectory) }
+
+        let tokenStore = TokenStore(
+            service: "com.steipete.repobar.login-restore-tests",
+            storage: .file(authDirectory)
+        )
+        let account = try Account(
+            username: "restart-user",
+            host: #require(URL(string: "https://github.com")),
+            authMethod: .pat
+        )
+        try tokenStore.savePAT("persisted-token", accountID: account.id)
+        var settings = UserSettings()
+        settings.accounts = [account]
+        settings.activeAccountID = account.id
+        let settingsStore = SettingsStore(defaults: defaults)
+        settingsStore.save(settings)
+
+        let restarted = AppState(
+            settingsStore: settingsStore,
+            accountManager: AccountManager(tokenStore: tokenStore)
+        )
+        await restarted.bootstrapAccounts()
+
+        #expect(restarted.session.account == .loggedIn(UserIdentity(username: account.username, host: account.host)))
+        #expect(restarted.session.hasStoredTokens)
+        #expect(restarted.session.activeAccountID == account.id)
+    }
 }


### PR DESCRIPTION
## Summary

- restore the persisted active account into the runtime session during startup
- require matching account-scoped credentials before presenting the account as signed in
- cover a full settings-and-token reload with a restart regression test

## Root cause

RepoBar persisted both the account record and its scoped credentials, but each new process initialized `Session.account` as logged out. Account bootstrap rebuilt clients and active IDs without restoring that runtime login state, so the status item and menu presented a signed-out session until a later refresh rediscovered the identity.

## Proof

- `pnpm check` (SwiftFormat, strict SwiftLint, 661 tests)
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean; no accepted/actionable findings)
- shipped 0.8.4 CLI login state remained present across an app quit/relaunch, confirming persistence was intact and runtime state restoration was missing
