### PR TITLE
build(deps): refresh 0.8.7 dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.8.7 - Unreleased
 
+- Refresh npm and Swift package resolutions, keep Commander pinned to its compatible positional-argument contract, and make SwiftPM tests load Sparkle from the Xcode 26 product layout.
+
 ## 0.8.6 - 2026-07-06
 
 - Replace the loading spinners in the menu with an animated contribution graph that spells "REPOBAR" while repositories and the contribution heatmap load, matching the repobar.app wordmark animation.

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "bf9950d42b5ec432d4b7c3b3b0de9344a757aebffe8e60aafc3679692c7b7fdd",
+  "originHash" : "ce363525a7fc2d5df7e60cd885b7aca447defb1fe96b98934bf21490c5eaf9c8",
   "pins" : [
     {
       "identity" : "apollo-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apollographql/apollo-ios",
       "state" : {
-        "revision" : "5a8d18cc239dd3c4b31c9e13e671dbcef5e4072a",
-        "version" : "2.2.0"
+        "revision" : "a6668545666c48b25ddb67c1329048633f45168b",
+        "version" : "2.3.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher",
       "state" : {
-        "revision" : "ac632bd26a1c00f139ff62fd01806f21cf67325e",
-        "version" : "8.10.0"
+        "revision" : "410984bf301f4fa224fe56277b3f8672cc465c79",
+        "version" : "8.11.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
-        "version" : "2.9.3"
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/steipete/Swiftdansi",
       "state" : {
-        "revision" : "94b7818be2103ef7c466027bcfce1657833c83bb",
-        "version" : "0.2.1"
+        "revision" : "66b33f2bb01d0484ede2504f3d89b1941941bf72",
+        "version" : "0.2.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .executable(name: "repobarcli", targets: ["repobarcli"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/steipete/Commander", from: "0.2.0"),
+        .package(url: "https://github.com/steipete/Commander", exact: "0.2.2"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.8.1"),
         .package(url: "https://github.com/orchetect/MenuBarExtraAccess", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-algorithms", from: "1.2.1"),

--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -9,5 +9,14 @@ mkdir -p "${CACHE_PATH}"
 
 ./Scripts/swiftpm_sanitize.sh
 
-echo "==> swift test"
-swift test -q --cache-path "${CACHE_PATH}" "$@"
+echo "==> swift build --build-tests"
+swift build -q --build-tests --cache-path "${CACHE_PATH}"
+
+BIN_PATH="$(swift build --show-bin-path --cache-path "${CACHE_PATH}")"
+if [ -d "${BIN_PATH}/Sparkle.framework" ]; then
+  mkdir -p "${BIN_PATH}/PackageFrameworks"
+  ln -sfn "../Sparkle.framework" "${BIN_PATH}/PackageFrameworks/Sparkle.framework"
+fi
+
+echo "==> swift test --skip-build"
+swift test -q --skip-build --cache-path "${CACHE_PATH}" "$@"

--- a/package.json
+++ b/package.json
@@ -25,15 +25,15 @@
     "ghrest": "pnpm exec tsx Scripts/ghrest.ts"
   },
   "dependencies": {
-    "graphql": "^17.0.1"
+    "graphql": "^17.0.2"
   },
   "devDependencies": {
     "@octokit/request": "^10.0.11",
-    "chalk": "^5.6.2",
+    "chalk": "^6.0.0",
     "commander": "^15.0.0",
     "dotenv-cli": "^11.0.0",
     "ora": "^9.4.1",
-    "tsx": "^4.22.4",
+    "tsx": "^4.23.1",
     "zod": "^4.4.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,15 +9,15 @@ importers:
   .:
     dependencies:
       graphql:
-        specifier: ^17.0.1
-        version: 17.0.1
+        specifier: ^17.0.2
+        version: 17.0.2
     devDependencies:
       '@octokit/request':
         specifier: ^10.0.11
         version: 10.0.11
       chalk:
-        specifier: ^5.6.2
-        version: 5.6.2
+        specifier: ^6.0.0
+        version: 6.0.0
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -28,8 +28,8 @@ importers:
         specifier: ^9.4.1
         version: 9.4.1
       tsx:
-        specifier: ^4.22.4
-        version: 4.22.4
+        specifier: ^4.23.1
+        version: 4.23.1
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -218,6 +218,10 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  chalk@6.0.0:
+    resolution: {integrity: sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg==}
+    engines: {node: '>=22'}
+
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
@@ -268,8 +272,8 @@ packages:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
 
-  graphql@17.0.1:
-    resolution: {integrity: sha512-8eWbg5Zcv/8o20nzEjHUGPTj20MLFJjc5kagbIPxbaeGxvFwpitJhemEC/k17n5+UD4M/9ea5rTuce78mELujQ==}
+  graphql@17.0.2:
+    resolution: {integrity: sha512-FRWbddMxfkjiB7z+aQDWIR+E34xo9I8c9mtK2RPv8PmMzKRvrdsreHL/Ui/TmwHJfhHChEtsFPyMHKI+xuarQQ==}
     engines: {node: ^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0}
 
   is-interactive@2.0.0:
@@ -337,8 +341,8 @@ packages:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
-  tsx@4.22.4:
-    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+  tsx@4.23.1:
+    resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -465,6 +469,8 @@ snapshots:
 
   chalk@5.6.2: {}
 
+  chalk@6.0.0: {}
+
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
@@ -530,7 +536,7 @@ snapshots:
 
   get-east-asian-width@1.6.0: {}
 
-  graphql@17.0.1: {}
+  graphql@17.0.2: {}
 
   is-interactive@2.0.0: {}
 
@@ -590,7 +596,7 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
-  tsx@4.22.4:
+  tsx@4.23.1:
     dependencies:
       esbuild: 0.28.1
     optionalDependencies:


### PR DESCRIPTION
## Summary

- refresh npm dependencies, including Chalk 6, GraphQL 17.0.2, and tsx 4.23.1
- refresh Swift package resolutions for Apollo, Kingfisher, Sparkle, and Swiftdansi
- keep Commander pinned at 0.2.2 because 0.2.4 breaks the established positional-argument CLI contract
- stage Sparkle in SwiftPM's expected PackageFrameworks path before running Xcode 26 tests
- rebase onto the landed SwiftFormat 0.62 migration

## Exact-head proof

Head: `abed42fd0366b61a51c5324c6fbaa286c3d8a010`
Base: `773ef3f16eeed3957f0e3f671fd116f1d2457e97`

- `pnpm install --frozen-lockfile`: passed
- `pnpm check`: formatter idempotent, SwiftLint clean, 76 CLI tests and 589 app/core tests passed (665 total)
- `pnpm build`: passed
- `pnpm outdated --json`: empty
- `pnpm audit --prod --audit-level=low`: no known vulnerabilities
- `bash -n Scripts/test.sh` and `swift package dump-package`: passed
- signed `RepoBar.app` launch and bundled CLI `--help`: passed using Developer ID Application: Peter Steinberger (`Y5PE65HELJ`)
- `codesign --verify --deep --strict`: passed for the launched bundle
- Codex autoreview: clean, no accepted or actionable findings
- public model identifier gate: pass; no model identifiers changed
