### PR TITLE
feat: animate menu loading with REPOBAR contribution-grid wordmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.8.6 - Unreleased
 
+- Replace the loading spinners in the menu with an animated contribution graph that spells "REPOBAR" while repositories and the contribution heatmap load, matching the repobar.app wordmark animation.
 - Reimagine the repobar.app website as a dark, menu-bar-themed page with a live menu mockup, a contribution-graph wordmark, current features like the reference monitor and multi-account support, and the corrected macOS 15 minimum system requirement.
 
 ## 0.8.5 - 2026-07-05

--- a/Sources/RepoBar/Views/ContributionHeaderView.swift
+++ b/Sources/RepoBar/Views/ContributionHeaderView.swift
@@ -56,8 +56,9 @@ struct ContributionHeaderView: View {
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                     .fill(Color.gray.opacity(0.12))
                 if showProgress {
-                    ProgressView()
-                        .controlSize(.regular)
+                    RepoBarLoadingGridView()
+                        .frame(height: Self.graphHeight - 8)
+                        .padding(.horizontal, 8)
                 }
             }
             .frame(maxWidth: .infinity, minHeight: Self.loadingHeight)

--- a/Sources/RepoBar/Views/MenuBannerViews.swift
+++ b/Sources/RepoBar/Views/MenuBannerViews.swift
@@ -308,13 +308,15 @@ struct MenuLoadingRowView: View {
     }
 
     var body: some View {
-        VStack(spacing: 8) {
-            ProgressView()
-                .controlSize(.regular)
+        VStack(spacing: 12) {
+            RepoBarLoadingGridView()
+                .frame(height: 44)
             Text(self.text)
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity, minHeight: 120)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(self.text)
     }
 }

