### PR TITLE
Reduce idle clipboard polling wakeups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.8.5 - Unreleased
 
+- Reduce idle wakeups from the opt-in GitHub reference watcher by backing off clipboard polling after inactivity while restoring one-second polling after changes.
+
 ## 0.8.4 - 2026-07-02
 
 - Coalesce concurrent OAuth token refreshes per account so rotating refresh tokens cannot race or overwrite newer credentials.

--- a/Sources/RepoBar/Support/GitHubReferenceMonitor.swift
+++ b/Sources/RepoBar/Support/GitHubReferenceMonitor.swift
@@ -66,14 +66,29 @@ final class GitHubReferenceMonitor {
     }
 }
 
+struct PasteboardPollCadence {
+    private(set) var unchangedPollCount = 0
+
+    var nextInterval: DispatchTimeInterval {
+        self.unchangedPollCount >= 5 ? .seconds(5) : .seconds(1)
+    }
+
+    var nextLeeway: DispatchTimeInterval {
+        self.unchangedPollCount >= 5 ? .seconds(2) : .milliseconds(500)
+    }
+
+    mutating func record(didChange: Bool) {
+        self.unchangedPollCount = didChange ? 0 : self.unchangedPollCount + 1
+    }
+}
+
 private final class PasteboardTextPoller: @unchecked Sendable {
     private let pasteboard: NSPasteboard
     private let queue = DispatchQueue(label: "com.steipete.repobar.github-reference-pasteboard", qos: .background)
     private let onText: @Sendable (String) -> Void
     private var timer: DispatchSourceTimer?
     private var lastChangeCount: Int
-    private let pollInterval: DispatchTimeInterval = .seconds(1)
-    private let pollLeeway: DispatchTimeInterval = .milliseconds(500)
+    private var cadence = PasteboardPollCadence()
     private let graceDelay: DispatchTimeInterval = .milliseconds(100)
 
     init(pasteboard: NSPasteboard, onText: @escaping @Sendable (String) -> Void) {
@@ -87,12 +102,12 @@ private final class PasteboardTextPoller: @unchecked Sendable {
             guard let self, self.timer == nil else { return }
 
             let timer = DispatchSource.makeTimerSource(queue: self.queue)
-            timer.schedule(deadline: .now() + self.pollInterval, repeating: self.pollInterval, leeway: self.pollLeeway)
             timer.setEventHandler { [weak self] in
                 self?.tick()
             }
-            timer.resume()
             self.timer = timer
+            self.scheduleNextPoll()
+            timer.resume()
         }
     }
 
@@ -105,15 +120,24 @@ private final class PasteboardTextPoller: @unchecked Sendable {
 
     private func tick() {
         self.readPasteboardChangeCount { [weak self] changeCount in
-            guard let self else { return }
-            guard changeCount != self.lastChangeCount else { return }
+            guard let self, self.timer != nil else { return }
+
+            let didChange = changeCount != self.lastChangeCount
+            self.cadence.record(didChange: didChange)
+            guard didChange else {
+                self.scheduleNextPoll()
+                return
+            }
 
             self.lastChangeCount = changeCount
             self.queue.asyncAfter(deadline: .now() + self.graceDelay) { [weak self] in
-                guard let self else { return }
+                guard let self, self.timer != nil else { return }
 
                 self.readPasteboardSnapshot { [weak self] delayedSnapshot in
-                    guard let self else { return }
+                    guard let self, self.timer != nil else { return }
+
+                    defer { self.scheduleNextPoll() }
+
                     guard changeCount == delayedSnapshot.changeCount else { return }
                     guard let text = delayedSnapshot.text else { return }
 
@@ -121,6 +145,13 @@ private final class PasteboardTextPoller: @unchecked Sendable {
                 }
             }
         }
+    }
+
+    private func scheduleNextPoll() {
+        self.timer?.schedule(
+            deadline: .now() + self.cadence.nextInterval,
+            leeway: self.cadence.nextLeeway
+        )
     }
 
     private func readPasteboardChangeCount(_ completion: @escaping @Sendable (Int) -> Void) {

--- a/Tests/RepoBarTests/SupportTests.swift
+++ b/Tests/RepoBarTests/SupportTests.swift
@@ -6,6 +6,26 @@ import Testing
 @MainActor
 struct RefreshAndBackoffTests {
     @Test
+    func `pasteboard polling backs off when unchanged and resets after activity`() {
+        var cadence = PasteboardPollCadence()
+        #expect(cadence.nextInterval == .seconds(1))
+        #expect(cadence.nextLeeway == .milliseconds(500))
+
+        for _ in 0 ..< 4 {
+            cadence.record(didChange: false)
+        }
+        #expect(cadence.nextInterval == .seconds(1))
+
+        cadence.record(didChange: false)
+        #expect(cadence.nextInterval == .seconds(5))
+        #expect(cadence.nextLeeway == .seconds(2))
+
+        cadence.record(didChange: true)
+        #expect(cadence.nextInterval == .seconds(1))
+        #expect(cadence.nextLeeway == .milliseconds(500))
+    }
+
+    @Test
     func `force refresh triggers tick`() {
         let scheduler = RefreshScheduler()
         var fired = false


### PR DESCRIPTION
## Summary

- back off the opt-in clipboard watcher from one-second to five-second polls after five unchanged checks
- restore one-second polling as soon as clipboard activity is observed
- cover cadence transitions and document the idle-efficiency improvement

## Measurements

Identical 20-second settled-idle windows with the GitHub reference watcher enabled:

| Build | Interrupt wakeups | Average CPU |
| --- | ---: | ---: |
| `main` | 20 | 0.0018% |
| patched | 6 | 0.0006% |

Time Profiler traces confirmed the app was otherwise blocked at idle. The patched result cuts observed wakeups by 70% and returns average CPU to the disabled-watcher baseline.

## Verification

- `pnpm test --filter RefreshAndBackoffTests` (15 tests)
- `pnpm check` (661 tests; format and lint clean)
- `autoreview --mode local --stream-engine-output` (clean; no actionable findings)
- debug app launch and checkout-path verification
