### PR TITLE
Reimagine repobar.app website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.8.6 - Unreleased
 
+- Reimagine the repobar.app website as a dark, menu-bar-themed page with a live menu mockup, a contribution-graph wordmark, current features like the reference monitor and multi-account support, and the corrected macOS 15 minimum system requirement.
+
 ## 0.8.5 - 2026-07-05
 
 - Restore the signed-in account immediately after restarting RepoBar when its persisted credentials are still available.

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,7 +8,7 @@
       name="description"
       content="RepoBar is a native macOS menu bar app for tracking your GitHub repositories: CI state, issues, pull requests, releases, local Git state, and rate limits — without opening a browser."
     />
-    <meta name="theme-color" content="#f4f0e8" />
+    <meta name="theme-color" content="#0a0e13" />
     <meta property="og:title" content="RepoBar — GitHub at a glance, from your menu bar" />
     <meta
       property="og:description"
@@ -18,83 +18,62 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://repobar.app/" />
     <meta name="twitter:card" content="summary_large_image" />
-    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%23ff6b2d'/%3E%3Ctext x='50%25' y='54%25' text-anchor='middle' fill='%23141414' font-family='Georgia,serif' font-size='34' font-weight='700'%3ERB%3C/text%3E%3C/svg%3E" />
-    <script>
-      (function () {
-        try {
-          var stored = localStorage.getItem("repobar-theme");
-          var prefers =
-            window.matchMedia &&
-            window.matchMedia("(prefers-color-scheme: dark)").matches;
-          var theme = stored || (prefers ? "dark" : "light");
-          document.documentElement.setAttribute("data-theme", theme);
-        } catch (e) {}
-      })();
-    </script>
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='14' fill='%230d1117'/%3E%3Crect x='12' y='12' width='18' height='18' rx='4' fill='%23196c2e'/%3E%3Crect x='34' y='12' width='18' height='18' rx='4' fill='%2326a641'/%3E%3Crect x='12' y='34' width='18' height='18' rx='4' fill='%2339d353'/%3E%3Crect x='34' y='34' width='18' height='18' rx='4' fill='%230e4429'/%3E%3C/svg%3E" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700;9..144,900&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Instrument+Sans:ital,wght@0,400;0,500;0,600;1,400&family=Geist+Mono:wght@400;500;600&display=swap"
       rel="stylesheet"
     />