--- a/Sources/RepoBar/Views/RepoBarLoadingView.swift
+++ b/Sources/RepoBar/Views/RepoBarLoadingView.swift
@@ -1,0 +1,175 @@
+import SwiftUI
+
+/// Pixel-glyph layout for the animated "REPOBAR" contribution grid shown while
+/// data loads. Mirrors the wordmark animation on https://repobar.app.
+enum RepoBarWordmarkGrid {
+    static let rows = 7
+    static let sidePadding = 3
+    static let word = "REPOBAR"
+    /// Each glyph is 5 columns wide plus 1 spacer column between letters.
+    static let columns = sidePadding * 2 + word.count * 6 - 1
+
+    private static let glyphs: [Character: [String]] = [
+        "R": ["XXXX.", "X...X", "X...X", "XXXX.", "X.X..", "X..X.", "X...X"],
+        "E": ["XXXXX", "X....", "X....", "XXXX.", "X....", "X....", "XXXXX"],
+        "P": ["XXXX.", "X...X", "X...X", "XXXX.", "X....", "X....", "X...."],
+        "O": [".XXX.", "X...X", "X...X", "X...X", "X...X", "X...X", ".XXX."],
+        "B": ["XXXX.", "X...X", "X...X", "XXXX.", "X...X", "X...X", "XXXX."],
+        "A": [".XXX.", "X...X", "X...X", "XXXXX", "X...X", "X...X", "X...X"]
+    ]
+
+    /// Row-major lit mask: `litMask[row][column]` is true where the wordmark
+    /// has a filled pixel.
+    static let litMask: [[Bool]] = {
+        var mask = Array(repeating: Array(repeating: false, count: columns), count: rows)
+        for (letterIndex, letter) in word.enumerated() {
+            guard let glyph = glyphs[letter] else { continue }
+
+            let offset = sidePadding + letterIndex * 6
+            for row in 0 ..< rows {
+                for (columnIndex, pixel) in glyph[row].enumerated() where pixel == "X" {
+                    mask[row][offset + columnIndex] = true
+                }
+            }
+        }
+        return mask
+    }()
+}
+
+/// Contribution-graph grid that spells "REPOBAR" while content loads: cells
+/// pop in staggered by column (like the website's year strip), then shimmer
+/// gently for as long as loading continues.
+struct RepoBarLoadingGridView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var startDate = Date()
+
+    private struct Cell {
+        let column: Int
+        let row: Int
+        /// Palette bucket 0...4; letters use 3/4, sparse background noise uses 1.
+        let level: Int
+        let appearDelay: Double
+    }
+
+    private static let appearDuration = 0.5
+    private static let columnStagger = 0.028
+    private static let shimmerPeriod = 2.6
+
+    private static let cells: [Cell] = {
+        var generator = SplitMix64(seed: 0x5245_504F_4241_5221)
+        var cells: [Cell] = []
+        cells.reserveCapacity(RepoBarWordmarkGrid.rows * RepoBarWordmarkGrid.columns)
+        for row in 0 ..< RepoBarWordmarkGrid.rows {
+            for column in 0 ..< RepoBarWordmarkGrid.columns {
+                let lit = RepoBarWordmarkGrid.litMask[row][column]
+                let level: Int = if lit {
+                    Double.random(in: 0 ... 1, using: &generator) > 0.35 ? 4 : 3
+                } else {
+                    Double.random(in: 0 ... 1, using: &generator) > 0.88 ? 1 : 0
+                }
+                let jitter = Double.random(in: 0 ... 0.2, using: &generator)
+                cells.append(Cell(
+                    column: column,
+                    row: row,
+                    level: level,
+                    appearDelay: Double(column) * columnStagger + jitter
+                ))
+            }
+        }
+        return cells
+    }()
+
+    var body: some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 30.0, paused: self.reduceMotion)) { timeline in
+            Canvas { context, size in
+                let elapsed = timeline.date.timeIntervalSince(self.startDate)
+                self.draw(in: &context, size: size, elapsed: elapsed, animated: !self.reduceMotion)
+            }
+        }
+        .accessibilityHidden(true)
+    }
+
+    private func draw(in context: inout GraphicsContext, size: CGSize, elapsed: Double, animated: Bool) {
+        let columns = CGFloat(RepoBarWordmarkGrid.columns)
+        let rows = CGFloat(RepoBarWordmarkGrid.rows)
+        let step = min(size.width / columns, size.height / rows)
+        guard step > 0 else { return }
+
+        let gap = max(0.5, step * 0.18)
+        let side = step - gap
+        let originX = (size.width - (step * columns - gap)) / 2
+        let originY = (size.height - (step * rows - gap)) / 2
+        let palette = Self.palette(for: self.colorScheme)
+
+        for cell in Self.cells {
+            var opacity = 1.0
+            var scale = 1.0
+            if animated, cell.level >= 3 {
+                let progress = min(max((elapsed - cell.appearDelay) / Self.appearDuration, 0), 1)
+                let eased = 1 - pow(1 - progress, 3)
+                opacity = eased
+                scale = 0.4 + 0.6 * eased
+                // Gentle brightness wave across the word once the pop-in settled.
+                let shimmerStrength = min(max((elapsed - 1.8) / 0.8, 0), 1)
+                if shimmerStrength > 0 {
+                    let phase = elapsed * (2 * .pi / Self.shimmerPeriod) - Double(cell.column) * 0.28
+                    opacity *= 1 - 0.25 * shimmerStrength * (0.5 + 0.5 * sin(phase))
+                }
+            }
+            guard opacity > 0 else { continue }
+
+            let scaledSide = side * scale
+            let inset = (side - scaledSide) / 2
+            let rect = CGRect(
+                x: originX + CGFloat(cell.column) * step + inset,
+                y: originY + CGFloat(cell.row) * step + inset,
+                width: scaledSide,
+                height: scaledSide
+            )
+            context.fill(
+                Path(roundedRect: rect, cornerRadius: scaledSide * 0.2),
+                with: .color(palette[cell.level].opacity(opacity))
+            )
+        }
+    }
+
+    /// Level 0 mirrors the empty heatmap cell; lit levels follow GitHub's
+    /// contribution greens — the bright dark-mode set matches the website,
+    /// the light set matches `HeatmapRasterView`'s in-app palette.
+    private static func palette(for colorScheme: ColorScheme) -> [Color] {
+        if colorScheme == .dark {
+            return [
+                Color(nsColor: .quaternaryLabelColor),
+                Color(red: 0.055, green: 0.267, blue: 0.161),
+                Color(red: 0.0, green: 0.427, blue: 0.196),
+                Color(red: 0.149, green: 0.651, blue: 0.255),
+                Color(red: 0.224, green: 0.827, blue: 0.325)
+            ]
+        }
+        return [
+            Color(nsColor: .quaternaryLabelColor),
+            Color(red: 0.74, green: 0.86, blue: 0.75).opacity(0.6),
+            Color(red: 0.56, green: 0.76, blue: 0.6).opacity(0.65),
+            Color(red: 0.3, green: 0.62, blue: 0.38).opacity(0.7),
+            Color(red: 0.18, green: 0.46, blue: 0.24).opacity(0.75)
+        ]
+    }
+}
+
+/// Deterministic RNG so the grid's speckle pattern is stable across renders.
+private struct SplitMix64: RandomNumberGenerator {
+    private var state: UInt64
+
+    init(seed: UInt64) {
+        self.state = seed
+    }
+
+    mutating func next() -> UInt64 {
+        self.state &+= 0x9E37_79B9_7F4A_7C15
+        var z = self.state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+}

--- a/Tests/RepoBarTests/RepoBarWordmarkGridTests.swift
+++ b/Tests/RepoBarTests/RepoBarWordmarkGridTests.swift
@@ -1,0 +1,42 @@
+@testable import RepoBar
+import Testing
+
+struct RepoBarWordmarkGridTests {
+    @Test
+    func `grid dimensions match the seven letter wordmark`() {
+        // 7 letters × (5 glyph columns + 1 spacer) − trailing spacer + padding.
+        #expect(RepoBarWordmarkGrid.columns == 47)
+        #expect(RepoBarWordmarkGrid.rows == 7)
+        #expect(RepoBarWordmarkGrid.litMask.count == RepoBarWordmarkGrid.rows)
+        #expect(RepoBarWordmarkGrid.litMask.allSatisfy { $0.count == RepoBarWordmarkGrid.columns })
+    }
+
+    @Test
+    func `padding and letter spacer columns stay unlit`() {
+        for row in 0 ..< RepoBarWordmarkGrid.rows {
+            for column in 0 ..< RepoBarWordmarkGrid.sidePadding {
+                #expect(RepoBarWordmarkGrid.litMask[row][column] == false)
+                #expect(RepoBarWordmarkGrid.litMask[row][RepoBarWordmarkGrid.columns - 1 - column] == false)
+            }
+            for letterIndex in 0 ..< (RepoBarWordmarkGrid.word.count - 1) {
+                let spacer = RepoBarWordmarkGrid.sidePadding + letterIndex * 6 + 5
+                #expect(RepoBarWordmarkGrid.litMask[row][spacer] == false)
+            }
+        }
+    }
+
+    @Test
+    func `every letter lights pixels and repeated Rs match`() {
+        func letterMask(_ letterIndex: Int) -> [[Bool]] {
+            let offset = RepoBarWordmarkGrid.sidePadding + letterIndex * 6
+            return RepoBarWordmarkGrid.litMask.map { row in Array(row[offset ..< offset + 5]) }
+        }
+
+        for letterIndex in 0 ..< RepoBarWordmarkGrid.word.count {
+            let litCount = letterMask(letterIndex).joined().count(where: { $0 })
+            #expect(litCount > 10, "letter \(letterIndex) should light a full glyph")
+        }
+        // R appears at positions 0 and 6; identical glyphs must render identically.
+        #expect(letterMask(0) == letterMask(6))
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the generic spinner loading states with an animated contribution graph that spells REPOBAR — the same wordmark animation the repobar.app website uses.

- New `RepoBarLoadingGridView`: SwiftUI `Canvas` + `TimelineView`, 47×7 grid of 5×7 pixel glyphs. Cells pop in staggered by column with the site's timing (0.5 s ease-out, 0.028 s/column stagger + jitter), then a gentle brightness wave travels across the word while loading continues.
- Shown in the menu's repo-list loading row (startup) and in the contribution heatmap placeholder while contributions load.
- Bright GitHub contribution greens in dark mode (website look); the app's muted heatmap palette in light mode. Level-0 cells use `quaternaryLabelColor`, plus sparse level-1 speckle like the site.
- Respects Reduce Motion (renders the finished grid statically) and hides the decorative grid from accessibility; the loading row exposes its text label instead.
- Deterministic seeded RNG so the speckle/level pattern is stable across frames and renders.

## Testing

- `pnpm check` green: swiftformat, swiftlint, 665 tests including new `RepoBarWordmarkGridTests` (grid dimensions, spacer/padding columns, glyph coverage).
- Verified live in an `NSMenu` with a status-item harness hosting the exact view: the grid animates during menu tracking (screenshot below taken from the open menu).

## Screenshot

Captured from the open menu (dark mode), pop-in complete:

![REPOBAR loading animation in the menu](https://gist.githubusercontent.com/steipete/63f4405eef085b04bfab4f91d83f3b67/raw/repobar-loading-pr.png)
