### PR TITLE
fix: make PAT token field visible and clearly focusable

### DIFF
--- a/Sources/RepoBar/Settings/AccountSettingsView.swift
+++ b/Sources/RepoBar/Settings/AccountSettingsView.swift
@@ -101,10 +101,11 @@ struct AccountSettingsView: View {
                     .pickerStyle(.segmented)
 
                     if self.authMethod == .pat {
-                        LabeledContent("Token") {
-                            SecureField("ghp_...", text: self.$patInput)
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Token")
+                            SecureField("ghp_… or github_pat_…", text: self.$patInput)
+                                .textFieldStyle(.roundedBorder)
                                 .frame(minWidth: self.enterpriseFieldMinWidth)
-                                .layoutPriority(1)
                         }
                         Text("Recommended for SAML SSO organizations. Required scopes: repo, read:org")
                             .font(.caption)


### PR DESCRIPTION
## Problem

In **Preferences → Accounts → Add Account**, signing in with a Personal Access Token is confusing because the **Token** field is hard to see. It's a borderless `SecureField` wrapped in a right-aligned `LabeledContent`, so:

- there's no visible box — the field looks like empty space;
- the text cursor blinks at the far-right edge with no focus ring, so it isn't clear the field is selected or where to paste;
- because it isn't obvious you're typing into it, **Sign in with Token** stays disabled (`patInput.isEmpty`) and the form looks broken.

## Fix

Give the Token field a `.roundedBorder` style and a full-width, left-aligned labeled layout (label above the field). It now reads as a clear, clickable box that spans the row and shows the standard macOS focus ring when selected. The placeholder also hints fine-grained tokens (`github_pat_…`).

Presentation only — the `$patInput` binding, validation, and sign-in flow are unchanged.

### Before
Borderless field on the trailing edge of a `LabeledContent` row: no box outline, cursor at the far right, no focus ring on selection.

### After
Full-width bordered field beneath a "Token" label: clear box, spans the row, standard focus ring when selected.