+    <script>
+      document.documentElement.classList.add("js");
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "RepoBar",
+        "operatingSystem": "macOS 15.0 or later",
+        "applicationCategory": "DeveloperApplication",
+        "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+        "license": "https://github.com/steipete/RepoBar/blob/main/LICENSE",
+        "url": "https://repobar.app/",
+        "image": "https://repobar.app/assets/repobar.png",
+        "author": { "@type": "Person", "name": "Peter Steinberger", "url": "https://steipete.me/" }
+      }
+    </script>
     <style>
       :root {
-        color-scheme: light;
-        --paper: #f5f6f7;
-        --paper-warm: #ffffff;
-        --ink: #14161a;
-        --ink-soft: #2a2d33;
-        --ink-muted: #5b6068;
-        --accent: #ff6b2d;
-        --accent-dark: #cf4c1a;
-        --amber: #f5a623;
-        --olive: #5d6b3a;
-        --line: #14161a;
-        --line-soft: rgba(20, 22, 26, 0.12);
-        --panel: #ffffff;
-        --panel-soft: #fafbfc;
-        --grid-line: rgba(20, 22, 26, 0.045);
-        --shadow-lg: 0 28px 60px rgba(20, 22, 26, 0.08);
-        --shadow-md: 0 14px 36px rgba(20, 22, 26, 0.06);
-        --shadow-sm: 0 6px 18px rgba(20, 22, 26, 0.04);
-        --radius: 18px;
-        --radius-sm: 12px;
-        color-scheme: light;
-      }
-
-      [data-theme="dark"] {
         color-scheme: dark;
-        --paper: #0e0c0b;
-        --paper-warm: #14110f;
-        --ink: #f3ead9;
-        --ink-soft: #d8cfbb;
-        --ink-muted: #968a78;
-        --accent: #ff8350;
-        --accent-dark: #ff6b2d;
-        --line: rgba(243, 234, 217, 0.22);
-        --line-soft: rgba(243, 234, 217, 0.10);
-        --panel: #14110f;
-        --panel-soft: #1a1715;
-        --grid-line: rgba(243, 234, 217, 0.05);
-        --shadow-lg: 0 28px 60px rgba(0, 0, 0, 0.55);
-        --shadow-md: 0 14px 36px rgba(0, 0, 0, 0.4);
-        --shadow-sm: 0 6px 18px rgba(0, 0, 0, 0.3);
+        --bg: #0a0e13;
+        --bg-deep: #070a0e;
+        --ink: #e9eef4;
+        --ink-soft: #b4bfca;
+        --ink-muted: #7d8894;
+        --hairline: rgba(255, 255, 255, 0.09);
+        --hairline-soft: rgba(255, 255, 255, 0.055);
+        --panel: rgba(22, 27, 34, 0.62);
+        --panel-solid: #10151c;
+        --g0: rgba(255, 255, 255, 0.055);
+        --g1: #0e4429;
+        --g2: #006d32;
+        --g3: #26a641;
+        --g4: #39d353;
+        --green: #3fb950;
+        --green-bright: #39d353;
+        --blue: #2f81f7;
+        --select: linear-gradient(180deg, #3577f0, #2360d8);
+        --amber: #ffc832;
+        --red: #ff6459;
+        --serif: "Instrument Serif", "Times New Roman", serif;
+        --sans: "Instrument Sans", "Helvetica Neue", sans-serif;
+        --mono: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+        --menubar-h: 42px;
+        --radius: 14px;
       }
 
       * {
         box-sizing: border-box;
-      }
-
-      img,
-      svg,
-      video {
-        max-width: 100%;
-      }
-
-      code,
-      pre,
-      a {
-        overflow-wrap: anywhere;
       }
 
       html {
@@ -103,534 +82,886 @@
 
       body {
         margin: 0;
-        font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-          "Liberation Mono", "Courier New", monospace;
+        background: var(--bg);
         color: var(--ink);
-        background: var(--paper);
-        min-height: 100vh;
-        position: relative;
+        font-family: var(--sans);
+        font-size: 16px;
+        line-height: 1.6;
         overflow-x: hidden;
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
-        transition: background-color 0.25s ease, color 0.25s ease;
       }
 
-      body::before {
-        content: "";
+      img,
+      svg {
+        max-width: 100%;
+      }
+
+      a {
+        color: inherit;
+      }
+
+      ::selection {
+        background: rgba(57, 211, 83, 0.28);
+      }
+
+      /* Atmosphere: aurora glow + faint dot grid, echoing the app's wallpaper */
+      .sky {
         position: fixed;
         inset: 0;
-        pointer-events: none;
-        background-image:
-          linear-gradient(to right, var(--grid-line) 1px, transparent 1px),
-          linear-gradient(to bottom, var(--grid-line) 1px, transparent 1px);
-        background-size: 64px 64px;
         z-index: 0;
-        transition: background-image 0.25s ease;
+        pointer-events: none;
+        background:
+          radial-gradient(1100px 620px at 82% -10%, rgba(31, 111, 235, 0.16), transparent 62%),
+          radial-gradient(900px 560px at 8% 4%, rgba(35, 134, 54, 0.14), transparent 60%),
+          radial-gradient(760px 700px at 50% 108%, rgba(13, 60, 97, 0.22), transparent 65%);
       }
 
-      body::after {
+      .sky::after {
         content: "";
-        position: fixed;
+        position: absolute;
         inset: 0;
-        pointer-events: none;
-        background:
-          radial-gradient(900px 520px at 8% -4%, rgba(255, 107, 45, 0.05), transparent 60%),
-          radial-gradient(700px 460px at 96% 4%, rgba(245, 166, 35, 0.04), transparent 65%);
-        z-index: 0;
-        transition: opacity 0.25s ease;
+        background-image: radial-gradient(rgba(233, 238, 244, 0.05) 1px, transparent 1px);
+        background-size: 26px 26px;
+        mask-image: radial-gradient(1200px 800px at 50% 0%, #000 30%, transparent 80%);
+        -webkit-mask-image: radial-gradient(1200px 800px at 50% 0%, #000 30%, transparent 80%);
       }
 
-      [data-theme="dark"] body::after {
-        background:
-          radial-gradient(900px 520px at 8% -4%, rgba(255, 131, 80, 0.08), transparent 60%),
-          radial-gradient(700px 460px at 96% 4%, rgba(245, 166, 35, 0.05), transparent 65%);
-      }
-
-      .frame {
-        max-width: 1180px;
-        margin: 0 auto;
-        padding: 36px 28px 80px;
-        position: relative;
-        z-index: 1;
-      }
-
-      /* ---------- Header ---------- */
-      header {
+      /* ---------- The menu bar (site nav) ---------- */
+      .menubar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: var(--menubar-h);
         display: flex;
         align-items: center;
-        justify-content: space-between;
-        gap: 20px;
-        border: 1px solid var(--line);
-        padding: 12px 16px;
-        background: var(--panel);
-        border-radius: 999px;
-        box-shadow: var(--shadow-md);
-        position: sticky;
-        top: 18px;
-        z-index: 10;
-        backdrop-filter: blur(8px);
-      }
-
-      .logo {
-        display: flex;
-        align-items: center;
-        gap: 12px;
-        font-family: "Fraunces", "Times New Roman", serif;
-        font-size: 22px;
-        font-weight: 700;
-        letter-spacing: 0.01em;
-      }
-
-      .logo-badge {
-        width: 36px;
-        height: 36px;
-        border-radius: 12px;
-        background: conic-gradient(from 220deg, var(--accent), #ffb01f, #ffc86d, var(--accent));
-        border: 1px solid var(--line);
-        display: grid;
-        place-items: center;
-        color: var(--ink);
-        font-weight: 700;
-        font-size: 14px;
-        font-family: "IBM Plex Mono", monospace;
-      }
-
-      nav.top-nav {
-        display: flex;
         gap: 4px;
+        padding: 0 14px;
+        background: rgba(13, 17, 23, 0.72);
+        backdrop-filter: blur(18px) saturate(1.4);
+        -webkit-backdrop-filter: blur(18px) saturate(1.4);
+        border-bottom: 1px solid var(--hairline);
+        z-index: 50;
+        font-family: var(--mono);
+        font-size: 12.5px;
+      }
+
+      .menubar .wordmark {
+        display: flex;
         align-items: center;
-      }
-
-      nav.top-nav a {
-        font-size: 11px;
-        text-transform: uppercase;
-        letter-spacing: 0.16em;
-        color: var(--ink-muted);
+        gap: 9px;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        color: var(--ink);
         text-decoration: none;
-        padding: 8px 12px;
-        border-radius: 999px;
-        transition: background 0.15s ease, color 0.15s ease;
+        padding: 4px 8px 4px 2px;
       }
 
-      nav.top-nav a:hover {
-        background: var(--paper-warm);
+      .menubar .glyph {
+        display: grid;
+        grid-template-columns: repeat(2, 7px);
+        grid-auto-rows: 7px;
+        gap: 2px;
+      }
+
+      .menubar .glyph i {
+        border-radius: 2px;
+      }
+
+      .menubar .glyph i:nth-child(1) { background: var(--g2); }
+      .menubar .glyph i:nth-child(2) { background: var(--g4); }
+      .menubar .glyph i:nth-child(3) { background: var(--g3); }
+      .menubar .glyph i:nth-child(4) { background: var(--g1); }
+
+      .menubar nav {
+        display: flex;
+        align-items: center;
+        gap: 2px;
+      }
+
+      .menubar nav a {
+        color: var(--ink-soft);
+        text-decoration: none;
+        padding: 5px 10px;
+        border-radius: 6px;
+        transition: background 0.12s ease, color 0.12s ease;
+      }
+
+      .menubar nav a:hover {
+        background: rgba(255, 255, 255, 0.1);
         color: var(--ink);
       }
 
-      .nav-cta {
-        background: var(--ink) !important;
-        color: var(--paper) !important;
-        border: 1px solid var(--line);
-        margin-left: 6px;
+      .menubar .spacer {
+        flex: 1;
       }
 
-      .nav-cta:hover {
-        background: var(--accent-dark) !important;
-        color: #fff !important;
-      }
-
-      .theme-toggle {
-        width: 36px;
-        height: 36px;
-        border-radius: 999px;
-        border: 1px solid var(--line-soft);
-        background: var(--paper-warm);
+      .menubar .ticker {
         color: var(--ink-muted);
-        display: inline-grid;
-        place-items: center;
-        cursor: pointer;
-        margin: 0 4px 0 6px;
-        padding: 0;
-        transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 5px 10px;
+        border-radius: 6px;
+        white-space: nowrap;
+        overflow: hidden;
       }
 
-      .theme-toggle:hover {
-        background: var(--panel-soft);
+      .menubar .ticker .led {
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: var(--green-bright);
+        box-shadow: 0 0 8px rgba(57, 211, 83, 0.7);
+        flex: 0 0 auto;
+      }
+
+      .menubar .ticker span {
+        transition: opacity 0.35s ease;
+      }
+
+      .menubar .ticker span.fade {
+        opacity: 0;
+      }
+
+      .menubar .gh {
+        display: inline-flex;
+        align-items: center;
+        padding: 5px 8px;
+        border-radius: 6px;
+        color: var(--ink-soft);
+        transition: background 0.12s ease, color 0.12s ease;
+      }
+
+      .menubar .gh:hover {
+        background: rgba(255, 255, 255, 0.1);
         color: var(--ink);
-        border-color: var(--line);
-        transform: rotate(-12deg);
       }
 
-      .theme-toggle:focus-visible {
-        outline: 2px solid var(--accent);
-        outline-offset: 2px;
+      .menubar .gh svg {
+        width: 15px;
+        height: 15px;
       }
 
-      .theme-toggle svg {
-        width: 16px;
-        height: 16px;
+      .menubar .clock {
+        color: var(--ink-soft);
+        padding: 5px 4px 5px 8px;
+        font-variant-numeric: tabular-nums;
+        white-space: nowrap;
       }
 
-      .theme-toggle .icon-moon {
-        display: none;
-      }
-
-      [data-theme="dark"] .theme-toggle .icon-sun {
-        display: none;
-      }
-
-      [data-theme="dark"] .theme-toggle .icon-moon {
-        display: block;
-      }
-
-      @media (max-width: 760px) {
-        .frame {
-          padding: 18px 14px 56px;
-        }
-
-        header {
-          top: 10px;
-          gap: 10px;
-          padding: 10px 12px;
-          max-width: 100%;
-        }
-
-        .logo {
-          min-width: 0;
-          font-size: 18px;
-        }
-
-        .logo-badge {
-          width: 32px;
-          height: 32px;
-          border-radius: 10px;
-          flex: 0 0 auto;
-        }
-
-        nav.top-nav {
-          min-width: 0;
-          flex: 0 0 auto;
-        }
-
-        nav.top-nav a:not(.nav-cta) {
+      @media (max-width: 900px) {
+        .menubar nav {
           display: none;
         }
-
-        .nav-cta {
-          margin-left: 2px;
-          padding-inline: 14px;
+        .menubar .ticker {
+          display: none;
         }
+      }
 
-        .theme-toggle {
-          width: 34px;
-          height: 34px;
-          margin: 0 2px;
-          flex: 0 0 auto;
+      /* ---------- Frame ---------- */
+      .frame {
+        position: relative;
+        z-index: 1;
+        max-width: 1160px;
+        margin: 0 auto;
+        padding: calc(var(--menubar-h) + 64px) 28px 90px;
+      }
+
+      section {
+        margin-top: 130px;
+        scroll-margin-top: calc(var(--menubar-h) + 28px);
+      }
+
+      /* Scroll reveal — hidden state only applies when JS is running (html.js) */
+      html.js .reveal {
+        opacity: 0;
+        transform: translateY(22px);
+        transition: opacity 0.7s ease, transform 0.7s cubic-bezier(0.22, 0.9, 0.3, 1);
+      }
+
+      html.js .reveal.in {
+        opacity: 1;
+        transform: none;
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        html {
+          scroll-behavior: auto;
+        }
+        html.js .reveal {
+          opacity: 1;
+          transform: none;
+          transition: none;
         }
       }
 
       /* ---------- Hero ---------- */
       .hero {
-        margin-top: 56px;
         display: grid;
-        grid-template-columns: minmax(300px, 1.05fr) minmax(300px, 1fr);
-        gap: 56px;
+        grid-template-columns: minmax(320px, 1.12fr) minmax(300px, 0.88fr);
+        gap: 64px;
+        align-items: start;
+      }
+
+      .eyebrow {
+        font-family: var(--mono);
+        font-size: 12px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--green-bright);
+        display: flex;
         align-items: center;
-        min-width: 0;
+        gap: 12px;
+        margin-bottom: 26px;
       }
 
-      .hero h1 {
-        font-family: "Fraunces", "Times New Roman", serif;
-        font-size: clamp(40px, 5.6vw, 72px);
-        line-height: 0.98;
-        margin: 0 0 22px;
-        letter-spacing: -0.015em;
-        font-weight: 600;
+      .eyebrow::before {
+        content: "";
+        width: 30px;
+        height: 1px;
+        background: var(--green-bright);
+        opacity: 0.6;
       }
 
-      .hero h1 em {
+      h1 {
+        font-family: var(--serif);
+        font-weight: 400;
+        font-size: clamp(46px, 6.4vw, 84px);
+        line-height: 1.0;
+        letter-spacing: -0.01em;
+        margin: 0 0 26px;
+      }
+
+      h1 em {
         font-style: italic;
-        color: var(--accent-dark);
-        font-weight: 600;
-      }
-
-      .hero h1 .strike {
-        text-decoration: line-through;
-        text-decoration-color: var(--accent);
-        text-decoration-thickness: 4px;
-        color: var(--ink-muted);
+        color: var(--green-bright);
       }
 
       .hero-lead {
-        font-size: 16px;
+        font-size: 18px;
         line-height: 1.65;
         color: var(--ink-soft);
-        margin: 0 0 28px;
-        max-width: 52ch;
+        max-width: 54ch;
+        margin: 0 0 32px;
       }
 
-      .hero-bullets {
-        margin: 0 0 30px;
-        padding: 0;
-        list-style: none;
-        display: grid;
-        gap: 10px;
-      }
-
-      .hero-bullets li {
-        display: flex;
-        gap: 12px;
-        align-items: baseline;
-        font-size: 14px;
-        line-height: 1.55;
-      }
-
-      .hero-bullets li span {
-        color: var(--accent-dark);
-        font-weight: 600;
-        font-feature-settings: "tnum" 1;
-        min-width: 26px;
+      .hero-lead b {
+        color: var(--ink);
+        font-weight: 500;
       }
 
       .cta-row {
         display: flex;
         flex-wrap: wrap;
-        gap: 12px;
+        gap: 14px;
         align-items: center;
+        margin-bottom: 22px;
       }
 
-      .button {
+      .btn {
         display: inline-flex;
         align-items: center;
         gap: 10px;
-        padding: 13px 20px;
-        border-radius: 999px;
-        border: 1px solid var(--line);
-        background: var(--ink);
-        color: var(--paper);
-        font-size: 12px;
+        font-family: var(--mono);
+        font-size: 13px;
         font-weight: 500;
         text-decoration: none;
-        letter-spacing: 0.1em;
-        text-transform: uppercase;
-        box-shadow: 0 12px 30px rgba(20, 20, 20, 0.2);
-        transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+        padding: 13px 22px;
+        border-radius: 10px;
+        border: 1px solid transparent;
+        transition: transform 0.16s ease, box-shadow 0.16s ease, background 0.16s ease, border-color 0.16s ease;
       }
 
-      .button:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 18px 36px rgba(20, 20, 20, 0.25);
-      }
-
-      .button.secondary {
-        background: var(--panel);
-        color: var(--ink);
-      }
-
-      .button.secondary:hover {
-        background: var(--paper-warm);
-      }
-
-      .button svg {
+      .btn svg {
         width: 16px;
         height: 16px;
       }
 
-      /* Hero panel (screenshot) */
-      .hero-panel {
-        position: relative;
-        background: var(--panel);
-        border: 1px solid var(--line);
-        border-radius: var(--radius);
-        padding: 14px;
-        box-shadow: var(--shadow-lg);
-        transform: rotate(0.6deg);
+      .btn.primary {
+        background: linear-gradient(180deg, #34c04f, #219a3d);
+        color: #04180a;
+        box-shadow: 0 10px 30px rgba(46, 160, 67, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.25);
       }
 
-      .hero-panel::before {
-        content: "";
-        position: absolute;
-        inset: -10px -14px;
-        border: 1px dashed var(--line);
-        border-radius: 26px;
-        z-index: -1;
-        transform: rotate(-1.4deg);
-        opacity: 0.5;
+      .btn.primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 16px 38px rgba(46, 160, 67, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.25);
       }
 
-      .hero-panel img {
-        width: 100%;
-        display: block;
-        border-radius: 12px;
-        border: 1px solid var(--line-soft);
-        background: #f8f8f8;
+      .btn.ghost {
+        background: rgba(255, 255, 255, 0.06);
+        border-color: var(--hairline);
+        color: var(--ink);
       }
 
-      .hero-tag {
-        position: absolute;
-        bottom: -18px;
-        left: 14px;
-        background: var(--ink);
-        color: var(--paper-warm);
-        padding: 7px 14px;
-        border-radius: 999px;
-        font-size: 10px;
-        text-transform: uppercase;
-        letter-spacing: 0.18em;
-        box-shadow: var(--shadow-md);
-        border: 1px solid var(--line);
+      .btn.ghost:hover {
+        background: rgba(255, 255, 255, 0.1);
+        transform: translateY(-2px);
       }
 
-      .hero-stamp {
-        position: absolute;
-        top: -22px;
-        right: -12px;
-        width: 90px;
-        height: 90px;
-        background: var(--accent);
-        color: #1a0e07;
-        border-radius: 50%;
-        display: grid;
-        place-items: center;
-        font-family: "Fraunces", serif;
-        font-style: italic;
-        font-weight: 700;
-        line-height: 1.05;
-        text-align: center;
+      .brew-line {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        font-family: var(--mono);
         font-size: 13px;
-        border: 2px solid var(--line);
-        transform: rotate(-12deg);
-        box-shadow: var(--shadow-md);
+        color: var(--ink-soft);
+        background: rgba(0, 0, 0, 0.42);
+        border: 1px solid var(--hairline);
+        border-radius: 10px;
+        padding: 11px 8px 11px 16px;
+        max-width: 100%;
       }
 
-      /* ---------- Section primitives ---------- */
-      section {
-        margin-top: 110px;
+      .brew-line .dollar {
+        color: var(--green-bright);
+        user-select: none;
+      }
+
+      .brew-line code {
+        color: var(--ink);
+        white-space: nowrap;
+        overflow-x: auto;
+        scrollbar-width: none;
+      }
+
+      .copy-btn {
+        flex: 0 0 auto;
+        width: 30px;
+        height: 30px;
+        display: inline-grid;
+        place-items: center;
+        background: rgba(255, 255, 255, 0.07);
+        border: 1px solid var(--hairline);
+        border-radius: 7px;
+        color: var(--ink-soft);
+        cursor: pointer;
+        transition: background 0.14s ease, color 0.14s ease, border-color 0.14s ease;
+      }
+
+      .copy-btn:hover {
+        background: rgba(255, 255, 255, 0.13);
+        color: var(--ink);
+      }
+
+      .copy-btn:focus-visible {
+        outline: 2px solid var(--green-bright);
+        outline-offset: 2px;
+      }
+
+      .copy-btn svg {
+        width: 14px;
+        height: 14px;
+      }
+
+      .copy-btn.copied {
+        background: rgba(57, 211, 83, 0.2);
+        border-color: rgba(57, 211, 83, 0.5);
+        color: var(--green-bright);
+      }
+
+      .fine-print {
+        font-family: var(--mono);
+        font-size: 12px;
+        color: var(--ink-muted);
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px 18px;
+      }
+
+      .fine-print span::before {
+        content: "✓ ";
+        color: var(--green);
+      }
+
+      /* ---------- The mock dropdown ---------- */
+      .mock-wrap {
         position: relative;
+        justify-self: end;
+        width: min(380px, 100%);
       }
 
-      .section-tag {
+      .mock-wrap .from-bar {
+        position: absolute;
+        top: -34px;
+        right: 26px;
+        font-family: var(--mono);
+        font-size: 11px;
+        color: var(--ink-muted);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .mock-wrap .from-bar::after {
+        content: "▾";
+        margin-left: 6px;
+        color: var(--green-bright);
+      }
+
+      .mock {
+        background: rgba(19, 25, 33, 0.86);
+        backdrop-filter: blur(22px) saturate(1.3);
+        -webkit-backdrop-filter: blur(22px) saturate(1.3);
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        border-radius: 16px;
+        box-shadow:
+          0 40px 90px rgba(0, 0, 0, 0.6),
+          0 4px 16px rgba(0, 0, 0, 0.4),
+          inset 0 1px 0 rgba(255, 255, 255, 0.07);
+        padding: 10px;
+        font-family: var(--mono);
+        font-size: 12px;
+      }
+
+      .mock-contrib {
+        padding: 10px 10px 12px;
+        border-bottom: 1px solid var(--hairline-soft);
+      }
+
+      .mock-contrib .label {
+        display: flex;
+        justify-content: space-between;
+        color: var(--ink-muted);
+        font-size: 11px;
+        margin-bottom: 9px;
+      }
+
+      .mini-heatmap {
+        display: grid;
+        grid-template-rows: repeat(7, 1fr);
+        grid-auto-flow: column;
+        grid-auto-columns: 1fr;
+        gap: 2.5px;
+        height: 58px;
+      }
+
+      .mini-heatmap i {
+        border-radius: 2px;
+        background: var(--g0);
+      }
+
+      .mini-heatmap i.l1 { background: var(--g1); }
+      .mini-heatmap i.l2 { background: var(--g2); }
+      .mini-heatmap i.l3 { background: var(--g3); }
+      .mini-heatmap i.l4 { background: var(--g4); }
+
+      .mock-filters {
+        display: flex;
+        gap: 4px;
+        padding: 10px;
+        border-bottom: 1px solid var(--hairline-soft);
+      }
+
+      .mock-filters span {
+        padding: 4px 11px;
+        border-radius: 7px;
+        color: var(--ink-muted);
+        font-size: 11.5px;
+      }
+
+      .mock-filters span.on {
+        background: rgba(255, 255, 255, 0.12);
+        color: var(--ink);
+      }
+
+      .mock-repo {
+        padding: 10px 10px 11px;
+        border-radius: 9px;
+        display: grid;
+        gap: 5px;
+        margin: 3px 2px;
+      }
+
+      .mock-repo.selected {
+        background: var(--select);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
+      }
+
+      .mock-repo .row1 {
         display: flex;
         align-items: center;
-        gap: 14px;
-        font-size: 11px;
-        text-transform: uppercase;
-        letter-spacing: 0.22em;
-        color: var(--ink-muted);
-        margin-bottom: 18px;
-      }
-
-      .section-tag::before {
-        content: "";
-        width: 36px;
-        height: 1px;
-        background: var(--ink-muted);
-      }
-
-      .section-title {
-        font-family: "Fraunces", serif;
+        gap: 8px;
         font-weight: 600;
-        font-size: clamp(32px, 4vw, 50px);
-        line-height: 1.05;
-        margin: 0 0 18px;
-        letter-spacing: -0.01em;
+        font-size: 12.5px;
+        color: var(--ink);
       }
 
-      .section-title em {
+      .mock-repo .row1 .when {
+        margin-left: auto;
+        font-weight: 400;
+        font-size: 11px;
+        color: var(--ink-muted);
+      }
+
+      .mock-repo.selected .row1 .when,
+      .mock-repo.selected .stats,
+      .mock-repo.selected .branch {
+        color: rgba(255, 255, 255, 0.82);
+      }
+
+      .ci-dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        flex: 0 0 auto;
+        background: var(--green-bright);
+      }
+
+      .ci-dot.running {
+        background: var(--amber);
+        animation: pulse 1.1s ease-in-out infinite;
+      }
+
+      @keyframes pulse {
+        0%, 100% { box-shadow: 0 0 0 0 rgba(255, 200, 50, 0.55); }
+        50% { box-shadow: 0 0 0 6px rgba(255, 200, 50, 0); }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .ci-dot.running {
+          animation: none;
+        }
+      }
+
+      .mock-repo .stats {
+        color: var(--ink-muted);
+        font-size: 11.5px;
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+
+      .mock-repo .branch {
+        color: var(--ink-soft);
+        font-size: 11.5px;
+      }
+
+      .mock-repo .branch b {
+        color: var(--green-bright);
+        font-weight: 500;
+      }
+
+      .mock-repo.selected .branch b {
+        color: #b8ffcb;
+      }
+
+      .mock-foot {
+        display: flex;
+        justify-content: space-between;
+        padding: 11px 12px 6px;
+        border-top: 1px solid var(--hairline-soft);
+        margin-top: 4px;
+        color: var(--ink-muted);
+        font-size: 11.5px;
+      }
+
+      .mock-foot kbd {
+        font-family: var(--mono);
+        color: var(--ink-soft);
+      }
+
+      @media (max-width: 980px) {
+        .hero {
+          grid-template-columns: 1fr;
+          gap: 72px;
+        }
+        .mock-wrap {
+          justify-self: center;
+        }
+      }
+
+      /* ---------- Year-in-green strip ---------- */
+      .yearline {
+        margin-top: 120px;
+        text-align: center;
+      }
+
+      .yeargrid {
+        /* 47 columns must fit the viewport: min(cap, fluid share of width) */
+        --cell: min(13px, calc((100vw - 224px) / 47));
+        display: inline-grid;
+        grid-template-rows: repeat(7, var(--cell));
+        grid-auto-flow: column;
+        grid-auto-columns: var(--cell);
+        gap: 3px;
+        padding: 22px;
+        border: 1px solid var(--hairline-soft);
+        border-radius: var(--radius);
+        background: rgba(0, 0, 0, 0.28);
+        max-width: 100%;
+        overflow: hidden;
+      }
+
+      .yeargrid i {
+        border-radius: 2.5px;
+        background: var(--g0);
+      }
+
+      .yeargrid i.l1 { background: var(--g1); }
+      .yeargrid i.l2 { background: var(--g2); }
+      .yeargrid i.l3 { background: var(--g3); }
+      .yeargrid i.l4 { background: var(--g4); }
+
+      .yeargrid.animate i.lit {
+        opacity: 0;
+        animation: cell-in 0.5s ease forwards;
+        animation-delay: var(--d, 0s);
+      }
+
+      @keyframes cell-in {
+        from {
+          opacity: 0;
+          transform: scale(0.4);
+        }
+        to {
+          opacity: 1;
+          transform: scale(1);
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .yeargrid.animate i.lit {
+          opacity: 1;
+          animation: none;
+        }
+      }
+
+      @media (max-width: 640px) {
+        .yeargrid {
+          --cell: calc((100vw - 160px) / 47);
+          gap: 2px;
+          padding: 14px;
+        }
+      }
+
+      .yearline .caption {
+        margin-top: 16px;
+        font-family: var(--mono);
+        font-size: 12px;
+        color: var(--ink-muted);
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+      }
+
+      /* ---------- Section headings ---------- */
+      .kicker {
+        font-family: var(--mono);
+        font-size: 12px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--green-bright);
+        margin-bottom: 18px;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .kicker::before {
+        content: "";
+        width: 30px;
+        height: 1px;
+        background: var(--green-bright);
+        opacity: 0.6;
+      }
+
+      h2 {
+        font-family: var(--serif);
+        font-weight: 400;
+        font-size: clamp(34px, 4.4vw, 56px);
+        line-height: 1.04;
+        letter-spacing: -0.008em;
+        margin: 0 0 20px;
+      }
+
+      h2 em {
         font-style: italic;
-        color: var(--accent-dark);
+        color: var(--green-bright);
       }
 
-      .section-lead {
-        font-size: 15px;
+      .lead {
+        font-size: 16.5px;
         line-height: 1.7;
         color: var(--ink-soft);
         max-width: 64ch;
         margin: 0;
       }
 
-      /* ---------- Datasheet grid ---------- */
-      .datasheet {
-        margin-top: 36px;
+      .lead a,
+      .answer a {
+        color: var(--green-bright);
+        text-decoration: underline;
+        text-decoration-color: rgba(57, 211, 83, 0.4);
+        text-underline-offset: 3px;
+      }
+
+      .lead code,
+      .answer code {
+        font-family: var(--mono);
+        font-size: 0.85em;
+        background: rgba(255, 255, 255, 0.07);
+        border: 1px solid var(--hairline-soft);
+        padding: 1px 6px;
+        border-radius: 5px;
+      }
+
+      /* ---------- Feature menus ---------- */
+      .menus {
+        margin-top: 44px;
         display: grid;
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-        gap: 0;
-        border: 1px solid var(--line);
-        border-radius: var(--radius);
-        background: var(--panel);
-        overflow: hidden;
-        box-shadow: var(--shadow-md);
-        min-width: 0;
-      }
-
-      .datasheet .cell {
-        padding: 26px 24px;
-        border-right: 1px solid var(--line-soft);
-        border-bottom: 1px solid var(--line-soft);
-        display: flex;
-        flex-direction: column;
-        gap: 12px;
-        background: var(--panel);
-        position: relative;
-      }
-
-      .datasheet .cell:nth-child(3n) {
-        border-right: none;
-      }
-
-      .datasheet .cell:nth-last-child(-n + 3) {
-        border-bottom: none;
-      }
-
-      .cell-num {
-        font-size: 11px;
-        color: var(--accent-dark);
-        font-weight: 600;
-        letter-spacing: 0.18em;
-      }
-
-      .cell-title {
-        font-family: "Fraunces", serif;
-        font-size: 22px;
-        line-height: 1.15;
-        font-weight: 600;
-        margin: 0;
-      }
-
-      .cell-body {
-        font-size: 13px;
-        line-height: 1.6;
-        color: var(--ink-soft);
-        margin: 0;
-      }
-
-      .cell-icon {
-        position: absolute;
-        top: 22px;
-        right: 22px;
-        width: 28px;
-        height: 28px;
-        color: var(--ink-muted);
-        opacity: 0.55;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 22px;
+        align-items: start;
       }
 
       @media (max-width: 880px) {
-        .datasheet {
+        .menus {
           grid-template-columns: 1fr;
-        }
-        .datasheet .cell {
-          border-right: none;
-          border-bottom: 1px solid var(--line-soft);
-        }
-        .datasheet .cell:last-child {
-          border-bottom: none;
         }
       }
 
-      /* ---------- Two column ---------- */
+      .menu-panel {
+        background: var(--panel);
+        backdrop-filter: blur(16px);
+        -webkit-backdrop-filter: blur(16px);
+        border: 1px solid var(--hairline);
+        border-radius: 16px;
+        padding: 8px;
+        box-shadow: 0 24px 60px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.05);
+      }
+
+      .menu-panel .panel-title {
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--ink-muted);
+        padding: 10px 14px 8px;
+        border-bottom: 1px solid var(--hairline-soft);
+        margin-bottom: 4px;
+      }
+
+      .menu-item {
+        display: grid;
+        grid-template-columns: 34px 1fr auto;
+        gap: 0 12px;
+        align-items: start;
+        padding: 13px 12px;
+        border-radius: 10px;
+        transition: background 0.13s ease;
+      }
+
+      .menu-item:hover {
+        background: rgba(47, 129, 247, 0.16);
+      }
+
+      .menu-item .icon {
+        width: 34px;
+        height: 34px;
+        border-radius: 9px;
+        display: grid;
+        place-items: center;
+        background: rgba(57, 211, 83, 0.1);
+        border: 1px solid rgba(57, 211, 83, 0.22);
+        color: var(--green-bright);
+        grid-row: span 2;
+      }
+
+      .menu-item .icon svg {
+        width: 17px;
+        height: 17px;
+      }
+
+      .menu-item h3 {
+        font-family: var(--sans);
+        font-size: 16px;
+        font-weight: 600;
+        margin: 1px 0 3px;
+        line-height: 1.3;
+      }
+
+      .menu-item .chev {
+        color: var(--ink-muted);
+        font-family: var(--mono);
+        font-size: 13px;
+        padding-top: 3px;
+        grid-row: span 2;
+      }
+
+      .menu-item p {
+        grid-column: 2 / 4;
+        margin: 0;
+        font-size: 13.5px;
+        line-height: 1.55;
+        color: var(--ink-soft);
+      }
+
+      .browse-strip {
+        margin-top: 26px;
+        font-family: var(--mono);
+        font-size: 12.5px;
+        color: var(--ink-muted);
+        line-height: 2.1;
+      }
+
+      .browse-strip b {
+        font-weight: 500;
+        color: var(--ink-soft);
+        background: rgba(255, 255, 255, 0.06);
+        border: 1px solid var(--hairline-soft);
+        padding: 3px 10px;
+        border-radius: 999px;
+        margin-right: 6px;
+        white-space: nowrap;
+      }
+
+      /* ---------- Screenshot ---------- */
+      .shot {
+        margin-top: 44px;
+        position: relative;
+        border-radius: 20px;
+        border: 1px solid var(--hairline);
+        background: rgba(0, 0, 0, 0.35);
+        padding: 12px;
+        box-shadow: 0 50px 110px rgba(0, 0, 0, 0.55);
+      }
+
+      .shot img {
+        display: block;
+        width: 100%;
+        border-radius: 12px;
+      }
+
+      .shot .tag {
+        position: absolute;
+        top: -14px;
+        left: 26px;
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        background: var(--green-bright);
+        color: #04180a;
+        font-weight: 600;
+        padding: 6px 13px;
+        border-radius: 999px;
+        box-shadow: 0 8px 22px rgba(57, 211, 83, 0.35);
+      }
+
+      /* ---------- Local Git ---------- */
       .two-col {
+        margin-top: 44px;
         display: grid;
         grid-template-columns: minmax(280px, 1fr) minmax(280px, 1fr);
         gap: 56px;
         align-items: start;
-        margin-top: 36px;
-        min-width: 0;
       }
 
       @media (max-width: 880px) {
         .two-col {
           grid-template-columns: 1fr;
-          gap: 36px;
+          gap: 40px;
         }
       }
 
@@ -638,244 +969,228 @@
         list-style: none;
         margin: 0;
         padding: 0;
-        display: grid;
-        gap: 0;
-        border-top: 1px solid var(--line-soft);
+        border-top: 1px solid var(--hairline);
+        font-size: 14px;
       }
 
       .field-list li {
-        padding: 14px 0;
-        border-bottom: 1px solid var(--line-soft);
         display: grid;
-        grid-template-columns: 110px 1fr;
+        grid-template-columns: 118px 1fr;
         gap: 18px;
-        font-size: 13px;
-        line-height: 1.55;
+        padding: 15px 2px;
+        border-bottom: 1px solid var(--hairline-soft);
       }
 
       .field-list .label {
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.13em;
         text-transform: uppercase;
-        letter-spacing: 0.14em;
-        font-size: 10px;
-        color: var(--ink-muted);
+        color: var(--green-bright);
         padding-top: 3px;
       }
 
       .field-list .value {
         color: var(--ink-soft);
+        line-height: 1.55;
       }
 
-      /* ---------- Sync / gitcrawl panel ---------- */
-      .sync-panel {
-        margin-top: 36px;
-        border: 1px solid var(--line);
-        border-radius: var(--radius);
-        background: linear-gradient(180deg, #1a1715 0%, #0f0d0c 100%);
-        color: #f3ead9;
-        padding: 32px;
-        box-shadow: var(--shadow-lg);
-        position: relative;
-        overflow: hidden;
-      }
-
-      .sync-panel::before {
-        content: "";
-        position: absolute;
-        inset: 0;
-        background-image:
-          radial-gradient(rgba(255, 192, 137, 0.06) 1px, transparent 1px);
-        background-size: 4px 4px;
-        opacity: 0.6;
-        pointer-events: none;
-      }
-
-      .sync-grid {
-        display: grid;
-        grid-template-columns: minmax(260px, 1fr) minmax(260px, 1fr);
-        gap: 36px;
-        align-items: start;
-        position: relative;
-        min-width: 0;
-      }
-
-      @media (max-width: 880px) {
-        .sync-grid {
+      @media (max-width: 560px) {
+        .field-list li {
           grid-template-columns: 1fr;
+          gap: 5px;
         }
       }
 
-      .sync-eyebrow {
-        font-size: 10px;
-        text-transform: uppercase;
-        letter-spacing: 0.24em;
-        color: var(--amber);
-        margin-bottom: 14px;
-        display: flex;
-        align-items: center;
-        gap: 10px;
+      .side-note h3 {
+        font-family: var(--serif);
+        font-weight: 400;
+        font-size: 28px;
+        margin: 0 0 14px;
       }
 
-      .sync-eyebrow::before {
-        content: "";
-        width: 18px;
-        height: 1px;
-        background: var(--amber);
-      }
-
-      .sync-panel h2 {
-        font-family: "Fraunces", serif;
-        font-size: clamp(28px, 3.4vw, 40px);
-        line-height: 1.08;
+      .side-note p {
+        font-size: 15px;
+        line-height: 1.7;
+        color: var(--ink-soft);
         margin: 0 0 16px;
-        font-weight: 600;
-        color: #fff5e3;
       }
 
-      .sync-panel h2 em {
-        color: var(--amber);
+      .side-note a {
+        color: var(--green-bright);
+        text-decoration: underline;
+        text-decoration-color: rgba(57, 211, 83, 0.4);
+        text-underline-offset: 3px;
+      }
+
+      /* ---------- Sync panel ---------- */
+      .sync-panel {
+        margin-top: 44px;
+        border: 1px solid var(--hairline);
+        border-radius: 20px;
+        background:
+          radial-gradient(680px 320px at 12% 0%, rgba(35, 134, 54, 0.16), transparent 60%),
+          linear-gradient(180deg, #0e131a, #090d12);
+        padding: 40px;
+        display: grid;
+        grid-template-columns: minmax(260px, 1.05fr) minmax(260px, 0.95fr);
+        gap: 44px;
+        box-shadow: 0 40px 90px rgba(0, 0, 0, 0.45);
+      }
+
+      @media (max-width: 880px) {
+        .sync-panel {
+          grid-template-columns: 1fr;
+          padding: 28px 22px;
+        }
+      }
+
+      .sync-panel h3 {
+        font-family: var(--serif);
+        font-weight: 400;
+        font-size: clamp(26px, 3vw, 36px);
+        line-height: 1.1;
+        margin: 0 0 16px;
+      }
+
+      .sync-panel h3 em {
         font-style: italic;
+        color: var(--green-bright);
       }
 
       .sync-panel p {
-        font-size: 14px;
+        font-size: 14.5px;
         line-height: 1.7;
-        color: #d8cfbb;
+        color: var(--ink-soft);
         margin: 0 0 14px;
       }
 
       .sync-panel a {
-        color: var(--amber);
+        color: var(--green-bright);
         text-decoration: underline;
-        text-decoration-color: rgba(245, 166, 35, 0.4);
+        text-decoration-color: rgba(57, 211, 83, 0.4);
         text-underline-offset: 3px;
       }
 
-      .sync-flow {
-        background: rgba(0, 0, 0, 0.3);
-        border: 1px dashed rgba(245, 166, 35, 0.35);
+      .sync-panel code {
+        font-family: var(--mono);
+        font-size: 0.85em;
+        background: rgba(57, 211, 83, 0.1);
+        border: 1px solid rgba(57, 211, 83, 0.2);
+        color: #a5f3b8;
+        padding: 1px 6px;
+        border-radius: 5px;
+      }
+
+      .flow {
+        border: 1px dashed rgba(57, 211, 83, 0.3);
         border-radius: 14px;
-        padding: 22px;
-        font-size: 12px;
-        line-height: 1.65;
+        background: rgba(0, 0, 0, 0.3);
+        padding: 8px 18px;
+        font-family: var(--mono);
+        font-size: 12.5px;
+        line-height: 1.6;
+        align-self: start;
       }
 
-      .sync-flow .step {
+      .flow .step {
         display: grid;
-        grid-template-columns: 28px 1fr;
+        grid-template-columns: 24px 1fr;
         gap: 12px;
-        padding: 10px 0;
-        border-bottom: 1px dashed rgba(245, 166, 35, 0.18);
+        padding: 13px 0;
+        border-bottom: 1px dashed rgba(57, 211, 83, 0.16);
+        color: var(--ink-soft);
       }
 
-      .sync-flow .step:last-child {
+      .flow .step:last-child {
         border-bottom: none;
       }
 
-      .sync-flow .step b {
-        color: var(--amber);
+      .flow .num {
+        color: var(--green-bright);
+      }
+
+      .flow b {
+        color: var(--ink);
         font-weight: 600;
       }
 
-      .sync-flow .num {
-        color: var(--amber);
-        font-weight: 600;
+      .flow code {
+        background: none;
+        border: none;
+        color: #a5f3b8;
+        padding: 0;
       }
 
       /* ---------- Terminal ---------- */
       .terminal {
-        margin-top: 36px;
-        background: #0f0d0c;
-        border-radius: var(--radius);
-        border: 1px solid var(--line);
-        box-shadow: var(--shadow-lg);
+        margin-top: 44px;
+        border-radius: 16px;
+        border: 1px solid var(--hairline);
+        background: #0a0c10;
+        box-shadow: 0 40px 90px rgba(0, 0, 0, 0.5);
         overflow: hidden;
       }
 
-      .terminal-bar {
+      .term-bar {
         display: flex;
         align-items: center;
         gap: 8px;
         padding: 12px 16px;
-        background: #1a1715;
-        border-bottom: 1px solid #2a2522;
+        background: rgba(255, 255, 255, 0.04);
+        border-bottom: 1px solid var(--hairline-soft);
       }
 
-      .terminal-bar .dot {
+      .term-bar .dot {
         width: 11px;
         height: 11px;
         border-radius: 50%;
-        background: #3a3331;
-        border: 1px solid #15110f;
       }
 
-      .terminal-bar .dot.r {
-        background: #ff5f57;
-      }
-      .terminal-bar .dot.y {
-        background: #febc2e;
-      }
-      .terminal-bar .dot.g {
-        background: #28c840;
-      }
+      .term-bar .dot.r { background: #ff5f57; }
+      .term-bar .dot.y { background: #febc2e; }
+      .term-bar .dot.g { background: #28c840; }
 
-      .terminal-bar .title {
-        margin-left: 14px;
+      .term-bar .title {
+        margin-left: 12px;
+        font-family: var(--mono);
         font-size: 11px;
-        color: #9a8e7e;
+        letter-spacing: 0.16em;
         text-transform: uppercase;
-        letter-spacing: 0.18em;
+        color: var(--ink-muted);
       }
 
-      .terminal-body {
-        padding: 22px 24px;
+      .term-body {
+        padding: 24px 26px;
+        font-family: var(--mono);
         font-size: 13px;
-        line-height: 1.75;
-        color: #e8dcc4;
+        line-height: 1.85;
+        color: #cfd8e3;
         overflow-x: auto;
       }
 
-      .terminal-body .prompt {
-        color: var(--amber);
-        user-select: none;
+      .term-body .prompt { color: var(--green-bright); user-select: none; }
+      .term-body .cmd { color: #eef3f8; }
+      .term-body .flag { color: #79c0ff; }
+      .term-body .arg { color: #ffa657; }
+      .term-body .out { color: #768390; display: block; padding-left: 16px; }
+      .term-body .ok { color: #57d364; }
+      .term-body .warn { color: #e3b341; }
+      .term-body .row { display: block; }
+
+      @media (max-width: 640px) {
+        .term-body {
+          padding: 18px 16px;
+          font-size: 12px;
+        }
       }
 
-      .terminal-body .cmd {
-        color: #fff5e3;
-      }
-
-      .terminal-body .flag {
-        color: #b5d18d;
-      }
-
-      .terminal-body .arg {
-        color: #f5b27c;
-      }
-
-      .terminal-body .out {
-        color: #968a78;
-        display: block;
-        padding-left: 14px;
-      }
-
-      .terminal-body .ok {
-        color: #7fc28a;
-      }
-
-      .terminal-body .warn {
-        color: #d3b56a;
-      }
-
-      .terminal-body .row {
-        display: block;
-      }
-
-      /* ---------- Install grid ---------- */
+      /* ---------- Install ---------- */
       .install-grid {
-        margin-top: 36px;
+        margin-top: 44px;
         display: grid;
         grid-template-columns: repeat(3, minmax(0, 1fr));
-        gap: 18px;
-        min-width: 0;
+        gap: 20px;
       }
 
       @media (max-width: 880px) {
@@ -886,181 +1201,116 @@
 
       .install-card {
         background: var(--panel);
-        border: 1px solid var(--line);
-        border-radius: var(--radius);
-        padding: 22px;
-        box-shadow: var(--shadow-sm);
+        backdrop-filter: blur(16px);
+        -webkit-backdrop-filter: blur(16px);
+        border: 1px solid var(--hairline);
+        border-radius: 16px;
+        padding: 24px;
         display: flex;
         flex-direction: column;
-        gap: 14px;
+        gap: 13px;
         min-width: 0;
-        overflow: hidden;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+      }
+
+      .install-card.featured {
+        border-color: rgba(57, 211, 83, 0.4);
+        box-shadow: 0 0 0 1px rgba(57, 211, 83, 0.12), 0 24px 60px rgba(0, 0, 0, 0.35),
+          inset 0 1px 0 rgba(255, 255, 255, 0.05);
+      }
+
+      .install-card .badge {
+        font-family: var(--mono);
+        font-size: 10.5px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--green-bright);
       }
 
       .install-card h3 {
-        font-family: "Fraunces", serif;
-        font-size: 22px;
+        font-family: var(--serif);
+        font-weight: 400;
+        font-size: 26px;
         margin: 0;
-        font-weight: 600;
-      }
-
-      .install-card .install-label {
-        font-size: 10px;
-        text-transform: uppercase;
-        letter-spacing: 0.2em;
-        color: var(--accent-dark);
-        font-weight: 600;
       }
 
       .install-card p {
-        font-size: 13px;
+        margin: 0;
+        font-size: 13.5px;
         line-height: 1.6;
         color: var(--ink-soft);
-        margin: 0;
       }
 
-      .install-command-row {
-        position: relative;
-        min-width: 0;
+      .install-card p code {
+        font-family: var(--mono);
+        font-size: 0.85em;
+        background: rgba(255, 255, 255, 0.07);
+        border: 1px solid var(--hairline-soft);
+        padding: 1px 6px;
+        border-radius: 5px;
       }
 
-      .install-command {
-        margin: 0;
-        padding: 12px 44px 12px 14px;
-        border-radius: var(--radius-sm);
-        background: #141414;
-        color: #fff6e9;
-        font-size: 12px;
-        line-height: 1.5;
-        border: 1px solid #1f1f1f;
-        overflow-x: auto;
-        font-family: "IBM Plex Mono", monospace;
-        max-width: 100%;
-        min-width: 0;
-        white-space: pre;
-      }
-
-      .copy-button {
-        position: absolute;
-        right: 8px;
-        top: 50%;
-        transform: translateY(-50%);
-        width: 30px;
-        height: 30px;
-        border: 1px solid #2a2a2a;
-        background: #1b1b1b;
-        color: #fff6e9;
-        border-radius: 8px;
-        display: inline-flex;
+      .cmd-row {
+        display: flex;
         align-items: center;
-        justify-content: center;
-        cursor: pointer;
-        transition: transform 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+        gap: 8px;
+        background: rgba(0, 0, 0, 0.45);
+        border: 1px solid var(--hairline);
+        border-radius: 10px;
+        padding: 10px 8px 10px 14px;
+        min-width: 0;
       }
 
-      .copy-button:hover {
-        transform: translateY(-50%) scale(1.06);
-        background: #222;
-        border-color: #3a3a3a;
+      .cmd-row code {
+        font-family: var(--mono);
+        font-size: 12px;
+        color: var(--ink);
+        white-space: pre;
+        overflow-x: auto;
+        flex: 1;
+        scrollbar-width: none;
       }
 
-      .copy-button:focus-visible {
-        outline: 2px solid #ffd3a1;
-        outline-offset: 2px;
-      }
-
-      .copy-button svg {
-        width: 14px;
-        height: 14px;
-      }
-
-      .copy-button.copied {
-        background: #2d6a4f;
-        border-color: #3b7f60;
-      }
-
-      .install-card a.text-link {
+      .install-card .text-link {
+        font-family: var(--mono);
+        font-size: 13px;
         color: var(--ink);
         text-decoration: underline;
-        text-decoration-color: var(--accent);
+        text-decoration-color: rgba(57, 211, 83, 0.5);
         text-decoration-thickness: 2px;
-        text-underline-offset: 3px;
-        font-size: 13px;
+        text-underline-offset: 4px;
       }
 
-      .install-card a.text-link:hover {
-        color: var(--accent-dark);
-      }
-
-      /* ---------- Marquee strip ---------- */
-      .strip {
-        margin-top: 80px;
-        border-top: 1px dashed var(--line-soft);
-        border-bottom: 1px dashed var(--line-soft);
-        padding: 16px 0;
-        overflow: hidden;
-        font-family: "Fraunces", serif;
-        font-style: italic;
-        font-size: 22px;
-        color: var(--ink-muted);
-        white-space: nowrap;
-      }
-
-      .strip-track {
-        display: inline-flex;
-        gap: 40px;
-        animation: marquee 38s linear infinite;
-      }
-
-      .strip-track span {
-        display: inline-flex;
-        align-items: center;
-        gap: 16px;
-      }
-
-      .strip-track span::after {
-        content: "✦";
-        color: var(--accent);
-        font-style: normal;
-      }
-
-      @keyframes marquee {
-        0% {
-          transform: translateX(0);
-        }
-        100% {
-          transform: translateX(-50%);
-        }
-      }
-
-      @media (prefers-reduced-motion: reduce) {
-        .strip-track {
-          animation: none;
-        }
+      .install-card .text-link:hover {
+        color: var(--green-bright);
       }
 
       /* ---------- FAQ ---------- */
       .faq {
-        margin-top: 36px;
-        border-top: 1px solid var(--line-soft);
+        margin-top: 44px;
+        border-top: 1px solid var(--hairline);
       }
 
       .faq details {
-        border-bottom: 1px solid var(--line-soft);
-        padding: 22px 4px;
+        border-bottom: 1px solid var(--hairline-soft);
+        padding: 24px 4px;
       }
 
       .faq summary {
         cursor: pointer;
         list-style: none;
-        font-family: "Fraunces", serif;
-        font-size: 22px;
-        font-weight: 600;
-        line-height: 1.25;
+        font-family: var(--serif);
+        font-weight: 400;
+        font-size: 24px;
+        line-height: 1.3;
         display: flex;
         justify-content: space-between;
         align-items: baseline;
-        gap: 18px;
+        gap: 20px;
+      }
+
+      .faq summary:hover {
+        color: var(--green-bright);
       }
 
       .faq summary::-webkit-details-marker {
@@ -1069,10 +1319,10 @@
 
       .faq summary::after {
         content: "+";
-        color: var(--accent-dark);
-        font-family: "IBM Plex Mono", monospace;
+        font-family: var(--mono);
         font-size: 22px;
-        transition: transform 0.2s ease;
+        color: var(--green-bright);
+        flex: 0 0 auto;
       }
 
       .faq details[open] summary::after {
@@ -1081,498 +1331,393 @@
 
       .faq .answer {
         margin-top: 14px;
-        font-size: 14px;
+        font-size: 14.5px;
         line-height: 1.7;
         color: var(--ink-soft);
-        max-width: 70ch;
-      }
-
-      .faq .answer code {
-        background: var(--panel-soft);
-        border: 1px solid var(--line-soft);
-        padding: 1px 6px;
-        border-radius: 4px;
-        font-size: 12px;
-      }
-
-      .faq .answer a {
-        color: var(--accent-dark);
-        text-decoration: underline;
-        text-underline-offset: 3px;
+        max-width: 72ch;
       }
 
       /* ---------- Footer ---------- */
       footer {
-        margin-top: 90px;
-        padding-top: 32px;
-        border-top: 1px solid var(--line-soft);
-        display: grid;
-        grid-template-columns: minmax(200px, 1fr) auto;
-        gap: 24px;
+        margin-top: 140px;
+        border-top: 1px solid var(--hairline);
+        padding-top: 36px;
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        gap: 20px 30px;
+        font-family: var(--mono);
         font-size: 12px;
         color: var(--ink-muted);
-      }
-
-      footer .credits {
-        text-transform: uppercase;
-        letter-spacing: 0.16em;
+        letter-spacing: 0.06em;
       }
 
       footer a {
-        color: var(--ink);
+        color: var(--ink-soft);
         text-decoration: none;
       }
 
       footer a:hover {
-        color: var(--accent-dark);
+        color: var(--green-bright);
       }
 
       footer .links {
         display: flex;
-        gap: 22px;
-        text-transform: uppercase;
-        letter-spacing: 0.16em;
+        flex-wrap: wrap;
+        gap: 12px 24px;
       }
 
       @media (max-width: 760px) {
+        .frame {
+          padding: calc(var(--menubar-h) + 44px) 18px 60px;
+        }
         section {
-          margin-top: 72px;
+          margin-top: 90px;
         }
-
-        .section-title {
-          font-size: clamp(30px, 10vw, 42px);
-        }
-
-        .section-lead,
         .hero-lead {
-          font-size: 14px;
+          font-size: 16px;
         }
-
-        .hero {
-          gap: 36px;
-        }
-
-        .hero-panel {
-          transform: none;
-          padding: 10px;
-        }
-
-        .hero-panel::before {
-          display: none;
-        }
-
-        .hero-tag {
-          position: static;
-          display: inline-flex;
-          margin-top: 10px;
-        }
-
-        .hero-stamp {
-          display: none;
-        }
-
-        .install-card {
-          padding: 20px 18px;
-        }
-
-        .install-command {
-          padding-right: 58px;
-          min-height: 58px;
-          white-space: pre-wrap;
-          word-break: break-word;
-        }
-
-        .copy-button {
-          position: absolute;
-          top: 8px;
-          right: 8px;
-          bottom: 8px;
-          width: 38px;
-          height: auto;
-          transform: none;
-        }
-
-        .copy-button:hover {
-          transform: scale(1.03);
-        }
-
-        .field-list li {
-          grid-template-columns: 1fr;
-          gap: 4px;
-        }
-
         .sync-panel {
-          padding: 24px 18px;
-        }
-
-        .sync-flow {
-          padding: 16px;
-        }
-
-        .sync-flow .step {
-          grid-template-columns: 1fr;
-          gap: 6px;
-        }
-
-        .terminal-body {
-          padding: 18px 16px;
-          font-size: 12px;
-        }
-
-        .faq summary {
-          font-size: 20px;
-        }
-
-        footer {
-          grid-template-columns: 1fr;
-        }
-        footer .links {
-          flex-wrap: wrap;
-          gap: 14px 22px;
-        }
-      }
-
-      /* ---------- Hero responsive ---------- */
-      @media (max-width: 980px) {
-        .hero {
-          grid-template-columns: 1fr;
-          gap: 48px;
-        }
-        .hero-stamp {
-          right: 12px;
-          width: 78px;
-          height: 78px;
-          font-size: 11px;
+          gap: 28px;
         }
       }
     </style>
   </head>
   <body>
-    <div class="frame">
-      <!-- Header -->
-      <header>
-        <div class="logo">
-          <div class="logo-badge">RB</div>
-          RepoBar
-        </div>
-        <nav class="top-nav">
-          <a href="#features">Features</a>
-          <a href="#sync">Sync</a>
-          <a href="#cli">CLI</a>
-          <a href="#install">Install</a>
-          <button
-            class="theme-toggle"
-            type="button"
-            aria-label="Toggle dark mode"
-            title="Toggle dark mode"
-          >
-            <svg
-              class="icon-sun"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              aria-hidden="true"
-            >
-              <circle cx="12" cy="12" r="4" />
-              <path d="M12 2v2" />
-              <path d="M12 20v2" />
-              <path d="M4.93 4.93l1.41 1.41" />
-              <path d="M17.66 17.66l1.41 1.41" />
-              <path d="M2 12h2" />
-              <path d="M20 12h2" />
-              <path d="M4.93 19.07l1.41-1.41" />
-              <path d="M17.66 6.34l1.41-1.41" />
-            </svg>
-            <svg
-              class="icon-moon"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              aria-hidden="true"
-            >
-              <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
-            </svg>
-          </button>
-          <a class="nav-cta" href="https://github.com/steipete/RepoBar" rel="noreferrer">GitHub →</a>
-        </nav>
-      </header>
+    <div class="sky" aria-hidden="true"></div>
 
+    <!-- Site nav, dressed as the macOS menu bar RepoBar lives in -->
+    <header class="menubar">
+      <a class="wordmark" href="#top" aria-label="RepoBar — back to top">
+        <span class="glyph" aria-hidden="true"><i></i><i></i><i></i><i></i></span>
+        RepoBar
+      </a>
+      <nav aria-label="Sections">
+        <a href="#features">Features</a>
+        <a href="#local">Local</a>
+        <a href="#sync">Sync</a>
+        <a href="#cli">CLI</a>
+        <a href="#install">Install</a>
+        <a href="#faq">FAQ</a>
+      </nav>
+      <div class="spacer"></div>
+      <div class="ticker" aria-hidden="true">
+        <span class="led"></span>
+        <span id="ticker-text">12 repos · all checks green</span>
+      </div>
+      <a class="gh" href="https://github.com/steipete/RepoBar" rel="noreferrer" aria-label="RepoBar on GitHub">
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M12 2C6.48 2 2 6.58 2 12.24c0 4.5 2.87 8.32 6.84 9.67.5.1.68-.22.68-.48 0-.24-.01-.88-.01-1.72-2.78.62-3.37-1.36-3.37-1.36-.46-1.17-1.12-1.48-1.12-1.48-.92-.64.07-.63.07-.63 1.02.07 1.55 1.07 1.55 1.07.9 1.58 2.36 1.12 2.94.85.09-.67.35-1.12.63-1.38-2.22-.26-4.56-1.14-4.56-5.06 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.32.1-2.75 0 0 .84-.27 2.75 1.05a9.3 9.3 0 012.5-.35c.85 0 1.7.12 2.5.35 1.9-1.32 2.75-1.05 2.75-1.05.55 1.43.2 2.49.1 2.75.64.72 1.03 1.63 1.03 2.75 0 3.93-2.35 4.79-4.59 5.05.36.32.69.93.69 1.88 0 1.36-.01 2.46-.01 2.79 0 .26.18.59.69.49 3.96-1.35 6.83-5.17 6.83-9.67C22 6.58 17.52 2 12 2z" />
+        </svg>
+      </a>
+      <span class="clock" id="menubar-clock" aria-hidden="true"></span>
+    </header>
+
+    <div class="frame" id="top">
       <!-- Hero -->
       <main class="hero">
-        <section>
-          <h1>
-            GitHub <em>at a glance</em>,
-            from your <span class="strike">browser</span> menu bar.
-          </h1>
+        <div>
+          <div class="eyebrow">Native macOS · Free &amp; open source</div>
+          <h1>A maintainer's <em>cockpit</em>, docked in your menu&nbsp;bar.</h1>
           <p class="hero-lead">
-            RepoBar is a native macOS menu bar app for keeping GitHub work visible without
-            living in tabs. CI status, open issues and pull requests, releases, traffic,
-            local Git state, and rate-limit health — for every repository you care about,
-            one click away.
+            RepoBar keeps GitHub work visible without living in tabs. <b>CI state, issues,
+            pull requests, releases, local checkouts, and rate limits</b> — for every
+            repository you care about, one click from the clock.
           </p>
-          <ul class="hero-bullets">
-            <li><span>01</span>Real-time CI state with one-click jump to Actions or Checks.</li>
-            <li><span>02</span>Issues, PRs, releases, branches, tags, commits — all browsable inline.</li>
-            <li><span>03</span>Local checkout status: branch, ahead/behind, dirty files, worktrees.</li>
-            <li><span>04</span>Persistent SQLite cache with offline reads from gitcrawl-format archives.</li>
-          </ul>
           <div class="cta-row">
-            <a class="button" href="https://github.com/steipete/RepoBar/releases/latest" rel="noreferrer">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <a class="btn primary" href="https://github.com/steipete/RepoBar/releases/latest" rel="noreferrer">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <path d="M12 3v12" />
                 <path d="M7 10l5 5 5-5" />
                 <path d="M4 21h16" />
               </svg>
               Download for macOS
             </a>
-            <a class="button secondary" href="https://github.com/steipete/RepoBar" rel="noreferrer">
-              <svg viewBox="0 0 24 24" fill="currentColor">
-                <path d="M12 2C6.48 2 2 6.58 2 12.24c0 4.5 2.87 8.32 6.84 9.67.5.1.68-.22.68-.48 0-.24-.01-.88-.01-1.72-2.78.62-3.37-1.36-3.37-1.36-.46-1.17-1.12-1.48-1.12-1.48-.92-.64.07-.63.07-.63 1.02.07 1.55 1.07 1.55 1.07.9 1.58 2.36 1.12 2.94.85.09-.67.35-1.12.63-1.38-2.22-.26-4.56-1.14-4.56-5.06 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.32.1-2.75 0 0 .84-.27 2.75 1.05a9.3 9.3 0 012.5-.35c.85 0 1.7.12 2.5.35 1.9-1.32 2.75-1.05 2.75-1.05.55 1.43.2 2.49.1 2.75.64.72 1.03 1.63 1.03 2.75 0 3.93-2.35 4.79-4.59 5.05.36.32.69.93.69 1.88 0 1.36-.01 2.46-.01 2.79 0 .26.18.59.69.49 3.96-1.35 6.83-5.17 6.83-9.67C22 6.58 17.52 2 12 2z" />
-              </svg>
-              Source on GitHub
-            </a>
+            <a class="btn ghost" href="https://github.com/steipete/RepoBar" rel="noreferrer">Source on GitHub</a>
           </div>
-        </section>
+          <div class="cta-row">
+            <div class="brew-line">
+              <span class="dollar">$</span>
+              <code id="brew-command">brew install --cask repobar</code>
+              <button class="copy-btn" type="button" data-copy-target="brew-command" aria-label="Copy Homebrew install command">
+                <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                  <path d="M16 1H6a2 2 0 00-2 2v12h2V3h10V1zm3 4H10a2 2 0 00-2 2v14a2 2 0 002 2h9a2 2 0 002-2V7a2 2 0 00-2-2zm0 16H10V7h9v14z" />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div class="fine-print">
+            <span>macOS 15+</span>
+            <span>Apple Silicon &amp; Intel</span>
+            <span>MIT licensed</span>
+            <span>No telemetry</span>
+          </div>
+        </div>
 
-        <aside class="hero-panel">
-          <img src="assets/repobar.png" alt="RepoBar showing repository cards with issues, PRs, CI runs, releases, and activity in the macOS menu bar" />
-          <div class="hero-tag">Live menu bar preview</div>
-          <div class="hero-stamp">Free<br />&amp; Open<br />Source</div>
+        <aside class="mock-wrap" aria-label="Illustration of the RepoBar menu">
+          <div class="from-bar" aria-hidden="true">Live from the menu bar</div>
+          <div class="mock" aria-hidden="true">
+            <div class="mock-contrib">
+              <div class="label"><span>Contributions · last 12 months</span><span>›</span></div>
+              <div class="mini-heatmap" id="mini-heatmap"></div>
+            </div>
+            <div class="mock-filters">
+              <span class="on">All</span><span>Pinned</span><span>Work</span>
+            </div>
+            <div class="mock-repo selected">
+              <div class="row1"><span class="ci-dot"></span>steipete/RepoBar<span class="when">13 min ago</span></div>
+              <div class="stats"><span>Issues 1</span><span>PRs 4</span><span>★ 190</span><span>⑂ 9</span></div>
+              <div class="branch"><b>✓ main</b> · up to date</div>
+            </div>
+            <div class="mock-repo">
+              <div class="row1"><span class="ci-dot running" id="mock-ci"></span>openclaw/openclaw<span class="when">24 min ago</span></div>
+              <div class="stats"><span>Issues 12</span><span>PRs 4</span><span>★ 412</span><span>⑂ 38</span></div>
+              <div class="branch"><b id="mock-ci-branch">● main</b> · <span id="mock-ci-label">CI running…</span></div>
+            </div>
+            <div class="mock-repo">
+              <div class="row1"><span class="ci-dot"></span>steipete/summarize<span class="when">2 hrs ago</span></div>
+              <div class="stats"><span>Issues 4</span><span>PRs 0</span><span>★ 475</span><span>⑂ 26</span></div>
+              <div class="branch"><b>✓ main</b> · v0.8.2 released</div>
+            </div>
+            <div class="mock-foot">
+              <span>Preferences… <kbd>⌘,</kbd></span>
+              <span>Quit RepoBar <kbd>⌘Q</kbd></span>
+            </div>
+          </div>
         </aside>
       </main>
 
-      <!-- Features datasheet -->
-      <section id="features">
-        <div class="section-tag">§01 — Datasheet</div>
-        <h2 class="section-title">Everything that matters about a repo, <em>visible at once</em>.</h2>
-        <p class="section-lead">
-          One menu, multiple repositories, every signal that drives day-to-day work — without
-          jumping between tabs, dashboards, or the GitHub CLI.
+      <!-- A year of green -->
+      <div class="yearline reveal" aria-hidden="true">
+        <div class="yeargrid" id="yeargrid"></div>
+        <div class="caption">Your whole year of shipping, one glance from the clock</div>
+      </div>
+
+      <!-- Features -->
+      <section id="features" class="reveal">
+        <div class="kicker">What you see</div>
+        <h2>Everything a repo is up to, <em>in one menu</em>.</h2>
+        <p class="lead">
+          One dropdown, every signal that drives day-to-day maintainer work. No tabs, no
+          dashboards, no waiting for a web page to hydrate.
         </p>
 
-        <div class="datasheet">
-          <div class="cell">
-            <div class="cell-num">01</div>
-            <h3 class="cell-title">CI status</h3>
-            <p class="cell-body">Green/red/yellow indicator per repository with click-through to Checks or the Actions run.</p>
-            <svg class="cell-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <circle cx="12" cy="12" r="9" />
-              <path d="M9 12l2 2 4-4" />
-            </svg>
+        <div class="menus">
+          <div class="menu-panel">
+            <div class="panel-title">Remote state</div>
+            <div class="menu-item">
+              <span class="icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9" /><path d="M9 12l2 2 4-4" /></svg>
+              </span>
+              <h3>CI at a glance</h3>
+              <span class="chev">›</span>
+              <p>Green, red, or running per repository — with one click through to the Actions run or Checks page.</p>
+            </div>
+            <div class="menu-item">
+              <span class="icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="3" /><circle cx="6" cy="18" r="3" /><circle cx="18" cy="18" r="3" /><path d="M6 9v6" /><path d="M18 15V9a3 3 0 00-3-3H9" /></svg>
+              </span>
+              <h3>Issues &amp; pull requests</h3>
+              <span class="chev">›</span>
+              <p>Open counts and recent lists with labels, authors, and draft state — PRs never leak into issue counts.</p>
+            </div>
+            <div class="menu-item">
+              <span class="icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 12l-8 8H4v-8l8-8 8 8z" /><circle cx="9" cy="15" r="1.4" /></svg>
+              </span>
+              <h3>Releases &amp; changelogs</h3>
+              <span class="chev">›</span>
+              <p>Latest release with click-through, inline previews of a local CHANGELOG.md, and opt-in release notifications for pinned repos.</p>
+            </div>
+            <div class="menu-item">
+              <span class="icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="5" height="5" /><rect x="10" y="3" width="5" height="5" /><rect x="17" y="3" width="4" height="5" /><rect x="3" y="10" width="5" height="5" /><rect x="10" y="10" width="5" height="5" /><rect x="3" y="17" width="5" height="4" /></svg>
+              </span>
+              <h3>Activity heatmaps</h3>
+              <span class="chev">›</span>
+              <p>Your contribution graph in the header, plus a blocky per-repo commit heatmap for every repository.</p>
+            </div>
           </div>
-          <div class="cell">
-            <div class="cell-num">02</div>
-            <h3 class="cell-title">Issues &amp; pull requests</h3>
-            <p class="cell-body">Open counts, recent lists, draft state, labels, and authors — corrected so PRs never leak into issue counts.</p>
-            <svg class="cell-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <circle cx="6" cy="6" r="3" />
-              <circle cx="6" cy="18" r="3" />
-              <circle cx="18" cy="18" r="3" />
-              <path d="M6 9v6" />
-              <path d="M18 15V9a3 3 0 00-3-3H9" />
-              <path d="M12 3l-3 3 3 3" />
-            </svg>
+
+          <div class="menu-panel">
+            <div class="panel-title">Close to home</div>
+            <div class="menu-item">
+              <span class="icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="5" r="2.5" /><circle cx="6" cy="19" r="2.5" /><circle cx="18" cy="12" r="2.5" /><path d="M6 7.5v9" /><path d="M6 12c0 3.5 3 5 7 5h2.5" /></svg>
+              </span>
+              <h3>Local checkouts</h3>
+              <span class="chev">›</span>
+              <p>Branch, upstream, ahead/behind, dirty files, and worktrees — local state right next to remote state.</p>
+            </div>
+            <div class="menu-item">
+              <span class="icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 17a9 9 0 0118 0" /><path d="M12 17l3-5" /><circle cx="12" cy="17" r="1.2" /></svg>
+              </span>
+              <h3>Rate-limit meter</h3>
+              <span class="chev">›</span>
+              <p>Live REST and GraphQL budgets with grouped resources, progress bars, and reset times — before you hit the wall.</p>
+            </div>
+            <div class="menu-item">
+              <span class="icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2" /><path d="M7 9h6" /><path d="M7 13h4" /><path d="M17 9v.01" /></svg>
+              </span>
+              <h3>Reference monitor</h3>
+              <span class="chev">›</span>
+              <p>Opt-in: copy an issue number or commit hash anywhere on your Mac and RepoBar resolves it to the matching issue, PR, or commit.</p>
+            </div>
+            <div class="menu-item">
+              <span class="icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="8" r="3.5" /><path d="M2.5 20c.8-3.2 3.4-5 6.5-5s5.7 1.8 6.5 5" /><circle cx="17.5" cy="9" r="2.5" /><path d="M15.5 14.6c2.7.3 4.9 1.9 5.6 4.6" /></svg>
+              </span>
+              <h3>Multi-account</h3>
+              <span class="chev">›</span>
+              <p>GitHub.com and GitHub Enterprise side by side, with per-account credentials, caches, and CLI flags.</p>
+            </div>
           </div>
-          <div class="cell">
-            <div class="cell-num">03</div>
-            <h3 class="cell-title">Releases &amp; tags</h3>
-            <p class="cell-body">Latest release name, date, and click-through. Inline preview of a local CHANGELOG.md when present.</p>
-            <svg class="cell-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M20 12l-8 8H4v-8l8-8 8 8z" />
-              <circle cx="9" cy="15" r="1.4" />
-            </svg>
-          </div>
-          <div class="cell">
-            <div class="cell-num">04</div>
-            <h3 class="cell-title">Activity heatmap</h3>
-            <p class="cell-body">Per-repo blocky commit heatmap plus a header showing your overall GitHub contribution graph.</p>
-            <svg class="cell-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <rect x="3" y="3" width="5" height="5" />
-              <rect x="10" y="3" width="5" height="5" />
-              <rect x="17" y="3" width="4" height="5" />
-              <rect x="3" y="10" width="5" height="5" />
-              <rect x="10" y="10" width="5" height="5" />
-              <rect x="3" y="17" width="5" height="4" />
-            </svg>
-          </div>
-          <div class="cell">
-            <div class="cell-num">05</div>
-            <h3 class="cell-title">Local Git state</h3>
-            <p class="cell-body">Branch, upstream, ahead/behind, dirty files, worktrees. Optional auto fast-forward on a cadence — never destructive.</p>
-            <svg class="cell-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <circle cx="6" cy="5" r="2.5" />
-              <circle cx="6" cy="19" r="2.5" />
-              <circle cx="18" cy="12" r="2.5" />
-              <path d="M6 7.5v9" />
-              <path d="M6 12c0 3.5 3 5 7 5h2.5" />
-            </svg>
-          </div>
-          <div class="cell">
-            <div class="cell-num">06</div>
-            <h3 class="cell-title">Rate-limit meter</h3>
-            <p class="cell-body">Live REST + GraphQL bucket meter in the menu bar, with grouped resources, progress bars, and reset times.</p>
-            <svg class="cell-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M3 17a9 9 0 0118 0" />
-              <path d="M12 17l3-5" />
-              <circle cx="12" cy="17" r="1.2" />
-            </svg>
-          </div>
+        </div>
+
+        <p class="browse-strip">
+          Browse inline:
+          <b>issues</b> <b>pull requests</b> <b>releases</b> <b>CI runs</b> <b>discussions</b>
+          <b>tags</b> <b>branches</b> <b>contributors</b> <b>commits</b> <b>activity</b>
+        </p>
+      </section>
+
+      <!-- Screenshot -->
+      <section id="shot" class="reveal">
+        <div class="kicker">The real thing</div>
+        <h2>Not a mockup. <em>Your menu bar</em>, tonight.</h2>
+        <p class="lead">
+          Repository cards, submenus for issues and commits, contribution graphs, and local
+          Git state — all rendered natively, all one click deep.
+        </p>
+        <div class="shot">
+          <span class="tag">Actual screenshot</span>
+          <img
+            src="assets/repobar.png"
+            alt="RepoBar menus on macOS showing repository cards with issues, PRs, CI runs, releases, commits, and a contribution heatmap"
+            loading="lazy"
+            decoding="async"
+          />
         </div>
       </section>
 
       <!-- Local Git -->
-      <section id="local">
-        <div class="section-tag">§02 — Local first</div>
-        <h2 class="section-title">Built for people who <em>actually clone</em> their repositories.</h2>
-        <p class="section-lead">
-          RepoBar can scan a projects folder such as <code>~/Projects</code> and match local
+      <section id="local" class="reveal">
+        <div class="kicker">Local first</div>
+        <h2>Built for people who <em>actually clone</em>.</h2>
+        <p class="lead">
+          RepoBar scans a projects folder such as <code>~/Projects</code> and matches local
           checkouts to GitHub. Local state appears next to remote state — no second tool, no
           IDE switch.
         </p>
 
         <div class="two-col">
-          <div>
-            <ul class="field-list">
-              <li><span class="label">Branch</span><span class="value">Current branch and upstream tracking ref.</span></li>
-              <li><span class="label">Sync</span><span class="value">Ahead/behind counts versus the upstream branch.</span></li>
-              <li><span class="label">Dirty</span><span class="value">Staged, unstaged, and untracked file summary.</span></li>
-              <li><span class="label">Worktrees</span><span class="value">All worktrees with their checked-out branches.</span></li>
-              <li><span class="label">Auto sync</span><span class="value">Optional fetch + fast-forward on a cadence. Never force-pushes, never resets.</span></li>
-              <li><span class="label">Open</span><span class="value">Open in Finder, Terminal, or your editor — straight from the submenu.</span></li>
-            </ul>
-          </div>
-          <div>
-            <h3 class="cell-title" style="font-size: 26px; margin: 0 0 14px;">Repository browser, not picker.</h3>
-            <p class="section-lead" style="margin-bottom: 18px;">
-              Preferences › Repositories searches every repository RepoBar can access and lets you
-              tag each one as <b>Visible</b>, <b>Pinned</b>, or <b>Hidden</b>. Manual rules survive
-              even when a token rotation drops a repo from view, so access problems become legible.
+          <ul class="field-list">
+            <li><span class="label">Branch</span><span class="value">Current branch and upstream tracking ref.</span></li>
+            <li><span class="label">Sync</span><span class="value">Ahead/behind counts versus the upstream branch.</span></li>
+            <li><span class="label">Dirty</span><span class="value">Staged, unstaged, and untracked file summary.</span></li>
+            <li><span class="label">Worktrees</span><span class="value">All worktrees with their checked-out branches.</span></li>
+            <li><span class="label">Auto sync</span><span class="value">Optional fetch + fast-forward on a cadence. Never force-pushes, never resets.</span></li>
+            <li><span class="label">Open</span><span class="value">Open in Finder, Terminal, or your editor — straight from the submenu.</span></li>
+          </ul>
+          <div class="side-note">
+            <h3>A repository browser, not a picker.</h3>
+            <p>
+              Preferences › Repositories searches every repository RepoBar can access — by
+              name, description, language, or topic — and lets you tag each one as
+              <b>Visible</b>, <b>Pinned</b>, or <b>Hidden</b>. Manual rules survive even when
+              a token rotation drops a repo from view, so access problems stay legible.
             </p>
-            <p class="section-lead">
-              Authentication uses the <a class="text-link" href="https://github.com/apps/repobar/installations/new" rel="noreferrer">RepoBar GitHub App</a>
-              for GitHub.com, with PAT fallback for SAML SSO and Enterprise. Tokens land in the
-              macOS Keychain on release builds.
+            <p>
+              Authentication uses the
+              <a href="https://github.com/apps/repobar/installations/new" rel="noreferrer">RepoBar GitHub App</a>
+              for GitHub.com, with PAT fallback for SAML SSO and Enterprise. Tokens live in
+              the macOS Keychain on release builds.
             </p>
           </div>
         </div>
       </section>
 
       <!-- Sync / gitcrawl -->
-      <section id="sync">
-        <div class="section-tag">§03 — Offline-ready</div>
-        <h2 class="section-title">Syncs with the <em>gitcrawl.sh</em> archive format.</h2>
-        <p class="section-lead">
-          RepoBar opens from local data first and spends GitHub requests carefully. It keeps a
-          persistent SQLite cache for ETags, response bodies, GraphQL responses, recent lists,
-          and rate-limit state — and it can read GitHub backups in the same Git-backed snapshot
-          format that <a href="https://gitcrawl.sh/" rel="noreferrer" style="color: var(--accent-dark); text-decoration: underline;">gitcrawl.sh</a>
-          publishes.
+      <section id="sync" class="reveal">
+        <div class="kicker">Offline-ready</div>
+        <h2>Opens from local data. <em>Spends requests carefully</em>.</h2>
+        <p class="lead">
+          A persistent SQLite cache holds ETags, response bodies, GraphQL results, recent
+          lists, and rate-limit state. And RepoBar reads GitHub backups in the same
+          Git-backed snapshot format that
+          <a href="https://gitcrawl.sh/" rel="noreferrer">gitcrawl.sh</a> publishes.
         </p>
 
         <div class="sync-panel">
-          <div class="sync-grid">
-            <div>
-              <div class="sync-eyebrow">Compatible with gitcrawl.sh</div>
-              <h2>One archive, <em>two readers.</em></h2>
-              <p>
-                <a href="https://gitcrawl.sh/" rel="noreferrer">gitcrawl</a> is a local-first
-                GitHub crawler that publishes a portable SQLite database via Git. RepoBar reads
-                the same Discrawl-style snapshot shape — <code style="background:rgba(245,166,35,0.12);padding:1px 6px;border-radius:4px;color:var(--amber);">manifest.json</code>
-                plus per-table <code style="background:rgba(245,166,35,0.12);padding:1px 6px;border-radius:4px;color:var(--amber);">tables/&lt;table&gt;/*.jsonl(.gz)</code>
-                files — and imports them into its own SQLite cache.
-              </p>
-              <p>
-                When GitHub is rate-limited, offline, or temporarily unavailable, RepoBar falls
-                back to the imported archive automatically. Issue and PR lists keep answering;
-                CI status keeps loading from cache; the menu does not go blank.
-              </p>
-              <p>
-                RepoBar owns its own cache and archive configuration. It does not modify
-                gitcrawl databases or read gitcrawl config — point it at any compatible
-                snapshot Git repository and it imports cleanly.
-              </p>
-            </div>
-
-            <div class="sync-flow">
-              <div class="step">
-                <span class="num">→</span>
-                <span><b>gitcrawl.sh</b> publishes a portable SQLite snapshot to a Git repo.</span>
-              </div>
-              <div class="step">
-                <span class="num">→</span>
-                <span><b>RepoBar</b> clones it and imports <code style="color:var(--amber);">manifest.json</code> into <code style="color:var(--amber);">~/Library/Application&nbsp;Support/RepoBar</code>.</span>
-              </div>
-              <div class="step">
-                <span class="num">→</span>
-                <span>Live GitHub requests are preferred while the budget is healthy and ETags are fresh.</span>
-              </div>
-              <div class="step">
-                <span class="num">→</span>
-                <span>If GitHub is rate-limited or offline, <b>archive reads serve issue/PR lists</b> seamlessly.</span>
-              </div>
-              <div class="step">
-                <span class="num">→</span>
-                <span><code style="color:var(--amber);">repobar archives update</code> pulls the snapshot Git repo and re-imports on demand.</span>
-              </div>
-            </div>
+          <div>
+            <h3>One archive, <em>two readers</em>.</h3>
+            <p>
+              <a href="https://gitcrawl.sh/" rel="noreferrer">gitcrawl</a> is a local-first
+              GitHub crawler that publishes a portable SQLite database via Git. RepoBar reads
+              the same snapshot shape — <code>manifest.json</code> plus per-table
+              <code>tables/&lt;table&gt;/*.jsonl(.gz)</code> files — and imports it into its
+              own cache.
+            </p>
+            <p>
+              When GitHub is rate-limited, offline, or having a day, RepoBar falls back to
+              the imported archive automatically. Issue and PR lists keep answering; the menu
+              never goes blank.
+            </p>
+            <p>
+              RepoBar owns its own cache and archive configuration. It never writes to
+              gitcrawl databases and never reads gitcrawl config — point it at any compatible
+              snapshot repository and it imports cleanly.
+            </p>
+          </div>
+          <div class="flow" aria-label="How archive sync works">
+            <div class="step"><span class="num">01</span><span><b>gitcrawl.sh</b> publishes a portable SQLite snapshot to a Git repo.</span></div>
+            <div class="step"><span class="num">02</span><span><b>RepoBar</b> clones it and imports <code>manifest.json</code> into its own SQLite cache.</span></div>
+            <div class="step"><span class="num">03</span><span>Live GitHub requests are preferred while the budget is healthy and ETags are fresh.</span></div>
+            <div class="step"><span class="num">04</span><span>Rate-limited or offline? <b>Archive reads serve issue and PR lists</b> seamlessly.</span></div>
+            <div class="step"><span class="num">05</span><span><code>repobar archives update</code> pulls the snapshot repo and re-imports on demand.</span></div>
           </div>
         </div>
       </section>
 
       <!-- CLI -->
-      <section id="cli">
-        <div class="section-tag">§04 — Automation</div>
-        <h2 class="section-title">A first-class <em>CLI</em>.</h2>
-        <p class="section-lead">
-          RepoBar ships <code>repobar</code> alongside the app — same auth, same cache, same
-          archive paths. Use it for scripts, agents, diagnostics, or just because you live in
-          the terminal.
+      <section id="cli" class="reveal">
+        <div class="kicker">Automation</div>
+        <h2>The same app, <em>as a command</em>.</h2>
+        <p class="lead">
+          RepoBar ships a <code>repobar</code> CLI alongside the app — same auth, same cache,
+          same archive paths. Use it for scripts, agents, diagnostics, or just because you
+          live in the terminal. <code>--json</code> for machines, <code>--plain</code> for
+          pipes.
         </p>
 
         <div class="terminal">
-          <div class="terminal-bar">
+          <div class="term-bar">
             <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
             <span class="title">~ — repobar</span>
           </div>
-          <pre class="terminal-body"><span class="row"><span class="prompt">$</span> <span class="cmd">repobar</span> repos <span class="flag">--owner</span> <span class="arg">openclaw</span> <span class="flag">--sort</span> <span class="arg">prs</span> <span class="flag">--plain</span></span><span class="out">openclaw/openclaw    issues 12   prs  4   ★ 412   pushed 24m ago</span><span class="out">openclaw/gitcrawl    issues  3   prs  1   ★  68   pushed  3h ago</span><span class="row"></span><span class="row"><span class="prompt">$</span> <span class="cmd">repobar</span> rate-limits <span class="flag">--plain</span></span><span class="out"><span class="ok">core   </span> 4983 / 5000   resets in 53m</span><span class="out"><span class="ok">graphql</span>  984 / 5000   resets in 47m</span><span class="out"><span class="warn">search </span>   24 /   30   resets in  1m</span><span class="row"></span><span class="row"><span class="prompt">$</span> <span class="cmd">repobar</span> archives add <span class="arg">openclaw</span> \</span><span class="row">    <span class="flag">--repo</span> <span class="arg">~/Backups/github-openclaw</span> \</span><span class="row">    <span class="flag">--db</span>   <span class="arg">~/Library/Application Support/RepoBar/Archives/openclaw.sqlite</span></span><span class="out"><span class="ok">added</span> source 'openclaw' (format: discrawlSnapshot)</span><span class="row"></span><span class="row"><span class="prompt">$</span> <span class="cmd">repobar</span> archives update <span class="arg">openclaw</span> <span class="flag">--json</span></span><span class="out">{"source":"openclaw","manifestVersion":1,"importedTables":7,"totalRows":48211}</span></pre>
+          <pre class="term-body"><span class="row"><span class="prompt">$</span> <span class="cmd">repobar</span> repos <span class="flag">--owner</span> <span class="arg">openclaw</span> <span class="flag">--sort</span> <span class="arg">prs</span> <span class="flag">--plain</span></span><span class="out">openclaw/openclaw    issues 12   prs  4   ★ 412   pushed 24m ago</span><span class="out">openclaw/gitcrawl    issues  3   prs  1   ★  68   pushed  3h ago</span><span class="row"></span><span class="row"><span class="prompt">$</span> <span class="cmd">repobar</span> rate-limits <span class="flag">--plain</span></span><span class="out"><span class="ok">core   </span> 4983 / 5000   resets in 53m</span><span class="out"><span class="ok">graphql</span>  984 / 5000   resets in 47m</span><span class="out"><span class="warn">search </span>   24 /   30   resets in  1m</span><span class="row"></span><span class="row"><span class="prompt">$</span> <span class="cmd">repobar</span> archives add <span class="arg">openclaw</span> <span class="flag">--repo</span> <span class="arg">~/Backups/github-openclaw</span></span><span class="out"><span class="ok">added</span> source 'openclaw' (format: discrawlSnapshot)</span><span class="row"></span><span class="row"><span class="prompt">$</span> <span class="cmd">repobar</span> archives update <span class="arg">openclaw</span> <span class="flag">--json</span></span><span class="out">{"source":"openclaw","manifestVersion":1,"importedTables":7,"totalRows":48211}</span></pre>
         </div>
       </section>
 
-      <!-- Marquee -->
-      <div class="strip" aria-hidden="true">
-        <div class="strip-track">
-          <span>CI status</span><span>Open issues</span><span>Pull requests</span><span>Releases</span>
-          <span>Local Git</span><span>Worktrees</span><span>Activity heatmap</span><span>Rate-limit meter</span>
-          <span>SQLite cache</span><span>gitcrawl.sh archives</span><span>Offline-ready</span>
-          <span>CI status</span><span>Open issues</span><span>Pull requests</span><span>Releases</span>
-          <span>Local Git</span><span>Worktrees</span><span>Activity heatmap</span><span>Rate-limit meter</span>
-          <span>SQLite cache</span><span>gitcrawl.sh archives</span><span>Offline-ready</span>
-        </div>
-      </div>
-
       <!-- Install -->
-      <section id="install">
-        <div class="section-tag">§05 — Install</div>
-        <h2 class="section-title">Three paths, one menu bar app.</h2>
-        <p class="section-lead">
-          RepoBar is free and open source under the MIT license. Sparkle handles updates on
-          release builds. macOS Sonoma or later, Apple Silicon and Intel.
+      <section id="install" class="reveal">
+        <div class="kicker">Install</div>
+        <h2>Three paths, <em>one menu bar</em>.</h2>
+        <p class="lead">
+          Free and open source under the MIT license. Sparkle keeps release builds updated.
+          macOS 15 (Sequoia) or later, Apple Silicon and Intel.
         </p>
 
         <div class="install-grid">
-          <div class="install-card">
-            <div class="install-label">Recommended</div>
+          <div class="install-card featured">
+            <div class="badge">Recommended</div>
             <h3>Homebrew</h3>
             <p>The fastest path. Updates with the rest of your Brew apps.</p>
-            <div class="install-command-row">
-              <pre class="install-command"><code id="brew-command">brew install --cask repobar</code></pre>
-              <button class="copy-button" type="button" data-copy-target="brew-command" aria-label="Copy Homebrew install command">
+            <div class="cmd-row">
+              <code id="brew-command-2">brew install --cask repobar</code>
+              <button class="copy-btn" type="button" data-copy-target="brew-command-2" aria-label="Copy Homebrew install command">
                 <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                   <path d="M16 1H6a2 2 0 00-2 2v12h2V3h10V1zm3 4H10a2 2 0 00-2 2v14a2 2 0 002 2h9a2 2 0 002-2V7a2 2 0 00-2-2zm0 16H10V7h9v14z" />
                 </svg>
@@ -1581,20 +1726,20 @@
           </div>
 
           <div class="install-card">
-            <div class="install-label">Direct</div>
+            <div class="badge">Direct</div>
             <h3>Download release</h3>
-            <p>Signed and notarised <code>.dmg</code> on every release. Pinned to GitHub.</p>
+            <p>Signed and notarised <code>.dmg</code> on every release, straight from GitHub.</p>
             <a class="text-link" href="https://github.com/steipete/RepoBar/releases/latest" rel="noreferrer">Latest release →</a>
             <a class="text-link" href="https://github.com/steipete/RepoBar/releases" rel="noreferrer">All releases →</a>
           </div>
 
           <div class="install-card">
-            <div class="install-label">For hackers</div>
+            <div class="badge">For hackers</div>
             <h3>Build from source</h3>
             <p>SwiftPM with <code>pnpm</code> wrapper scripts. Xcode 26 / Swift 6.2.</p>
-            <div class="install-command-row">
-              <pre class="install-command"><code id="source-command">git clone https://github.com/steipete/RepoBar &amp;&amp; cd RepoBar &amp;&amp; pnpm start</code></pre>
-              <button class="copy-button" type="button" data-copy-target="source-command" aria-label="Copy source build command">
+            <div class="cmd-row">
+              <code id="source-command">git clone https://github.com/steipete/RepoBar &amp;&amp; cd RepoBar &amp;&amp; pnpm start</code>
+              <button class="copy-btn" type="button" data-copy-target="source-command" aria-label="Copy source build command">
                 <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                   <path d="M16 1H6a2 2 0 00-2 2v12h2V3h10V1zm3 4H10a2 2 0 00-2 2v14a2 2 0 002 2h9a2 2 0 002-2V7a2 2 0 00-2-2zm0 16H10V7h9v14z" />
                 </svg>
@@ -1605,9 +1750,9 @@
       </section>
 
       <!-- FAQ -->
-      <section id="faq">
-        <div class="section-tag">§06 — FAQ</div>
-        <h2 class="section-title">Common questions.</h2>
+      <section id="faq" class="reveal">
+        <div class="kicker">FAQ</div>
+        <h2>Common questions.</h2>
 
         <div class="faq">
           <details>
@@ -1642,10 +1787,21 @@
             </div>
           </details>
           <details>
+            <summary>What's the reference monitor?</summary>
+            <div class="answer">
+              An opt-in, cache-first watcher (Advanced settings). Copy something like
+              <code>#123</code> or a commit hash anywhere on your Mac, and RepoBar resolves it
+              against cached issues, PRs, and commits in accessible repositories — falling
+              back to live lookups on cache misses. The best match appears as its own menu
+              bar item. Global monitoring requires the Accessibility permission.
+            </div>
+          </details>
+          <details>
             <summary>Does it support GitHub Enterprise?</summary>
             <div class="answer">
               Yes. Configure the enterprise host and OAuth settings in Preferences › Accounts.
-              TLS is required.
+              Multiple accounts are supported side by side, each with its own cache. TLS is
+              required.
             </div>
           </details>
           <details>
@@ -1668,8 +1824,8 @@
 
       <!-- Footer -->
       <footer>
-        <div class="credits">
-          RepoBar for macOS &middot; built by
+        <div>
+          RepoBar for macOS · built by
           <a href="https://steipete.me/" rel="noreferrer">@steipete</a>
         </div>
         <div class="links">
@@ -1683,44 +1839,191 @@
     </div>
 
     <script>
-      const themeToggle = document.querySelector(".theme-toggle");
-      if (themeToggle) {
-        themeToggle.addEventListener("click", () => {
-          const current =
-            document.documentElement.getAttribute("data-theme") || "light";
-          const next = current === "dark" ? "light" : "dark";
-          document.documentElement.setAttribute("data-theme", next);
-          try {
-            localStorage.setItem("repobar-theme", next);
-          } catch (e) {}
-        });
-      }
+      (function () {
+        "use strict";
+        var reduceMotion =
+          window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
-      const copyButtons = document.querySelectorAll(".copy-button");
-      copyButtons.forEach((button) => {
-        button.addEventListener("click", async () => {
-          const targetId = button.getAttribute("data-copy-target");
-          const target = document.getElementById(targetId);
-          if (!target) return;
-          const text = target.textContent?.trim() ?? "";
-          try {
-            await navigator.clipboard.writeText(text);
-            button.classList.add("copied");
-            const originalLabel = button.getAttribute("aria-label");
-            button.setAttribute("aria-label", "Copied");
-            setTimeout(() => {
-              button.classList.remove("copied");
-              if (originalLabel) button.setAttribute("aria-label", originalLabel);
-            }, 1200);
-          } catch {
-            const range = document.createRange();
-            const selection = window.getSelection();
-            range.selectNodeContents(target);
-            selection?.removeAllRanges();
-            selection?.addRange(range);
+        /* Menu bar clock, macOS style */
+        var clock = document.getElementById("menubar-clock");
+        function tick() {
+          var now = new Date();
+          var days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+          var months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+          var h = now.getHours();
+          var m = String(now.getMinutes()).padStart(2, "0");
+          clock.textContent =
+            days[now.getDay()] + " " + months[now.getMonth()] + " " + now.getDate() + "  " + h + ":" + m;
+        }
+        if (clock) {
+          tick();
+          setInterval(tick, 15000);
+        }
+
+        /* Menu bar status ticker */
+        var tickerText = document.getElementById("ticker-text");
+        var tickerMessages = [
+          "12 repos · all checks green",
+          "2 PRs waiting on review",
+          "main · up to date everywhere",
+          "core 4983/5000 · plenty left",
+          "release shipped · notes inline",
+        ];
+        if (tickerText && !reduceMotion) {
+          var t = 0;
+          setInterval(function () {
+            tickerText.classList.add("fade");
+            setTimeout(function () {
+              t = (t + 1) % tickerMessages.length;
+              tickerText.textContent = tickerMessages[t];
+              tickerText.classList.remove("fade");
+            }, 350);
+          }, 4200);
+        }
+
+        /* Mini heatmap in the mock dropdown */
+        var mini = document.getElementById("mini-heatmap");
+        if (mini) {
+          var cols = 40;
+          var frag = document.createDocumentFragment();
+          for (var c = 0; c < cols * 7; c++) {
+            var cell = document.createElement("i");
+            var r = Math.random();
+            if (r > 0.82) cell.className = "l4";
+            else if (r > 0.66) cell.className = "l3";
+            else if (r > 0.5) cell.className = "l2";
+            else if (r > 0.34) cell.className = "l1";
+            frag.appendChild(cell);
           }
+          mini.appendChild(frag);
+        }
+
+        /* Mock CI run completes while you watch */
+        var ciDot = document.getElementById("mock-ci");
+        var ciLabel = document.getElementById("mock-ci-label");
+        var ciBranch = document.getElementById("mock-ci-branch");
+        function ciDone() {
+          if (ciDot) ciDot.classList.remove("running");
+          if (ciLabel) ciLabel.textContent = "checks passed";
+          if (ciBranch) ciBranch.textContent = "✓ main";
+        }
+        if (reduceMotion) {
+          ciDone();
+        } else {
+          setTimeout(ciDone, 6500);
+        }
+
+        /* Contribution graph that spells the name — 5×7 pixel glyphs */
+        var GLYPHS = {
+          R: ["XXXX.", "X...X", "X...X", "XXXX.", "X.X..", "X..X.", "X...X"],
+          E: ["XXXXX", "X....", "X....", "XXXX.", "X....", "X....", "XXXXX"],
+          P: ["XXXX.", "X...X", "X...X", "XXXX.", "X....", "X....", "X...."],
+          O: [".XXX.", "X...X", "X...X", "X...X", "X...X", "X...X", ".XXX."],
+          B: ["XXXX.", "X...X", "X...X", "XXXX.", "X...X", "X...X", "XXXX."],
+          A: [".XXX.", "X...X", "X...X", "XXXXX", "X...X", "X...X", "X...X"],
+        };
+        var grid = document.getElementById("yeargrid");
+        if (grid) {
+          var word = "REPOBAR";
+          var pad = 3;
+          var totalCols = pad * 2 + word.length * 6 - 1;
+          var lit = [];
+          for (var row = 0; row < 7; row++) {
+            lit.push(new Array(totalCols).fill(false));
+          }
+          for (var i = 0; i < word.length; i++) {
+            var glyph = GLYPHS[word[i]];
+            var offset = pad + i * 6;
+            for (var gr = 0; gr < 7; gr++) {
+              for (var gc = 0; gc < 5; gc++) {
+                if (glyph[gr][gc] === "X") lit[gr][offset + gc] = true;
+              }
+            }
+          }
+          /* grid-auto-flow: column fills rows first, so emit column by column */
+          var gfrag = document.createDocumentFragment();
+          for (var col = 0; col < totalCols; col++) {
+            for (var row2 = 0; row2 < 7; row2++) {
+              var el = document.createElement("i");
+              if (lit[row2][col]) {
+                el.className = (Math.random() > 0.35 ? "l4" : "l3") + " lit";
+                el.style.setProperty("--d", (col * 0.028 + Math.random() * 0.2).toFixed(2) + "s");
+              } else if (Math.random() > 0.88) {
+                el.className = "l1";
+              }
+              gfrag.appendChild(el);
+            }
+          }
+          grid.appendChild(gfrag);
+          /* Start the fill animation when the strip scrolls into view */
+          if ("IntersectionObserver" in window && !reduceMotion) {
+            var gridObserver = new IntersectionObserver(
+              function (entries) {
+                entries.forEach(function (entry) {
+                  if (entry.isIntersecting) {
+                    grid.classList.add("animate");
+                    gridObserver.disconnect();
+                  }
+                });
+              },
+              { threshold: 0.4 }
+            );
+            gridObserver.observe(grid);
+          }
+        }
+
+        /* Scroll reveal */
+        var revealables = document.querySelectorAll(".reveal");
+        if ("IntersectionObserver" in window && !reduceMotion) {
+          var revealObserver = new IntersectionObserver(
+            function (entries) {
+              entries.forEach(function (entry) {
+                if (entry.isIntersecting) {
+                  entry.target.classList.add("in");
+                  revealObserver.unobserve(entry.target);
+                }
+              });
+            },
+            { threshold: 0.12 }
+          );
+          revealables.forEach(function (el) {
+            revealObserver.observe(el);
+          });
+        } else {
+          revealables.forEach(function (el) {
+            el.classList.add("in");
+          });
+        }
+
+        /* Copy buttons */
+        document.querySelectorAll(".copy-btn").forEach(function (button) {
+          button.addEventListener("click", function () {
+            var target = document.getElementById(button.getAttribute("data-copy-target"));
+            if (!target) return;
+            var text = (target.textContent || "").trim();
+            navigator.clipboard
+              .writeText(text)
+              .then(function () {
+                button.classList.add("copied");
+                var original = button.getAttribute("aria-label");
+                button.setAttribute("aria-label", "Copied");
+                setTimeout(function () {
+                  button.classList.remove("copied");
+                  if (original) button.setAttribute("aria-label", original);
+                }, 1200);
+              })
+              .catch(function () {
+                var range = document.createRange();
+                range.selectNodeContents(target);
+                var selection = window.getSelection();
+                if (selection) {
+                  selection.removeAllRanges();
+                  selection.addRange(range);
+                }
+              });
+          });
         });
-      });
+      })();
     </script>
   </body>
 </html>


### PR DESCRIPTION
Complete reimagining of the repobar.app website (GitHub Pages, docs/index.html).

## Concept

The site now behaves like the place RepoBar lives: a macOS desktop at night.

- A fixed faux macOS menu bar is the site nav, with a live clock and a rotating status ticker.
- The hero features a hand-built CSS recreation of the RepoBar dropdown - contribution header, filter pills, repo cards with CI dots. One card's CI run finishes while you watch.
- A contribution-graph strip spells REPOBAR in heatmap cells, animated on scroll.
- Features are presented as two macOS-style menu panels with hover highlights.
- Dark-only design; Instrument Serif / Instrument Sans / Geist Mono replace Fraunces / IBM Plex Mono.

## Content updates

- Adds current features the old page missed: reference monitor, multi-account support, release notifications, changelog previews.
- Fixes the stale minimum system requirement: macOS 15 (Sequoia), not Sonoma (Package.swift declares .macOS(.v15)).
- Keeps all factual copy aligned with README/docs: GitHub App auth with PAT fallback, gitcrawl.sh archive format, CLI examples, install paths, FAQ.
- Adds JSON-LD SoftwareApplication metadata.

## Robustness

- No horizontal overflow at 375/768/1440 (verified with Playwright).
- Scroll-reveal styling is gated on an html.js class, so the page renders fully without JavaScript.
- prefers-reduced-motion disables all animation.
- CNAME, .well-known/apple-app-site-association, llms.txt, and assets untouched.
