### PR TITLE
chore: format with SwiftFormat 0.62

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -13,3 +13,4 @@
 --enable blankLinesAfterGuardStatements
 --enable isEmpty
 --enable privateStateVariables
+--disable wrapMultilineStatementBraces

--- a/Sources/RepoBar/App/AppState+Actions.swift
+++ b/Sources/RepoBar/App/AppState+Actions.swift
@@ -22,13 +22,17 @@ extension AppState {
             repositories: repos,
             monitoredOwners: self.session.settings.monitoredOwners
         )
-        if Task.isCancelled { return }
+        if Task.isCancelled {
+            return
+        }
 
         await self.publishActionsOwnerPlaceholders(owners: owners, planTier: userTier)
 
         var snapshots: [ActionsOrgSnapshot] = []
         for owner in owners {
-            if Task.isCancelled { return }
+            if Task.isCancelled {
+                return
+            }
 
             let ownerRepos = repos.filter { $0.owner.lowercased() == owner.name.lowercased() }
             let runners = await Self.fetchRunners(github: github, owner: owner.name, repos: ownerRepos)

--- a/Sources/RepoBar/App/AppState+Activity.swift
+++ b/Sources/RepoBar/App/AppState+Activity.swift
@@ -99,7 +99,9 @@ extension AppState {
             }
             var out: [Repository] = []
             for await repo in group {
-                if let repo { out.append(repo) }
+                if let repo {
+                    out.append(repo)
+                }
             }
             return out
         }

--- a/Sources/RepoBar/App/AppState+Contributions.swift
+++ b/Sources/RepoBar/App/AppState+Contributions.swift
@@ -6,9 +6,13 @@ extension AppState {
     func loadContributionHeatmapIfNeeded(for username: String) async {
         guard self.session.settings.appearance.showContributionHeader else { return }
 
-        if self.session.contributionUser == username, !self.session.contributionHeatmap.isEmpty { return }
+        if self.session.contributionUser == username, !self.session.contributionHeatmap.isEmpty {
+            return
+        }
         let hasExisting = self.session.contributionUser == username && !self.session.contributionHeatmap.isEmpty
-        if self.session.contributionIsLoading, self.session.contributionUser == username { return }
+        if self.session.contributionIsLoading, self.session.contributionUser == username {
+            return
+        }
         if let cached = ContributionCacheStore.load(), cached.username == username, cached.isValid {
             await MainActor.run {
                 self.session.contributionUser = username

--- a/Sources/RepoBar/App/AppState+Refresh.swift
+++ b/Sources/RepoBar/App/AppState+Refresh.swift
@@ -13,7 +13,9 @@ extension AppState {
         if hasFreshSnapshot {
             return
         }
-        if self.refreshTask != nil || self.menuRefreshTask != nil { return }
+        if self.refreshTask != nil || self.menuRefreshTask != nil {
+            return
+        }
         self.lastMenuRefreshRequest = now
         self.menuRefreshTask = Task { [weak self] in
             try? await Task.sleep(for: .milliseconds(250))
@@ -49,7 +51,9 @@ extension AppState {
         let localSettings = self.session.settings.localProjects
         self.session.localProjectsScanInProgress = (localSettings.rootPath?.isEmpty == false)
         do {
-            if Task.isCancelled { return }
+            if Task.isCancelled {
+                return
+            }
             let now = Date()
             self.updateHeatmapRange(now: now)
             if await self.hasAuthenticationMaterial() == false {
@@ -233,7 +237,9 @@ extension AppState {
         let options = RepositoryDetailOptions(fetchHeatmap: fetchHeatmap)
         var detailed: [Repository] = []
         for batch in repos.chunked(into: limit) {
-            if Task.isCancelled { break }
+            if Task.isCancelled {
+                break
+            }
             let batchResult = await withTaskGroup(of: Repository?.self) { group in
                 for repo in batch {
                     group.addTask { [github, options] in
@@ -242,7 +248,9 @@ extension AppState {
                 }
                 var batchOutput: [Repository] = []
                 for await repo in group {
-                    if let repo { batchOutput.append(repo) }
+                    if let repo {
+                        batchOutput.append(repo)
+                    }
                 }
                 return batchOutput
             }

--- a/Sources/RepoBar/App/AppState+Visibility.swift
+++ b/Sources/RepoBar/App/AppState+Visibility.swift
@@ -58,7 +58,9 @@ extension AppState {
         let pinned = self.session.settings.repoList.pinnedRepositories
         let pinnedIndex = pinned.enumerated().reduce(into: [String: Int]()) { dict, entry in
             let key = self.normalizedFullName(entry.element)
-            if dict[key] == nil { dict[key] = entry.offset }
+            if dict[key] == nil {
+                dict[key] = entry.offset
+            }
         }
         return repos.map { repo in
             if let idx = pinnedIndex[self.normalizedFullName(repo.fullName)] {

--- a/Sources/RepoBar/App/AppState.swift
+++ b/Sources/RepoBar/App/AppState.swift
@@ -374,7 +374,9 @@ extension AppState {
             .sorted {
                 let lhsDate = $0.latestActivity?.date ?? $0.pushedAt ?? .distantPast
                 let rhsDate = $1.latestActivity?.date ?? $1.pushedAt ?? .distantPast
-                if lhsDate != rhsDate { return lhsDate > rhsDate }
+                if lhsDate != rhsDate {
+                    return lhsDate > rhsDate
+                }
                 return $0.fullName.localizedCaseInsensitiveCompare($1.fullName) == .orderedAscending
             }
 
@@ -458,7 +460,9 @@ extension AppState {
         return matches
             .filter { seen.insert($0.url).inserted }
             .sorted {
-                if $0.updatedAt != $1.updatedAt { return $0.updatedAt > $1.updatedAt }
+                if $0.updatedAt != $1.updatedAt {
+                    return $0.updatedAt > $1.updatedAt
+                }
                 return ($0.createdAt ?? .distantPast) > ($1.createdAt ?? .distantPast)
             }
     }
@@ -477,7 +481,9 @@ extension AppState {
             .sorted {
                 let lhs = $0.latestActivity?.date ?? $0.pushedAt ?? .distantPast
                 let rhs = $1.latestActivity?.date ?? $1.pushedAt ?? .distantPast
-                if lhs != rhs { return lhs > rhs }
+                if lhs != rhs {
+                    return lhs > rhs
+                }
                 return $0.fullName.localizedCaseInsensitiveCompare($1.fullName) == .orderedAscending
             }
 

--- a/Sources/RepoBar/App/Session.swift
+++ b/Sources/RepoBar/App/Session.swift
@@ -62,7 +62,9 @@ enum AccountState: Equatable {
     case loggedIn(UserIdentity)
 
     var isLoggedIn: Bool {
-        if case .loggedIn = self { return true }
+        if case .loggedIn = self {
+            return true
+        }
         return false
     }
 }

--- a/Sources/RepoBar/Auth/OAuthCoordinator.swift
+++ b/Sources/RepoBar/Auth/OAuthCoordinator.swift
@@ -38,7 +38,9 @@ final class OAuthCoordinator {
     }
 
     func loadTokens() -> OAuthTokens? {
-        if self.hasLoadedTokens { return self.cachedTokens }
+        if self.hasLoadedTokens {
+            return self.cachedTokens
+        }
         self.hasLoadedTokens = true
         let tokens = try? self.tokenStore.load()
         self.cachedTokens = tokens
@@ -52,7 +54,9 @@ final class OAuthCoordinator {
         let cachedTokens = self.cachedTokens
         let shouldReuseCachedTokens = force == false
             && cachedTokens?.expiresAt.map { $0 > Date().addingTimeInterval(60) } != false
-        if shouldReuseCachedTokens, let cachedTokens { return cachedTokens }
+        if shouldReuseCachedTokens, let cachedTokens {
+            return cachedTokens
+        }
 
         let refreshed = try await self.tokenRefresher.refreshIfNeeded(host: self.lastHost, force: force)
         if refreshed != nil {

--- a/Sources/RepoBar/Auth/PATAuthenticator.swift
+++ b/Sources/RepoBar/Auth/PATAuthenticator.swift
@@ -95,7 +95,9 @@ public final class PATAuthenticator {
 
     /// Loads the stored PAT from Keychain.
     public func loadPAT() -> String? {
-        if self.hasLoadedPAT { return self.cachedPAT }
+        if self.hasLoadedPAT {
+            return self.cachedPAT
+        }
         self.hasLoadedPAT = true
         let pat = try? self.tokenStore.loadPAT()
         self.cachedPAT = pat

--- a/Sources/RepoBar/Settings/AccountSettingsView.swift
+++ b/Sources/RepoBar/Settings/AccountSettingsView.swift
@@ -476,7 +476,9 @@ struct AccountSettingsView: View {
         guard !self.enterpriseHost.isEmpty else { return nil }
         guard var components = URLComponents(string: enterpriseHost) else { return nil }
 
-        if components.scheme == nil { components.scheme = "https" }
+        if components.scheme == nil {
+            components.scheme = "https"
+        }
         guard components.scheme?.lowercased() == "https", components.host != nil else { return nil }
 
         components.path = ""
@@ -488,7 +490,9 @@ struct AccountSettingsView: View {
     private func validateToken() async {
         guard case .loggedIn = self.session.account else { return }
 
-        if self.tokenValidation == .checking { return }
+        if self.tokenValidation == .checking {
+            return
+        }
         self.tokenValidation = .checking
         let started = Date()
         await self.logAuth("Auth: token check started")
@@ -515,7 +519,9 @@ struct AccountSettingsView: View {
     private func refreshToken() async {
         guard case .loggedIn = self.session.account else { return }
 
-        if self.tokenValidation == .checking { return }
+        if self.tokenValidation == .checking {
+            return
+        }
         self.tokenValidation = .checking
         let started = Date()
         await self.logAuth("Auth: token refresh started")

--- a/Sources/RepoBar/Settings/AdvancedSettingsView.swift
+++ b/Sources/RepoBar/Settings/AdvancedSettingsView.swift
@@ -341,7 +341,9 @@ struct AdvancedSettingsView: View {
     private var localRepoSummary: String? {
         guard self.session.settings.localProjects.rootPath != nil else { return nil }
 
-        if self.session.localProjectsScanInProgress { return "Scanning…" }
+        if self.session.localProjectsScanInProgress {
+            return "Scanning…"
+        }
         let total = self.session.localDiscoveredRepoCount
         let matched = self.localMatchedRepoCount
         if total == 0 {
@@ -350,7 +352,9 @@ struct AdvancedSettingsView: View {
             }
             return "No repositories found yet."
         }
-        if matched > 0 { return "Found \(total) local repos · \(matched) match GitHub data." }
+        if matched > 0 {
+            return "Found \(total) local repos · \(matched) match GitHub data."
+        }
         return "Found \(total) local repos."
     }
 

--- a/Sources/RepoBar/Settings/DisplaySettingsView.swift
+++ b/Sources/RepoBar/Settings/DisplaySettingsView.swift
@@ -121,7 +121,9 @@ struct DisplaySettingsView: View {
     private func mainMenuVisibility(for item: MainMenuItemID) -> Binding<Bool> {
         Binding(
             get: {
-                if item.isRequired { return true }
+                if item.isRequired {
+                    return true
+                }
                 return !self.session.settings.menuCustomization.hiddenMainMenuItems.contains(item)
             },
             set: { isVisible in

--- a/Sources/RepoBar/Settings/RepoAutocompleteWindowView.swift
+++ b/Sources/RepoBar/Settings/RepoAutocompleteWindowView.swift
@@ -267,10 +267,18 @@ private struct RepoAutocompleteRow: View {
                             .truncationMode(.middle)
 
                         HStack(spacing: 6) {
-                            if self.repo.isFork { Badge(text: "Fork") }
-                            if self.repo.isArchived { Badge(text: "Archived") }
-                            if self.repo.discussionsEnabled == true { Badge(text: "Discussions") }
-                            if let lang = self.repo.language, !lang.isEmpty { Badge(text: lang) }
+                            if self.repo.isFork {
+                                Badge(text: "Fork")
+                            }
+                            if self.repo.isArchived {
+                                Badge(text: "Archived")
+                            }
+                            if self.repo.discussionsEnabled == true {
+                                Badge(text: "Discussions")
+                            }
+                            if let lang = self.repo.language, !lang.isEmpty {
+                                Badge(text: lang)
+                            }
                         }
                     }
 
@@ -361,20 +369,32 @@ private struct RepoAutocompleteRow: View {
     private static func compactAge(since date: Date) -> String {
         let seconds = max(0, Date().timeIntervalSince(date))
         let minutes = Int(seconds / 60)
-        if minutes < 1 { return "now" }
-        if minutes < 60 { return "\(minutes)m" }
+        if minutes < 1 {
+            return "now"
+        }
+        if minutes < 60 {
+            return "\(minutes)m"
+        }
 
         let hours = minutes / 60
-        if hours < 24 { return "\(hours)h" }
+        if hours < 24 {
+            return "\(hours)h"
+        }
 
         let days = hours / 24
-        if days < 7 { return "\(days)d" }
+        if days < 7 {
+            return "\(days)d"
+        }
 
         let weeks = days / 7
-        if weeks < 8 { return "\(weeks)w" }
+        if weeks < 8 {
+            return "\(weeks)w"
+        }
 
         let months = days / 30
-        if months < 24 { return "\(months)mo" }
+        if months < 24 {
+            return "\(months)mo"
+        }
 
         let years = days / 365
         return "\(years)y"

--- a/Sources/RepoBar/StatusBar/GitHubReferenceStatusCoordinator.swift
+++ b/Sources/RepoBar/StatusBar/GitHubReferenceStatusCoordinator.swift
@@ -166,7 +166,9 @@ final class GitHubReferenceStatusCoordinator: NSObject, NSMenuDelegate {
     }
 
     private func makeMenuIfNeeded() -> NSMenu {
-        if let menu { return menu }
+        if let menu {
+            return menu
+        }
 
         let menu = NSMenu()
         menu.autoenablesItems = false
@@ -176,7 +178,9 @@ final class GitHubReferenceStatusCoordinator: NSObject, NSMenuDelegate {
     }
 
     private func makeStatusItemIfNeeded() -> NSStatusItem {
-        if let statusItem { return statusItem }
+        if let statusItem {
+            return statusItem
+        }
 
         let item = self.statusBar.statusItem(withLength: Self.hiddenItemLength)
         item.autosaveName = "repobar-github-reference"
@@ -243,11 +247,15 @@ final class GitHubReferenceStatusCoordinator: NSObject, NSMenuDelegate {
             if let browserView = item.view as? GitHubReferenceBrowserMenuItemView {
                 browserView.preload()
                 remaining -= 1
-                if remaining <= 0 { return }
+                if remaining <= 0 {
+                    return
+                }
             }
             if let submenu = item.submenu {
                 self.preloadPreviews(in: submenu, remaining: &remaining)
-                if remaining <= 0 { return }
+                if remaining <= 0 {
+                    return
+                }
             }
         }
     }
@@ -267,8 +275,12 @@ final class GitHubReferenceStatusCoordinator: NSObject, NSMenuDelegate {
     }
 
     private func menuTitle(for matches: [GitHubReferenceMatch]) -> String {
-        if matches.count == 1, let match = matches.first { return self.menuTitle(for: match) }
-        if let repo = self.commonRepository(in: matches) { return "\(matches.count) GitHub references in \(repo)" }
+        if matches.count == 1, let match = matches.first {
+            return self.menuTitle(for: match)
+        }
+        if let repo = self.commonRepository(in: matches) {
+            return "\(matches.count) GitHub references in \(repo)"
+        }
         return "\(matches.count) GitHub references"
     }
 
@@ -295,7 +307,9 @@ final class GitHubReferenceStatusCoordinator: NSObject, NSMenuDelegate {
     }
 
     private func accessibilityDescription(for matches: [GitHubReferenceMatch]) -> String {
-        if matches.count == 1, let match = matches.first { return match.kind.label }
+        if matches.count == 1, let match = matches.first {
+            return match.kind.label
+        }
         return "\(matches.count) GitHub References"
     }
 
@@ -309,7 +323,9 @@ final class GitHubReferenceStatusCoordinator: NSObject, NSMenuDelegate {
 
     private func title(for match: GitHubReferenceMatch) -> String {
         var parts = [self.referenceText(for: match)]
-        if let state = match.state?.label { parts.append(state) }
+        if let state = match.state?.label {
+            parts.append(state)
+        }
         parts.append(Self.truncatedMiddle(match.repositoryFullName, maxCharacters: Self.repositoryTitleLimit))
         let title = Self.truncatedTail(match.title, maxCharacters: Self.summaryTitleLimit)
         return "\(parts.joined(separator: " ")): \(title)"
@@ -341,9 +357,13 @@ final class GitHubReferenceStatusCoordinator: NSObject, NSMenuDelegate {
     private func setButtonTitle(_ title: String?, for button: NSStatusBarButton) {
         let rawValue = title ?? ""
         let value = rawValue.isEmpty || button.image == nil ? rawValue : " \(rawValue)"
-        if button.title != value { button.title = value }
+        if button.title != value {
+            button.title = value
+        }
         let position: NSControl.ImagePosition = value.isEmpty ? .imageOnly : .imageLeft
-        if button.imagePosition != position { button.imagePosition = position }
+        if button.imagePosition != position {
+            button.imagePosition = position
+        }
     }
 
     private func audit(_ context: String) {

--- a/Sources/RepoBar/StatusBar/LocalGitMenuCoordinator.swift
+++ b/Sources/RepoBar/StatusBar/LocalGitMenuCoordinator.swift
@@ -572,7 +572,9 @@ final class LocalGitMenuCoordinator {
                         capturedError = error
                     }
                 }
-                if let capturedError { throw capturedError }
+                if let capturedError {
+                    throw capturedError
+                }
             }
             await MainActor.run {
                 switch result {

--- a/Sources/RepoBar/StatusBar/RecentListMenuCoordinator+MenuItems.swift
+++ b/Sources/RepoBar/StatusBar/RecentListMenuCoordinator+MenuItems.swift
@@ -194,7 +194,9 @@ extension RecentListMenuCoordinator {
 
         var options = counts.map { RecentIssueLabelOption(name: $0.key, colorHex: $0.value.colorHex, count: $0.value.count) }
         options.sort {
-            if $0.count != $1.count { return $0.count > $1.count }
+            if $0.count != $1.count {
+                return $0.count > $1.count
+            }
             return $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
         }
 

--- a/Sources/RepoBar/StatusBar/RecentMenuService.swift
+++ b/Sources/RepoBar/StatusBar/RecentMenuService.swift
@@ -69,7 +69,9 @@ final class RecentMenuService {
                 cache: self.recentIssuesCache,
                 wrap: RecentMenuItems.issues,
                 unwrap: { boxed in
-                    if case let .issues(items) = boxed { return items }
+                    if case let .issues(items) = boxed {
+                        return items
+                    }
                     return nil
                 },
                 fetch: { github, owner, name, limit in
@@ -84,7 +86,9 @@ final class RecentMenuService {
                 cache: self.recentPullRequestsCache,
                 wrap: RecentMenuItems.pullRequests,
                 unwrap: { boxed in
-                    if case let .pullRequests(items) = boxed { return items }
+                    if case let .pullRequests(items) = boxed {
+                        return items
+                    }
                     return nil
                 },
                 fetch: { github, owner, name, limit in
@@ -99,7 +103,9 @@ final class RecentMenuService {
                 cache: self.recentReleasesCache,
                 wrap: RecentMenuItems.releases,
                 unwrap: { boxed in
-                    if case let .releases(items) = boxed { return items }
+                    if case let .releases(items) = boxed {
+                        return items
+                    }
                     return nil
                 },
                 fetch: { github, owner, name, limit in
@@ -114,7 +120,9 @@ final class RecentMenuService {
                 cache: self.recentWorkflowRunsCache,
                 wrap: RecentMenuItems.workflowRuns,
                 unwrap: { boxed in
-                    if case let .workflowRuns(items) = boxed { return items }
+                    if case let .workflowRuns(items) = boxed {
+                        return items
+                    }
                     return nil
                 },
                 fetch: { github, owner, name, limit in
@@ -129,7 +137,9 @@ final class RecentMenuService {
                 cache: self.recentDiscussionsCache,
                 wrap: RecentMenuItems.discussions,
                 unwrap: { boxed in
-                    if case let .discussions(items) = boxed { return items }
+                    if case let .discussions(items) = boxed {
+                        return items
+                    }
                     return nil
                 },
                 fetch: { github, owner, name, limit in
@@ -144,7 +154,9 @@ final class RecentMenuService {
                 cache: self.recentTagsCache,
                 wrap: RecentMenuItems.tags,
                 unwrap: { boxed in
-                    if case let .tags(items) = boxed { return items }
+                    if case let .tags(items) = boxed {
+                        return items
+                    }
                     return nil
                 },
                 fetch: { github, owner, name, limit in
@@ -159,7 +171,9 @@ final class RecentMenuService {
                 cache: self.recentBranchesCache,
                 wrap: RecentMenuItems.branches,
                 unwrap: { boxed in
-                    if case let .branches(items) = boxed { return items }
+                    if case let .branches(items) = boxed {
+                        return items
+                    }
                     return nil
                 },
                 fetch: { github, owner, name, limit in
@@ -174,7 +188,9 @@ final class RecentMenuService {
                 cache: self.recentContributorsCache,
                 wrap: RecentMenuItems.contributors,
                 unwrap: { boxed in
-                    if case let .contributors(items) = boxed { return items }
+                    if case let .contributors(items) = boxed {
+                        return items
+                    }
                     return nil
                 },
                 fetch: { github, owner, name, limit in
@@ -188,7 +204,9 @@ final class RecentMenuService {
 
     func cachedRecentCommitCount(fullName: String) -> Int? {
         let key = self.cacheKey(fullName: fullName)
-        if let total = self.recentCommitCounts[key] { return total }
+        if let total = self.recentCommitCounts[key] {
+            return total
+        }
         return self.recentCommitsCache.stale(for: key)?.count
     }
 
@@ -375,7 +393,9 @@ final class RecentListCache<Item: Sendable> {
     }
 
     func task(for key: String, factory: @escaping @Sendable () async throws -> [Item]) -> Task<[Item], Error> {
-        if let existing = self.inflight[key] { return existing }
+        if let existing = self.inflight[key] {
+            return existing
+        }
         let task = Task { try await factory() }
         self.inflight[key] = task
         return task

--- a/Sources/RepoBar/StatusBar/RepoSubmenuBuilder.swift
+++ b/Sources/RepoBar/StatusBar/RepoSubmenuBuilder.swift
@@ -53,9 +53,13 @@ struct RepoSubmenuBuilder {
     ) -> [RepoSubmenuBlock] {
         var blocks: [RepoSubmenuBlock] = []
         for itemID in customization.repoSubmenuOrder {
-            if customization.hiddenRepoSubmenuItems.contains(itemID) { continue }
+            if customization.hiddenRepoSubmenuItems.contains(itemID) {
+                continue
+            }
             let items = self.repoSubmenuItems(for: itemID, repo: repo, isPinned: isPinned)
-            if items.isEmpty { continue }
+            if items.isEmpty {
+                continue
+            }
             blocks.append(RepoSubmenuBlock(group: itemID.group, items: items))
         }
         return blocks

--- a/Sources/RepoBar/StatusBar/StatusBarMenuBuilder+MenuItems.swift
+++ b/Sources/RepoBar/StatusBar/StatusBarMenuBuilder+MenuItems.swift
@@ -323,7 +323,9 @@ extension StatusBarMenuBuilder {
     ) -> NSMenuItem {
         let item = NSMenuItem(title: title, action: action, keyEquivalent: keyEquivalent)
         item.target = self.target
-        if let represented { item.representedObject = represented }
+        if let represented {
+            item.representedObject = represented
+        }
         if let systemImage, let image = self.cachedSystemImage(named: systemImage) {
             item.image = image
         }

--- a/Sources/RepoBar/StatusBar/StatusBarMenuBuilder.swift
+++ b/Sources/RepoBar/StatusBar/StatusBarMenuBuilder.swift
@@ -85,9 +85,13 @@ final class StatusBarMenuBuilder {
         let session = self.appState.session
         var blocks: [MainMenuBlock] = []
         for itemID in customization.mainMenuOrder {
-            if customization.hiddenMainMenuItems.contains(itemID), !itemID.isRequired { continue }
+            if customization.hiddenMainMenuItems.contains(itemID), !itemID.isRequired {
+                continue
+            }
             let items = self.mainMenuItems(for: itemID, repos: repos, settings: settings, session: session)
-            if items.isEmpty { continue }
+            if items.isEmpty {
+                continue
+            }
             blocks.append(MainMenuBlock(group: itemID.group, items: items))
         }
         return blocks
@@ -301,7 +305,9 @@ final class StatusBarMenuBuilder {
             }
         }
         let menuWidth = menu.size.width
-        if menuWidth > 0 { return max(menuWidth, Self.menuFixedWidth) }
+        if menuWidth > 0 {
+            return max(menuWidth, Self.menuFixedWidth)
+        }
         return Self.menuFixedWidth
     }
 
@@ -388,12 +394,16 @@ final class StatusBarMenuBuilder {
     }
 
     private func currentUsername() -> String? {
-        if case let .loggedIn(user) = self.appState.session.account { return user.username }
+        if case let .loggedIn(user) = self.appState.session.account {
+            return user.username
+        }
         return nil
     }
 
     private func currentDisplayName() -> String? {
-        if case let .loggedIn(user) = self.appState.session.account { return user.username }
+        if case let .loggedIn(user) = self.appState.session.account {
+            return user.username
+        }
         return nil
     }
 

--- a/Sources/RepoBar/StatusBar/StatusBarMenuManager+Actions.swift
+++ b/Sources/RepoBar/StatusBar/StatusBarMenuManager+Actions.swift
@@ -193,7 +193,9 @@ extension StatusBarMenuManager {
                         capturedError = error
                     }
                 }
-                if let capturedError { throw capturedError }
+                if let capturedError {
+                    throw capturedError
+                }
             }
             await MainActor.run {
                 self.closeCheckoutProgress()

--- a/Sources/RepoBar/StatusBar/StatusBarMenuManager.swift
+++ b/Sources/RepoBar/StatusBar/StatusBarMenuManager.swift
@@ -263,9 +263,15 @@ final class StatusBarMenuManager: NSObject, NSMenuDelegate {
         let signpost = self.signposter.beginInterval("menuWillOpen")
         defer { self.signposter.endInterval("menuWillOpen", signpost) }
         self.prepareMenuAppearance(menu)
-        if self.recentListCoordinator.handleMenuWillOpen(menu) { return }
-        if self.localGitMenuCoordinator.handleMenuWillOpen(menu) { return }
-        if self.changelogMenuCoordinator.handleMenuWillOpen(menu) { return }
+        if self.recentListCoordinator.handleMenuWillOpen(menu) {
+            return
+        }
+        if self.localGitMenuCoordinator.handleMenuWillOpen(menu) {
+            return
+        }
+        if self.changelogMenuCoordinator.handleMenuWillOpen(menu) {
+            return
+        }
         self.prefetchChangelogIfNeeded(for: menu)
         if menu === self.mainMenu {
             self.prepareMainMenuWillOpen(menu)
@@ -609,7 +615,9 @@ private extension StatusBarMenuManager {
     }
 
     func setButtonImage(_ image: NSImage, for button: NSStatusBarButton) {
-        if button.image === image { return }
+        if button.image === image {
+            return
+        }
         button.image = image
     }
 

--- a/Sources/RepoBar/Support/LocalRepoManager.swift
+++ b/Sources/RepoBar/Support/LocalRepoManager.swift
@@ -164,7 +164,9 @@ actor LocalRepoManager {
         maxDepth: Int
     ) -> [URL] {
         if forceRescan == false, let cached = self.discoveryCache[resolvedRoot] {
-            if now.timeIntervalSince(cached.discoveredAt) < self.discoveryCacheTTL { return cached.repoRoots }
+            if now.timeIntervalSince(cached.discoveredAt) < self.discoveryCacheTTL {
+                return cached.repoRoots
+            }
         }
 
         let roots = LocalProjectsService().discoverRepoRoots(

--- a/Sources/RepoBar/Support/NSColor+Contrast.swift
+++ b/Sources/RepoBar/Support/NSColor+Contrast.swift
@@ -13,7 +13,9 @@ extension NSColor {
         let fg = self.resolvedRGBColor(appearance: appearance)
         let bg = background.resolvedRGBColor(appearance: appearance)
 
-        if fg.contrastRatio(with: bg) >= minRatio { return self }
+        if fg.contrastRatio(with: bg) >= minRatio {
+            return self
+        }
 
         let white = Self.bestMix(foreground: fg, background: bg, target: .white, minRatio: minRatio)
         let black = Self.bestMix(foreground: fg, background: bg, target: .black, minRatio: minRatio)
@@ -21,8 +23,12 @@ extension NSColor {
         if let white, let black {
             return white.mixFraction <= black.mixFraction ? white.color : black.color
         }
-        if let white { return white.color }
-        if let black { return black.color }
+        if let white {
+            return white.color
+        }
+        if let black {
+            return black.color
+        }
 
         let fallbackWhite = fg.blended(with: .white, fraction: 1.0)
         let fallbackBlack = fg.blended(with: .black, fraction: 1.0)
@@ -63,7 +69,9 @@ extension NSColor {
     }
 
     private static func srgbToLinear(_ c: CGFloat) -> CGFloat {
-        if c <= 0.04045 { return c / 12.92 }
+        if c <= 0.04045 {
+            return c / 12.92
+        }
         return pow((c + 0.055) / 1.055, 2.4)
     }
 

--- a/Sources/RepoBar/Support/RepositoryErrorClassifier.swift
+++ b/Sources/RepoBar/Support/RepositoryErrorClassifier.swift
@@ -3,9 +3,15 @@ import Foundation
 enum RepositoryErrorClassifier {
     static func isNonCriticalMenuWarning(_ message: String) -> Bool {
         let lower = message.lowercased()
-        if lower.contains("generating repository stats") { return true }
-        if lower.contains("generating stats for this repo") { return true }
-        if lower.contains("http 202"), lower.contains("stats") { return true }
+        if lower.contains("generating repository stats") {
+            return true
+        }
+        if lower.contains("generating stats for this repo") {
+            return true
+        }
+        if lower.contains("http 202"), lower.contains("stats") {
+            return true
+        }
         return false
     }
 }

--- a/Sources/RepoBar/Support/StatValueFormatter.swift
+++ b/Sources/RepoBar/Support/StatValueFormatter.swift
@@ -2,7 +2,9 @@ import Foundation
 
 enum StatValueFormatter {
     static func compact(_ value: Int) -> String {
-        if value < 1000 { return "\(value)" }
+        if value < 1000 {
+            return "\(value)"
+        }
         if value < 10000 {
             let short = self.oneDecimal(value, divisor: 1000)
             return "\(short)K"

--- a/Sources/RepoBar/Support/TerminalApp.swift
+++ b/Sources/RepoBar/Support/TerminalApp.swift
@@ -32,7 +32,9 @@ enum TerminalApp: String, CaseIterable {
     private static let logger = RepoBarLogging.logger("terminal")
 
     var isInstalled: Bool {
-        if self == .terminal { return true }
+        if self == .terminal {
+            return true
+        }
         return NSWorkspace.shared.urlForApplication(withBundleIdentifier: self.bundleIdentifier) != nil
     }
 
@@ -49,7 +51,9 @@ enum TerminalApp: String, CaseIterable {
     }
 
     static var defaultPreferred: TerminalApp {
-        if let ghostty = installed.first(where: { $0 == .ghostty }) { return ghostty }
+        if let ghostty = installed.first(where: { $0 == .ghostty }) {
+            return ghostty
+        }
         return .terminal
     }
 

--- a/Sources/RepoBar/Views/ActionsLimitsMenuViews.swift
+++ b/Sources/RepoBar/Views/ActionsLimitsMenuViews.swift
@@ -172,8 +172,12 @@ struct ActionsQueueRowView: View {
     }
 
     private static func tint(for remainingPercent: Double) -> Color {
-        if remainingPercent <= 10 { return Color(nsColor: .systemRed) }
-        if remainingPercent <= 30 { return Color(nsColor: .systemOrange) }
+        if remainingPercent <= 10 {
+            return Color(nsColor: .systemRed)
+        }
+        if remainingPercent <= 30 {
+            return Color(nsColor: .systemOrange)
+        }
         return Color(nsColor: .systemGreen)
     }
 }
@@ -342,8 +346,12 @@ struct ActionsMinutesRowView: View {
     }
 
     private static func tint(for remainingPercent: Double) -> Color {
-        if remainingPercent <= 10 { return Color(nsColor: .systemRed) }
-        if remainingPercent <= 30 { return Color(nsColor: .systemOrange) }
+        if remainingPercent <= 10 {
+            return Color(nsColor: .systemRed)
+        }
+        if remainingPercent <= 30 {
+            return Color(nsColor: .systemOrange)
+        }
         return Color(nsColor: .systemGreen)
     }
 }

--- a/Sources/RepoBar/Views/AddRepoView.swift
+++ b/Sources/RepoBar/Views/AddRepoView.swift
@@ -33,8 +33,12 @@ struct AddRepoView: View {
                             if let lang = repo.language, !lang.isEmpty {
                                 Badge(text: lang)
                             }
-                            if repo.isFork { Badge(text: "Fork") }
-                            if repo.isArchived { Badge(text: "Archived") }
+                            if repo.isFork {
+                                Badge(text: "Fork")
+                            }
+                            if repo.isArchived {
+                                Badge(text: "Archived")
+                            }
                         }
                         if let description = repo.description, !description.isEmpty {
                             Text(description)

--- a/Sources/RepoBar/Views/HeatmapRasterView.swift
+++ b/Sources/RepoBar/Views/HeatmapRasterView.swift
@@ -168,7 +168,9 @@ final class HeatmapRasterNSView: NSView {
             "app:\(appearanceKey)"
         ].joined(separator: "|")
 
-        if self.lastAppliedRenderKey == renderKey, self.lastAppliedScale == scale { return }
+        if self.lastAppliedRenderKey == renderKey, self.lastAppliedScale == scale {
+            return
+        }
 
         if let cached = Self.imageCache.object(forKey: renderKey as NSString) {
             self.apply(image: cached, renderKey: renderKey, scale: scale)
@@ -185,10 +187,14 @@ final class HeatmapRasterNSView: NSView {
         )
 
         self.renderTask = Task { [weak self, payload, renderKey, scale, generation] in
-            if Task.isCancelled { return }
+            if Task.isCancelled {
+                return
+            }
             let imageTask = Task.detached(priority: .userInitiated) { payload.renderImage() }
             let image = await imageTask.value
-            if Task.isCancelled { return }
+            if Task.isCancelled {
+                return
+            }
             guard let self else { return }
             guard self.renderGeneration == generation else { return }
             guard let image else { return }
@@ -215,7 +221,9 @@ final class HeatmapRasterNSView: NSView {
         let totalCells = columns * HeatmapLayout.rows
         if self.cachedColumns == columns, self.cachedBuckets.count == totalCells {
             let hash = Self.bucketHash(for: self.cells, totalCells: totalCells)
-            if hash == self.cachedBucketHash { return (self.cachedBuckets, hash) }
+            if hash == self.cachedBucketHash {
+                return (self.cachedBuckets, hash)
+            }
         }
 
         let (buckets, hash) = Self.buildBuckets(for: self.cells, totalCells: totalCells)
@@ -232,7 +240,9 @@ final class HeatmapRasterNSView: NSView {
         xSpacing: CGFloat,
         xOffset: CGFloat
     ) -> [[CGRect]] {
-        if self.cachedGeometryKey == geometryKey { return self.cachedRectsByBucket }
+        if self.cachedGeometryKey == geometryKey {
+            return self.cachedRectsByBucket
+        }
 
         var rectsByBucket: [[CGRect]] = Array(repeating: [], count: 5)
         rectsByBucket[0].reserveCapacity(buckets.count)
@@ -495,14 +505,18 @@ private struct RenderPayload {
         if self.cornerRadius <= 0 {
             for bucket in 0 ..< min(self.rectsByBucket.count, self.palette.count) {
                 let rects = self.rectsByBucket[bucket]
-                if rects.isEmpty { continue }
+                if rects.isEmpty {
+                    continue
+                }
                 self.setFillColor(self.palette[bucket], on: context)
                 context.fill(rects)
             }
         } else {
             for bucket in 0 ..< min(self.rectsByBucket.count, self.palette.count) {
                 let rects = self.rectsByBucket[bucket]
-                if rects.isEmpty { continue }
+                if rects.isEmpty {
+                    continue
+                }
                 let path = CGMutablePath()
                 for rect in rects {
                     path.addRoundedRect(in: rect, cornerWidth: self.cornerRadius, cornerHeight: self.cornerRadius)

--- a/Sources/RepoBar/Views/IssueNavigatorModel.swift
+++ b/Sources/RepoBar/Views/IssueNavigatorModel.swift
@@ -88,8 +88,12 @@ final class IssueNavigatorModel {
     }
 
     var statusLine: String {
-        if self.isSearching { return "Searching…" }
-        if let errorText { return errorText }
+        if self.isSearching {
+            return "Searching…"
+        }
+        if let errorText {
+            return errorText
+        }
         return self.statusText
     }
 
@@ -405,7 +409,9 @@ final class IssueNavigatorModel {
         return matches
             .filter { seen.insert($0.url).inserted }
             .sorted {
-                if $0.updatedAt != $1.updatedAt { return $0.updatedAt > $1.updatedAt }
+                if $0.updatedAt != $1.updatedAt {
+                    return $0.updatedAt > $1.updatedAt
+                }
                 return ($0.createdAt ?? .distantPast) > ($1.createdAt ?? .distantPast)
             }
     }

--- a/Sources/RepoBar/Views/IssueNavigatorView.swift
+++ b/Sources/RepoBar/Views/IssueNavigatorView.swift
@@ -224,29 +224,28 @@ struct IssueNavigatorView: View {
         }
     }
 
+    @ViewBuilder
     private var previewPane: some View {
-        Group {
-            if let match = self.model.selectedMatch {
-                VStack(spacing: 0) {
-                    self.previewHeader(for: match)
-                    IssueNavigatorBrowserPreview(url: match.url, store: self.model.browserStore)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                }
-            } else {
-                VStack(spacing: 12) {
-                    Image(systemName: "rectangle.and.text.magnifyingglass")
-                        .font(.system(size: 36, weight: .regular))
-                        .foregroundStyle(.tertiary)
-                    Text("Pick a result")
-                        .font(.title2.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                    Text("Search by title, URL, owner/repo#number, or commit SHA.")
-                        .font(.callout)
-                        .foregroundStyle(.tertiary)
-                }
-                .padding(26)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        if let match = self.model.selectedMatch {
+            VStack(spacing: 0) {
+                self.previewHeader(for: match)
+                IssueNavigatorBrowserPreview(url: match.url, store: self.model.browserStore)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
+        } else {
+            VStack(spacing: 12) {
+                Image(systemName: "rectangle.and.text.magnifyingglass")
+                    .font(.system(size: 36, weight: .regular))
+                    .foregroundStyle(.tertiary)
+                Text("Pick a result")
+                    .font(.title2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Text("Search by title, URL, owner/repo#number, or commit SHA.")
+                    .font(.callout)
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(26)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 

--- a/Sources/RepoBar/Views/LocalRepoStateMenuView.swift
+++ b/Sources/RepoBar/Views/LocalRepoStateMenuView.swift
@@ -92,7 +92,9 @@ private struct LocalRepoHeaderRow: View {
     }
 
     private var syncColor: Color {
-        if self.isHighlighted { return MenuHighlightStyle.selectionText }
+        if self.isHighlighted {
+            return MenuHighlightStyle.selectionText
+        }
         let isLightAppearance = NSApp.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .aqua
         switch self.status.syncState {
         case .synced:

--- a/Sources/RepoBar/Views/MenuFilterViews.swift
+++ b/Sources/RepoBar/Views/MenuFilterViews.swift
@@ -16,7 +16,9 @@ struct MenuRepoFiltersView: View {
     private var filterSelection: Binding<MenuRepoSelection> {
         Binding(
             get: {
-                if self.session.account.isLoggedIn { return self.session.menuRepoSelection }
+                if self.session.account.isLoggedIn {
+                    return self.session.menuRepoSelection
+                }
                 return .local
             },
             set: { newValue in

--- a/Sources/RepoBar/Views/MenuItemViews.swift
+++ b/Sources/RepoBar/Views/MenuItemViews.swift
@@ -176,7 +176,9 @@ struct RepoMenuCardView: View {
     }
 
     private func localSyncColor(for state: LocalSyncState) -> Color {
-        if self.isHighlighted { return MenuHighlightStyle.selectionText }
+        if self.isHighlighted {
+            return MenuHighlightStyle.selectionText
+        }
         switch state {
         case .synced:
             return self.isLightAppearance

--- a/Sources/RepoBar/Views/MenuRowViewModels.swift
+++ b/Sources/RepoBar/Views/MenuRowViewModels.swift
@@ -29,8 +29,12 @@ struct LocalRefMenuRowViewModel {
         guard ahead > 0 || behind > 0 else { return "" }
 
         var parts: [String] = []
-        if ahead > 0 { parts.append("↑\(ahead)") }
-        if behind > 0 { parts.append("↓\(behind)") }
+        if ahead > 0 {
+            parts.append("↑\(ahead)")
+        }
+        if behind > 0 {
+            parts.append("↓\(behind)")
+        }
         return parts.joined(separator: " ")
     }
 

--- a/Sources/RepoBar/Views/RecentListSubmenuRowView.swift
+++ b/Sources/RepoBar/Views/RecentListSubmenuRowView.swift
@@ -99,12 +99,16 @@ struct RecentListSubmenuRowView: View {
     }
 
     private var hasBadge: Bool {
-        if let badgePrefixText, badgePrefixText.isEmpty == false { return true }
+        if let badgePrefixText, badgePrefixText.isEmpty == false {
+            return true
+        }
         return self.badgeText != nil
     }
 
     private var computedBadgeAccessibilityLabel: String {
-        if let badgeAccessibilityLabel { return badgeAccessibilityLabel }
+        if let badgeAccessibilityLabel {
+            return badgeAccessibilityLabel
+        }
         if let badgePrefixText, badgePrefixText.isEmpty == false, let badgeText {
             return "Badge \(badgePrefixText), \(badgeText)"
         }

--- a/Sources/RepoBarCore/API/GitHubClient.swift
+++ b/Sources/RepoBarCore/API/GitHubClient.swift
@@ -562,7 +562,9 @@ public actor GitHubClient {
 
             return tokens.accessToken
         }
-        if let token = try tokenStore.load()?.accessToken { return token }
+        if let token = try tokenStore.load()?.accessToken {
+            return token
+        }
         throw URLError(.userAuthenticationRequired)
     }
 

--- a/Sources/RepoBarCore/API/GitHubErrors.swift
+++ b/Sources/RepoBarCore/API/GitHubErrors.swift
@@ -20,7 +20,9 @@ public enum GitHubAPIError: Error {
     public var isAuthenticationFailure: Bool {
         switch self {
         case let .badStatus(code, message):
-            if code == 401 { return true }
+            if code == 401 {
+                return true
+            }
             if let message, message.localizedCaseInsensitiveContains("authentication refresh failed") {
                 return true
             }
@@ -31,12 +33,16 @@ public enum GitHubAPIError: Error {
     }
 
     public var rateLimitedUntil: Date? {
-        if case let .rateLimited(until, _) = self { return until }
+        if case let .rateLimited(until, _) = self {
+            return until
+        }
         return nil
     }
 
     public var retryAfter: Date? {
-        if case let .serviceUnavailable(date, _) = self { return date }
+        if case let .serviceUnavailable(date, _) = self {
+            return date
+        }
         return nil
     }
 }
@@ -74,7 +80,9 @@ struct RepoErrorAccumulator {
         guard let candidate else { return }
 
         if let current = rateLimit {
-            if candidate > current { self.rateLimit = candidate }
+            if candidate > current {
+                self.rateLimit = candidate
+            }
         } else {
             self.rateLimit = candidate
         }

--- a/Sources/RepoBarCore/API/GitHubModels.swift
+++ b/Sources/RepoBarCore/API/GitHubModels.swift
@@ -181,7 +181,9 @@ struct EventRepo: Decodable {
     }
 
     var fullName: String? {
-        if let name, name.contains("/") { return name }
+        if let name, name.contains("/") {
+            return name
+        }
         guard let url else { return nil }
 
         let parts = url.path.split(separator: "/")
@@ -465,8 +467,12 @@ extension RepoEvent {
 
     private func issueTarget(number: Int?, title: String?) -> String? {
         var parts: [String] = []
-        if let number { parts.append("#\(number)") }
-        if let title, !title.isEmpty { parts.append(title) }
+        if let number {
+            parts.append("#\(number)")
+        }
+        if let title, !title.isEmpty {
+            parts.append(title)
+        }
         guard parts.isEmpty == false else { return nil }
 
         return parts.joined(separator: ": ")

--- a/Sources/RepoBarCore/API/GitHubRecentDecoders.swift
+++ b/Sources/RepoBarCore/API/GitHubRecentDecoders.swift
@@ -194,8 +194,12 @@ enum GitHubRecentDecoders {
 
     private static func workflowRunTitle(_ run: ActionsRunsResponse.WorkflowRun) -> String {
         let preferred = (run.displayTitle ?? run.name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        if preferred.isEmpty == false { return preferred }
-        if let runNumber = run.runNumber { return "Run #\(runNumber)" }
+        if preferred.isEmpty == false {
+            return preferred
+        }
+        if let runNumber = run.runNumber {
+            return "Run #\(runNumber)"
+        }
         return "Workflow run"
     }
 
@@ -241,7 +245,9 @@ enum GitHubRecentDecoders {
             .joined(separator: " ")
         guard collapsed.isEmpty == false else { return nil }
 
-        if collapsed.count <= 240 { return collapsed }
+        if collapsed.count <= 240 {
+            return collapsed
+        }
         return "\(collapsed.prefix(237))..."
     }
 

--- a/Sources/RepoBarCore/API/GitHubRequestRunner.swift
+++ b/Sources/RepoBarCore/API/GitHubRequestRunner.swift
@@ -244,7 +244,9 @@ actor GitHubRequestRunner {
                 )
             }
             .sorted { lhs, rhs in
-                if lhs.retryAfter != rhs.retryAfter { return lhs.retryAfter < rhs.retryAfter }
+                if lhs.retryAfter != rhs.retryAfter {
+                    return lhs.retryAfter < rhs.retryAfter
+                }
                 return lhs.url < rhs.url
             }
         return RequestRunnerDiagnostics(
@@ -266,7 +268,9 @@ actor GitHubRequestRunner {
     ) async {
         let durationMs = Int((Date().timeIntervalSince(startedAt) * 1000).rounded())
         let snapshot = RateLimitSnapshot.from(response: response)
-        if let snapshot { self.latestRestRateLimit = snapshot }
+        if let snapshot {
+            self.latestRestRateLimit = snapshot
+        }
 
         let remaining = snapshot?.remaining.map(String.init) ?? response.value(forHTTPHeaderField: "X-RateLimit-Remaining") ?? "?"
         let limit = snapshot?.limit.map(String.init) ?? response.value(forHTTPHeaderField: "X-RateLimit-Limit") ?? "?"

--- a/Sources/RepoBarCore/API/GitHubRestAPI+ReferenceLookup.swift
+++ b/Sources/RepoBarCore/API/GitHubRestAPI+ReferenceLookup.swift
@@ -570,8 +570,12 @@ private struct WorkflowRunLookupResponse: Decodable {
 
     private var title: String {
         let preferred = (self.displayTitle ?? self.name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        if preferred.isEmpty == false { return preferred }
-        if let runNumber { return "Run #\(runNumber)" }
+        if preferred.isEmpty == false {
+            return preferred
+        }
+        if let runNumber {
+            return "Run #\(runNumber)"
+        }
         return "Workflow run"
     }
 

--- a/Sources/RepoBarCore/API/GraphQLClient.swift
+++ b/Sources/RepoBarCore/API/GraphQLClient.swift
@@ -223,7 +223,9 @@ actor GraphQLClient {
     private func logGraphQLResponse(_ response: HTTPURLResponse, label: String, startedAt: Date) async {
         let durationMs = Int((Date().timeIntervalSince(startedAt) * 1000).rounded())
         let snapshot = RateLimitSnapshot.from(response: response)
-        if let snapshot { self.rateLimit = snapshot }
+        if let snapshot {
+            self.rateLimit = snapshot
+        }
 
         let remaining = snapshot?.remaining.map(String.init) ?? response.value(forHTTPHeaderField: "X-RateLimit-Remaining") ?? "?"
         let limit = snapshot?.limit.map(String.init) ?? response.value(forHTTPHeaderField: "X-RateLimit-Limit") ?? "?"
@@ -371,7 +373,9 @@ struct ContributionDay: Decodable {
         if raw.contains("T") {
             let formatter = ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-            if let date = formatter.date(from: raw) { return date }
+            if let date = formatter.date(from: raw) {
+                return date
+            }
             formatter.formatOptions = [.withInternetDateTime]
             return formatter.date(from: raw)
         }

--- a/Sources/RepoBarCore/Auth/OAuthLoginFlow.swift
+++ b/Sources/RepoBarCore/Auth/OAuthLoginFlow.swift
@@ -118,7 +118,9 @@ public struct OAuthLoginFlow {
             throw GitHubAPIError.invalidHost
         }
 
-        if components.scheme == nil { components.scheme = "https" }
+        if components.scheme == nil {
+            components.scheme = "https"
+        }
         guard components.scheme?.lowercased() == "https", components.host != nil else {
             throw GitHubAPIError.invalidHost
         }

--- a/Sources/RepoBarCore/Auth/TokenStore.swift
+++ b/Sources/RepoBarCore/Auth/TokenStore.swift
@@ -230,7 +230,9 @@ public struct TokenStore: Sendable {
             // so that we never surface a mangled duplicate of an original ID.
             let sanitizedIndexed = Set(indexed.map { self.sanitizedFileComponent($0) })
             for id in self.scanFileAccountIDs(directory: directory) {
-                if sanitizedIndexed.contains(self.sanitizedFileComponent(id)) { continue }
+                if sanitizedIndexed.contains(self.sanitizedFileComponent(id)) {
+                    continue
+                }
                 found.insert(id)
             }
         case .keychain:
@@ -324,7 +326,9 @@ private extension TokenStore {
             if status == errSecDuplicateItem {
                 status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
             }
-            if status == errSecSuccess { return }
+            if status == errSecSuccess {
+                return
+            }
             lastStatus = status
             let isFinalAttempt = index == accessGroups.count - 1
             if isFinalAttempt || self.shouldRetryWithoutAccessGroup(status: status, accessGroup: group) == false {
@@ -348,10 +352,14 @@ private extension TokenStore {
             var item: CFTypeRef?
             let status = SecItemCopyMatching(query as CFDictionary, &item)
             if status == errSecItemNotFound {
-                if index == accessGroups.count - 1 { return nil }
+                if index == accessGroups.count - 1 {
+                    return nil
+                }
                 continue
             }
-            if status == errSecSuccess, let data = item as? Data { return data }
+            if status == errSecSuccess, let data = item as? Data {
+                return data
+            }
             lastStatus = status
             let isFinalAttempt = index == accessGroups.count - 1
             if isFinalAttempt || self.shouldRetryWithoutAccessGroup(status: status, accessGroup: group) == false {
@@ -563,7 +571,9 @@ private extension TokenStore {
 
             let middle = String(name.dropFirst(servicePrefix.count).dropLast(suffix.count))
             if let decoded = self.decodedFileComponent(middle) {
-                if decoded == "default" || decoded == "client" || decoded == "pat" { continue }
+                if decoded == "default" || decoded == "client" || decoded == "pat" {
+                    continue
+                }
                 for kind in AccountKeyKind.allCases {
                     let trailing = ":\(kind.rawValue)"
                     if decoded.hasSuffix(trailing), decoded.count > trailing.count {
@@ -575,7 +585,9 @@ private extension TokenStore {
             }
 
             // Skip legacy fixed-key entries.
-            if middle == "default" || middle == "client" || middle == "pat" { continue }
+            if middle == "default" || middle == "client" || middle == "pat" {
+                continue
+            }
             for kind in AccountKeyKind.allCases {
                 // The colon separator becomes `-` after sanitization.
                 let trailing = "-\(kind.rawValue)"
@@ -617,7 +629,9 @@ private extension TokenStore {
             for entry in entries {
                 guard let account = entry[accountKey] as? String else { continue }
 
-                if account == "default" || account == "client" || account == "pat" { continue }
+                if account == "default" || account == "client" || account == "pat" {
+                    continue
+                }
                 for kind in AccountKeyKind.allCases {
                     let trailing = ":\(kind.rawValue)"
                     if account.hasSuffix(trailing), account.count > trailing.count {

--- a/Sources/RepoBarCore/LocalProjects/LocalGitService.swift
+++ b/Sources/RepoBarCore/LocalProjects/LocalGitService.swift
@@ -238,7 +238,9 @@
             switch self {
             case let .commandFailed(output, error):
                 let message = error.trimmingCharacters(in: .whitespacesAndNewlines)
-                if message.isEmpty == false { return message }
+                if message.isEmpty == false {
+                    return message
+                }
                 let fallback = output.trimmingCharacters(in: .whitespacesAndNewlines)
                 return fallback.isEmpty ? "Git command failed." : fallback
             }
@@ -377,7 +379,9 @@
             }
         }
 
-        if added.isEmpty, modified.isEmpty, deleted.isEmpty { return nil }
+        if added.isEmpty, modified.isEmpty, deleted.isEmpty {
+            return nil
+        }
         return LocalDirtyCounts(added: added.count, modified: modified.count, deleted: deleted.count)
     }
 #endif

--- a/Sources/RepoBarCore/LocalProjects/LocalProjectsService.swift
+++ b/Sources/RepoBarCore/LocalProjects/LocalProjectsService.swift
@@ -209,7 +209,9 @@
             let fetchedPaths = Set(processed.filter(\.didFetch).map(\.status.path))
 
             statuses.sort { lhs, rhs in
-                if lhs.displayName != rhs.displayName { return lhs.displayName < rhs.displayName }
+                if lhs.displayName != rhs.displayName {
+                    return lhs.displayName < rhs.displayName
+                }
                 return lhs.path.path < rhs.path.path
             }
 
@@ -251,7 +253,9 @@
 
                 for child in children {
                     let name = child.lastPathComponent
-                    if name.hasPrefix(".") { continue }
+                    if name.hasPrefix(".") {
+                        continue
+                    }
 
                     let values = try? child.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
                     if values?.isSymbolicLink == true {
@@ -414,7 +418,9 @@
             }
         }
 
-        if added.isEmpty, modified.isEmpty, deleted.isEmpty { return nil }
+        if added.isEmpty, modified.isEmpty, deleted.isEmpty {
+            return nil
+        }
         return LocalDirtyCounts(added: added.count, modified: modified.count, deleted: deleted.count)
     }
 

--- a/Sources/RepoBarCore/LocalProjects/LocalRepoStatus.swift
+++ b/Sources/RepoBarCore/LocalProjects/LocalRepoStatus.swift
@@ -113,9 +113,15 @@ public struct LocalDirtyCounts: Equatable, Sendable {
 
     public var summary: String {
         var parts: [String] = []
-        if self.added > 0 { parts.append("+\(self.added)") }
-        if self.deleted > 0 { parts.append("-\(self.deleted)") }
-        if self.modified > 0 { parts.append("~\(self.modified)") }
+        if self.added > 0 {
+            parts.append("+\(self.added)")
+        }
+        if self.deleted > 0 {
+            parts.append("-\(self.deleted)")
+        }
+        if self.modified > 0 {
+            parts.append("~\(self.modified)")
+        }
         return parts.joined(separator: " ")
     }
 }
@@ -129,13 +135,23 @@ public enum LocalSyncState: String, Equatable, Sendable {
     case unknown
 
     public static func resolve(isClean: Bool, ahead: Int?, behind: Int?) -> LocalSyncState {
-        if !isClean { return .dirty }
+        if !isClean {
+            return .dirty
+        }
         guard let ahead, let behind else { return .unknown }
 
-        if ahead == 0, behind == 0 { return .synced }
-        if behind > 0, ahead == 0 { return .behind }
-        if ahead > 0, behind == 0 { return .ahead }
-        if ahead > 0, behind > 0 { return .diverged }
+        if ahead == 0, behind == 0 {
+            return .synced
+        }
+        if behind > 0, ahead == 0 {
+            return .behind
+        }
+        if ahead > 0, behind == 0 {
+            return .ahead
+        }
+        if ahead > 0, behind > 0 {
+            return .diverged
+        }
         return .unknown
     }
 
@@ -207,7 +223,9 @@ public struct LocalRepoIndex: Equatable, Sendable {
         if let preferred = self.preferredPathsByFullName[repo.fullName], let status = self.byPath[preferred] {
             return status
         }
-        if let exact = self.byFullName[repo.fullName] { return exact }
+        if let exact = self.byFullName[repo.fullName] {
+            return exact
+        }
         if let match = self.preferredStatus(in: self.byFullNameLowercased, forKey: repo.fullName.lowercased()) {
             return match
         }
@@ -218,12 +236,16 @@ public struct LocalRepoIndex: Equatable, Sendable {
         if let preferred = self.preferredPathsByFullName[fullName], let status = self.byPath[preferred] {
             return status
         }
-        if let exact = self.byFullName[fullName] { return exact }
+        if let exact = self.byFullName[fullName] {
+            return exact
+        }
         if let match = self.preferredStatus(in: self.byFullNameLowercased, forKey: fullName.lowercased()) {
             return match
         }
         let name = fullName.split(separator: "/").last.map(String.init)
-        if let name { return self.uniqueStatus(forName: name) }
+        if let name {
+            return self.uniqueStatus(forName: name)
+        }
         return nil
     }
 
@@ -233,7 +255,9 @@ public struct LocalRepoIndex: Equatable, Sendable {
 
     public func status(containingPath path: String) -> LocalRepoStatus? {
         let normalizedPath = URL(fileURLWithPath: PathFormatter.expandTilde(path)).standardizedFileURL.path
-        if let exact = self.byPath[normalizedPath] { return exact }
+        if let exact = self.byPath[normalizedPath] {
+            return exact
+        }
 
         let matches = self.all.filter { status in
             let repoPath = status.path.standardizedFileURL.path
@@ -247,7 +271,9 @@ public struct LocalRepoIndex: Equatable, Sendable {
     }
 
     private func uniqueStatus(forName name: String) -> LocalRepoStatus? {
-        if let exact = self.uniqueStatus(in: self.byName, forKey: name) { return exact }
+        if let exact = self.uniqueStatus(in: self.byName, forKey: name) {
+            return exact
+        }
         return self.uniqueStatus(in: self.byNameLowercased, forKey: name.lowercased())
     }
 
@@ -268,9 +294,15 @@ public struct LocalRepoIndex: Equatable, Sendable {
     private static func preferredStatus(_ lhs: LocalRepoStatus, _ rhs: LocalRepoStatus) -> LocalRepoStatus {
         let lhsDepth = lhs.path.pathComponents.count
         let rhsDepth = rhs.path.pathComponents.count
-        if lhsDepth != rhsDepth { return lhsDepth < rhsDepth ? lhs : rhs }
-        if lhs.worktreeName == nil, rhs.worktreeName != nil { return lhs }
-        if rhs.worktreeName == nil, lhs.worktreeName != nil { return rhs }
+        if lhsDepth != rhsDepth {
+            return lhsDepth < rhsDepth ? lhs : rhs
+        }
+        if lhs.worktreeName == nil, rhs.worktreeName != nil {
+            return lhs
+        }
+        if rhs.worktreeName == nil, lhs.worktreeName != nil {
+            return rhs
+        }
         return lhs.path.path <= rhs.path.path ? lhs : rhs
     }
 }

--- a/Sources/RepoBarCore/Models/ActionsUsageInfo.swift
+++ b/Sources/RepoBarCore/Models/ActionsUsageInfo.swift
@@ -75,9 +75,15 @@ public struct ActionsUsageInfo: Sendable, Equatable {
 
     private static func osLabel(for sku: String) -> String {
         let upper = sku.uppercased()
-        if upper.contains("MACOS") || upper.contains("MAC_OS") { return "macOS" }
-        if upper.contains("WINDOWS") { return "Windows" }
-        if upper.contains("LINUX") || upper.contains("UBUNTU") { return "Linux" }
+        if upper.contains("MACOS") || upper.contains("MAC_OS") {
+            return "macOS"
+        }
+        if upper.contains("WINDOWS") {
+            return "Windows"
+        }
+        if upper.contains("LINUX") || upper.contains("UBUNTU") {
+            return "Linux"
+        }
         return sku
     }
 }
@@ -317,8 +323,12 @@ public enum ActionsMinuteMultiplier {
 
     public static func multiplier(for os: String) -> Double {
         let lower = os.lowercased()
-        if lower.contains("macos") || lower.contains("mac") { return self.macOS }
-        if lower.contains("windows") || lower.contains("win") { return self.windows }
+        if lower.contains("macos") || lower.contains("mac") {
+            return self.macOS
+        }
+        if lower.contains("windows") || lower.contains("win") {
+            return self.windows
+        }
         return self.linux
     }
 }

--- a/Sources/RepoBarCore/Models/Repository+Activity.swift
+++ b/Sources/RepoBarCore/Models/Repository+Activity.swift
@@ -31,8 +31,12 @@ public extension Repository {
     }
 
     func activityLine(fallbackToPush: Bool) -> String? {
-        if let line = self.activityLine { return line }
-        if fallbackToPush, self.stats.pushedAt != nil { return "push" }
+        if let line = self.activityLine {
+            return line
+        }
+        if fallbackToPush, self.stats.pushedAt != nil {
+            return "push"
+        }
         return nil
     }
 }

--- a/Sources/RepoBarCore/Models/UserIdentity.swift
+++ b/Sources/RepoBarCore/Models/UserIdentity.swift
@@ -18,10 +18,18 @@ public struct UserIdentity: Equatable, Sendable {
     public static func planTier(from name: String?) -> GitHubPlanTier? {
         guard let name = name?.lowercased() else { return nil }
 
-        if name.contains("enterprise") { return .enterprise }
-        if name.contains("team") { return .team }
-        if name.contains("pro") || name.contains("developer") { return .pro }
-        if name.contains("free") { return .free }
+        if name.contains("enterprise") {
+            return .enterprise
+        }
+        if name.contains("team") {
+            return .team
+        }
+        if name.contains("pro") || name.contains("developer") {
+            return .pro
+        }
+        if name.contains("free") {
+            return .free
+        }
         return nil
     }
 }

--- a/Sources/RepoBarCore/Notifications/GitHubReleaseNotificationDetector.swift
+++ b/Sources/RepoBarCore/Notifications/GitHubReleaseNotificationDetector.swift
@@ -130,7 +130,9 @@ public enum GitHubReleaseNotificationDetector {
                 let wasPromotedToStable = previousRelease?.isPrerelease == true && release.isPrerelease == false
                 guard previousRelease == nil || wasPromotedToStable else { continue }
 
-                if release.isPrerelease, settings.includePrereleases == false { continue }
+                if release.isPrerelease, settings.includePrereleases == false {
+                    continue
+                }
 
                 let isNewAfterBaseline = previousBaseline.map { release.publishedAt > $0 } ?? false
                 guard isNewAfterBaseline || wasPromotedToStable else { continue }

--- a/Sources/RepoBarCore/Support/GitHubArchiveImporter.swift
+++ b/Sources/RepoBarCore/Support/GitHubArchiveImporter.swift
@@ -430,7 +430,9 @@ private struct ArchiveTableManifest: Decodable {
     let rows: Int
 
     var allFiles: [String] {
-        if let files, files.isEmpty == false { return files }
+        if let files, files.isEmpty == false {
+            return files
+        }
         return self.file.map { [$0] } ?? []
     }
 }

--- a/Sources/RepoBarCore/Support/GitHubArchiveReader.swift
+++ b/Sources/RepoBarCore/Support/GitHubArchiveReader.swift
@@ -226,9 +226,15 @@ public struct GitHubArchiveReader: Sendable {
         guard let object else { return nil }
 
         for key in keys {
-            if let value = object[key] as? Int { return value }
-            if let value = object[key] as? NSNumber { return value.intValue }
-            if let value = object[key] as? String, let int = Int(value) { return int }
+            if let value = object[key] as? Int {
+                return value
+            }
+            if let value = object[key] as? NSNumber {
+                return value.intValue
+            }
+            if let value = object[key] as? String, let int = Int(value) {
+                return int
+            }
         }
         return nil
     }
@@ -236,8 +242,12 @@ public struct GitHubArchiveReader: Sendable {
     private static func bool(_ value: String?) -> Bool? {
         guard let string = self.string(value)?.lowercased() else { return nil }
 
-        if ["1", "true", "yes"].contains(string) { return true }
-        if ["0", "false", "no"].contains(string) { return false }
+        if ["1", "true", "yes"].contains(string) {
+            return true
+        }
+        if ["0", "false", "no"].contains(string) {
+            return false
+        }
         return nil
     }
 
@@ -245,9 +255,15 @@ public struct GitHubArchiveReader: Sendable {
         guard let object else { return nil }
 
         for key in keys {
-            if let value = object[key] as? Bool { return value }
-            if let value = object[key] as? NSNumber { return value.boolValue }
-            if let value = object[key] as? String, let bool = self.bool(value) { return bool }
+            if let value = object[key] as? Bool {
+                return value
+            }
+            if let value = object[key] as? NSNumber {
+                return value.boolValue
+            }
+            if let value = object[key] as? String, let bool = self.bool(value) {
+                return bool
+            }
         }
         return nil
     }

--- a/Sources/RepoBarCore/Support/GitHubReferenceTranslator.swift
+++ b/Sources/RepoBarCore/Support/GitHubReferenceTranslator.swift
@@ -842,9 +842,15 @@ extension GitHubReferenceTranslator {
               let firstToken = self.referenceTokens(in: body).first
         else { return false }
 
-        if self.urlQuery(from: firstToken) != nil { return true }
-        if self.compoundBareIssueQueries(from: firstToken).isEmpty == false { return true }
-        if self.compoundRepositoryIssueQueries(from: firstToken).isEmpty == false { return true }
+        if self.urlQuery(from: firstToken) != nil {
+            return true
+        }
+        if self.compoundBareIssueQueries(from: firstToken).isEmpty == false {
+            return true
+        }
+        if self.compoundRepositoryIssueQueries(from: firstToken).isEmpty == false {
+            return true
+        }
         return self.tokenQuery(
             from: firstToken,
             minimumBareDigits: 1,

--- a/Sources/RepoBarCore/Support/GlobalActivityMerger.swift
+++ b/Sources/RepoBarCore/Support/GlobalActivityMerger.swift
@@ -33,7 +33,9 @@ public enum GlobalActivityMerger {
             guard seen.insert(key).inserted else { continue }
 
             results.append(event)
-            if results.count >= limit { break }
+            if results.count >= limit {
+                break
+            }
         }
         return results
     }

--- a/Sources/RepoBarCore/Support/MarkdownBlockParser.swift
+++ b/Sources/RepoBarCore/Support/MarkdownBlockParser.swift
@@ -86,7 +86,9 @@ private struct MarkdownBlockBuilder {
         }
 
         for child in listItem.children {
-            if child is Paragraph { continue }
+            if child is Paragraph {
+                continue
+            }
             self.appendBlocks(from: child, into: &blocks)
         }
     }

--- a/Sources/RepoBarCore/Support/PathFormatter.swift
+++ b/Sources/RepoBarCore/Support/PathFormatter.swift
@@ -5,7 +5,9 @@ public enum PathFormatter {
         guard path.hasPrefix("~") else { return path }
 
         let home = self.userHomeCandidates().first ?? NSString(string: "~").expandingTildeInPath
-        if path == "~" { return home }
+        if path == "~" {
+            return home
+        }
         if path.hasPrefix("~/") {
             return home + path.dropFirst(1)
         }
@@ -14,7 +16,9 @@ public enum PathFormatter {
 
     public static func abbreviateHome(_ path: String) -> String {
         for base in self.userHomeCandidates().sorted(by: { $0.count > $1.count }) {
-            if path == base { return "~" }
+            if path == base {
+                return "~"
+            }
             if path.hasPrefix(base + "/") {
                 return "~" + path.dropFirst(base.count)
             }
@@ -41,7 +45,9 @@ public enum PathFormatter {
         #if os(macOS)
             let user = NSUserName()
             let homeFromUser = NSHomeDirectoryForUser(user)
-            if let homeFromUser, homeFromUser.isEmpty == false { candidates.append(homeFromUser) }
+            if let homeFromUser, homeFromUser.isEmpty == false {
+                candidates.append(homeFromUser)
+            }
             if user.isEmpty == false {
                 candidates.append("/Users/\(user)")
                 candidates.append("/System/Volumes/Data/Users/\(user)")

--- a/Sources/RepoBarCore/Support/PullRequestAISummarizer.swift
+++ b/Sources/RepoBarCore/Support/PullRequestAISummarizer.swift
@@ -125,7 +125,9 @@ public struct PullRequestAISummarizer: Sendable {
             .joined(separator: " ")
         guard summary.isEmpty == false else { return nil }
 
-        if summary.count <= Self.maximumSummaryCharacters { return summary }
+        if summary.count <= Self.maximumSummaryCharacters {
+            return summary
+        }
 
         let prefix = String(summary.prefix(Self.maximumSummaryCharacters - 3))
             .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/RepoBarCore/Support/RateLimitJuice.swift
+++ b/Sources/RepoBarCore/Support/RateLimitJuice.swift
@@ -45,9 +45,15 @@ public struct RateLimitJuice: Equatable, Sendable {
     }
 
     public var compactRestText: String? {
-        if self.isRestLimited { return "0" }
-        if let restRemaining { return Self.shortCount(restRemaining) }
-        if let restPercent { return "\(Int(restPercent.rounded()))%" }
+        if self.isRestLimited {
+            return "0"
+        }
+        if let restRemaining {
+            return Self.shortCount(restRemaining)
+        }
+        if let restPercent {
+            return "\(Int(restPercent.rounded()))%"
+        }
         return nil
     }
 

--- a/Sources/RepoBarCore/Support/RateLimitStatusFormatter.swift
+++ b/Sources/RepoBarCore/Support/RateLimitStatusFormatter.swift
@@ -272,7 +272,9 @@ public enum RateLimitStatusFormatter {
         cooldowns
             .filter { $0.retryAfter > now }
             .sorted { lhs, rhs in
-                if lhs.retryAfter != rhs.retryAfter { return lhs.retryAfter < rhs.retryAfter }
+                if lhs.retryAfter != rhs.retryAfter {
+                    return lhs.retryAfter < rhs.retryAfter
+                }
                 return lhs.url < rhs.url
             }
     }
@@ -281,7 +283,9 @@ public enum RateLimitStatusFormatter {
         let grouped = Dictionary(grouping: cooldowns, by: \.endpoint)
         let rows = grouped.keys.sorted().compactMap { endpoint -> String? in
             guard let group = grouped[endpoint]?.sorted(by: { lhs, rhs in
-                if lhs.retryAfter != rhs.retryAfter { return lhs.retryAfter < rhs.retryAfter }
+                if lhs.retryAfter != rhs.retryAfter {
+                    return lhs.retryAfter < rhs.retryAfter
+                }
                 return lhs.url < rhs.url
             }), let first = group.first
             else { return nil }
@@ -357,7 +361,9 @@ public enum RateLimitStatusFormatter {
     private static func blockerRows(_ rows: [RateLimitDisplayRow], alreadyRepresent error: String) -> Bool {
         let cleaned = Self.cleanedBlockerText(error, fallback: "")
         return rows.contains { row in
-            if row.text == error || row.text == cleaned { return true }
+            if row.text == error || row.text == cleaned {
+                return true
+            }
             guard let detail = row.detailText else { return false }
 
             return detail.contains(error) || (cleaned.isEmpty == false && detail.contains(cleaned))
@@ -378,7 +384,9 @@ public enum RateLimitStatusFormatter {
         resources.sorted { lhs, rhs in
             let leftGroup = Self.resourceGroup(for: lhs.key).rawValue
             let rightGroup = Self.resourceGroup(for: rhs.key).rawValue
-            if leftGroup != rightGroup { return leftGroup < rightGroup }
+            if leftGroup != rightGroup {
+                return leftGroup < rightGroup
+            }
             return lhs.key < rhs.key
         }
     }

--- a/Sources/RepoBarCore/Support/ReleaseFormatter.swift
+++ b/Sources/RepoBarCore/Support/ReleaseFormatter.swift
@@ -8,9 +8,13 @@ public enum ReleaseFormatter {
 
     public static func releasedLabel(for date: Date, now: Date = Date()) -> String {
         let calendar = Calendar.current
-        if calendar.isDate(date, inSameDayAs: now) { return "today" }
+        if calendar.isDate(date, inSameDayAs: now) {
+            return "today"
+        }
         if let yesterday = calendar.date(byAdding: .day, value: -1, to: now),
-           calendar.isDate(date, inSameDayAs: yesterday) { return "yesterday" }
+           calendar.isDate(date, inSameDayAs: yesterday) {
+            return "yesterday"
+        }
         return DateFormatters.yyyyMMdd.string(from: date)
     }
 }

--- a/Sources/RepoBarCore/Support/RepoAutocompleteScoring.swift
+++ b/Sources/RepoBarCore/Support/RepoAutocompleteScoring.swift
@@ -35,8 +35,12 @@ public enum RepoAutocompleteScoring {
 
     public static func sort(_ scored: [Scored]) -> [Scored] {
         scored.sorted {
-            if $0.score != $1.score { return $0.score > $1.score }
-            if $0.sourceRank != $1.sourceRank { return $0.sourceRank < $1.sourceRank }
+            if $0.score != $1.score {
+                return $0.score > $1.score
+            }
+            if $0.sourceRank != $1.sourceRank {
+                return $0.sourceRank < $1.sourceRank
+            }
             return $0.repo.fullName.localizedCaseInsensitiveCompare($1.repo.fullName) == .orderedAscending
         }
     }
@@ -66,8 +70,12 @@ public enum RepoAutocompleteScoring {
         let fullName = repo.fullName.lowercased()
         let hasSlash = lowerQuery.contains("/")
         if hasSlash {
-            if fullName == lowerQuery { return 1000 }
-            if fullName.hasPrefix(lowerQuery) { return 700 }
+            if fullName == lowerQuery {
+                return 1000
+            }
+            if fullName.hasPrefix(lowerQuery) {
+                return 700
+            }
         }
 
         let parts = lowerQuery.split(separator: "/", omittingEmptySubsequences: false)
@@ -157,9 +165,15 @@ public enum RepoAutocompleteScoring {
         guard let language, !language.isEmpty else { return 0 }
 
         let lower = language.lowercased()
-        if lower == query { return 150 }
-        if lower.hasPrefix(query) { return 100 }
-        if lower.contains(query) { return 60 }
+        if lower == query {
+            return 150
+        }
+        if lower.hasPrefix(query) {
+            return 100
+        }
+        if lower.contains(query) {
+            return 60
+        }
         return 0
     }
 
@@ -167,8 +181,12 @@ public enum RepoAutocompleteScoring {
         guard let description, !description.isEmpty else { return 0 }
 
         let lower = description.lowercased()
-        if lower.contains(query) { return 60 }
-        if query.count <= 3, Self.isSubsequence(query, of: lower) { return 30 }
+        if lower.contains(query) {
+            return 60
+        }
+        if query.count <= 3, Self.isSubsequence(query, of: lower) {
+            return 30
+        }
         return 0
     }
 
@@ -180,10 +198,18 @@ public enum RepoAutocompleteScoring {
         guard !query.isEmpty else { return 0 }
 
         let lowerTarget = target.lowercased()
-        if lowerTarget == query { return weights.exact }
-        if lowerTarget.hasPrefix(query) { return weights.prefix }
-        if lowerTarget.contains(query) { return weights.substring }
-        if query.count <= 3, Self.isSubsequence(query, of: lowerTarget) { return weights.subsequence }
+        if lowerTarget == query {
+            return weights.exact
+        }
+        if lowerTarget.hasPrefix(query) {
+            return weights.prefix
+        }
+        if lowerTarget.contains(query) {
+            return weights.substring
+        }
+        if query.count <= 3, Self.isSubsequence(query, of: lowerTarget) {
+            return weights.subsequence
+        }
         return nil
     }
 

--- a/Sources/RepoBarCore/Support/RepositoryFilter.swift
+++ b/Sources/RepoBarCore/Support/RepositoryFilter.swift
@@ -17,11 +17,21 @@ public enum RepositoryFilter {
         let pinnedSet = Set(pinned.map { $0.lowercased() })
 
         return repos.filter { repo in
-            if pinnedSet.contains(repo.fullName.lowercased()) { return true }
-            if includeForks == false, repo.isFork { return false }
-            if includeArchived == false, repo.isArchived { return false }
-            if onlyWith.isActive, onlyWith.matches(repo) == false { return false }
-            if !ownerSet.isEmpty, !ownerSet.contains(repo.owner.lowercased()) { return false }
+            if pinnedSet.contains(repo.fullName.lowercased()) {
+                return true
+            }
+            if includeForks == false, repo.isFork {
+                return false
+            }
+            if includeArchived == false, repo.isArchived {
+                return false
+            }
+            if onlyWith.isActive, onlyWith.matches(repo) == false {
+                return false
+            }
+            if !ownerSet.isEmpty, !ownerSet.contains(repo.owner.lowercased()) {
+                return false
+            }
             return true
         }
     }

--- a/Sources/RepoBarCore/Support/RepositoryOnlyWith.swift
+++ b/Sources/RepoBarCore/Support/RepositoryOnlyWith.swift
@@ -20,8 +20,12 @@ public struct RepositoryOnlyWith: Sendable, Equatable {
         let hasPRs = repo.stats.openPulls > 0
 
         var ok = false
-        if self.requireIssues { ok = ok || hasIssues }
-        if self.requirePRs { ok = ok || hasPRs }
+        if self.requireIssues {
+            ok = ok || hasIssues
+        }
+        if self.requirePRs {
+            ok = ok || hasPRs
+        }
         return ok
     }
 }

--- a/Sources/RepoBarCore/Support/RepositoryPipeline.swift
+++ b/Sources/RepoBarCore/Support/RepositoryPipeline.swift
@@ -105,14 +105,18 @@ public enum RepositoryPipeline {
         if query.pinPriority, !query.pinned.isEmpty {
             let pinnedIndex = query.pinned.enumerated().reduce(into: [String: Int]()) { dict, entry in
                 let key = entry.element.lowercased()
-                if dict[key] == nil { dict[key] = entry.offset }
+                if dict[key] == nil {
+                    dict[key] = entry.offset
+                }
             }
             sorted = filtered.sorted { lhs, rhs in
                 let leftIndex = pinnedIndex[lhs.fullName.lowercased()]
                 let rightIndex = pinnedIndex[rhs.fullName.lowercased()]
                 switch (leftIndex, rightIndex) {
                 case let (left?, right?):
-                    if left != right { return left < right }
+                    if left != right {
+                        return left < right
+                    }
                 case (.some, .none):
                     return true
                 case (.none, .some):

--- a/Sources/RepoBarCore/Support/RepositorySort.swift
+++ b/Sources/RepoBarCore/Support/RepositorySort.swift
@@ -22,11 +22,21 @@ public enum RepositorySort {
         _ rhs: Repository,
         sortKey: RepositorySortKey
     ) -> Bool {
-        if let preferred = compare(lhs, rhs, sortKey: sortKey) { return preferred }
-        if let preferred = compare(lhs, rhs, sortKey: .activity) { return preferred }
-        if let preferred = compare(lhs, rhs, sortKey: .issues) { return preferred }
-        if let preferred = compare(lhs, rhs, sortKey: .pulls) { return preferred }
-        if let preferred = compare(lhs, rhs, sortKey: .stars) { return preferred }
+        if let preferred = compare(lhs, rhs, sortKey: sortKey) {
+            return preferred
+        }
+        if let preferred = compare(lhs, rhs, sortKey: .activity) {
+            return preferred
+        }
+        if let preferred = compare(lhs, rhs, sortKey: .issues) {
+            return preferred
+        }
+        if let preferred = compare(lhs, rhs, sortKey: .pulls) {
+            return preferred
+        }
+        if let preferred = compare(lhs, rhs, sortKey: .stars) {
+            return preferred
+        }
         return lhs.fullName.localizedCaseInsensitiveCompare(rhs.fullName) == .orderedAscending
     }
 
@@ -39,25 +49,37 @@ public enum RepositorySort {
         case .activity:
             let leftDate = lhs.activityDate ?? .distantPast
             let rightDate = rhs.activityDate ?? .distantPast
-            if leftDate != rightDate { return leftDate > rightDate }
+            if leftDate != rightDate {
+                return leftDate > rightDate
+            }
             return nil
         case .issues:
-            if lhs.stats.openIssues != rhs.stats.openIssues { return lhs.stats.openIssues > rhs.stats.openIssues }
+            if lhs.stats.openIssues != rhs.stats.openIssues {
+                return lhs.stats.openIssues > rhs.stats.openIssues
+            }
             return nil
         case .pulls:
-            if lhs.stats.openPulls != rhs.stats.openPulls { return lhs.stats.openPulls > rhs.stats.openPulls }
+            if lhs.stats.openPulls != rhs.stats.openPulls {
+                return lhs.stats.openPulls > rhs.stats.openPulls
+            }
             return nil
         case .stars:
-            if lhs.stats.stars != rhs.stats.stars { return lhs.stats.stars > rhs.stats.stars }
+            if lhs.stats.stars != rhs.stats.stars {
+                return lhs.stats.stars > rhs.stats.stars
+            }
             return nil
         case .name:
             let order = lhs.fullName.localizedCaseInsensitiveCompare(rhs.fullName)
-            if order != .orderedSame { return order == .orderedAscending }
+            if order != .orderedSame {
+                return order == .orderedAscending
+            }
             return nil
         case .event:
             let left = lhs.activityLine(fallbackToPush: true) ?? ""
             let right = rhs.activityLine(fallbackToPush: true) ?? ""
-            if left != right { return left.localizedCaseInsensitiveCompare(right) == .orderedAscending }
+            if left != right {
+                return left.localizedCaseInsensitiveCompare(right) == .orderedAscending
+            }
             return nil
         }
     }

--- a/Sources/repobarcli/CLIHelpers.swift
+++ b/Sources/repobarcli/CLIHelpers.swift
@@ -217,7 +217,9 @@ func parseHost(_ raw: String) throws -> URL {
         throw ValidationError("Invalid host: \(raw)")
     }
 
-    if components.scheme == nil { components.scheme = "https" }
+    if components.scheme == nil {
+        components.scheme = "https"
+    }
     guard let url = components.url else {
         throw ValidationError("Invalid host: \(raw)")
     }

--- a/Sources/repobarcli/CLIOutput.swift
+++ b/Sources/repobarcli/CLIOutput.swift
@@ -203,7 +203,9 @@ func renderJSONData(_ rows: [RepoRow], baseHost: URL) throws -> Data {
 
 func renderJSON(_ rows: [RepoRow], baseHost: URL) throws {
     let data = try renderJSONData(rows, baseHost: baseHost)
-    if let json = String(data: data, encoding: .utf8) { print(json) }
+    if let json = String(data: data, encoding: .utf8) {
+        print(json)
+    }
 }
 
 func padLeft(_ value: String, to width: Int) -> String {

--- a/Sources/repobarcli/CacheCommands.swift
+++ b/Sources/repobarcli/CacheCommands.swift
@@ -124,7 +124,9 @@ struct RateLimitsCommand: CommanderRunnableCommand {
         print("GitHub API Status")
         print("Cache DB: \(PathFormatter.displayString(summary.databasePath))")
         for (index, section) in sections.enumerated() {
-            if index > 0 { print("") }
+            if index > 0 {
+                print("")
+            }
             if let title = section.title {
                 print(title)
             }

--- a/Sources/repobarcli/Commands.swift
+++ b/Sources/repobarcli/Commands.swift
@@ -686,7 +686,9 @@ struct StatusCommand: CommanderRunnableCommand {
                 let encoder = JSONEncoder()
                 encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
                 let data = try encoder.encode(output)
-                if let json = String(data: data, encoding: .utf8) { print(json) }
+                if let json = String(data: data, encoding: .utf8) {
+                    print(json)
+                }
             } else if authenticated == false {
                 print("Logged out (\(resolved.id)).")
             } else {
@@ -719,7 +721,9 @@ struct StatusCommand: CommanderRunnableCommand {
                 let encoder = JSONEncoder()
                 encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
                 let data = try encoder.encode(output)
-                if let json = String(data: data, encoding: .utf8) { print(json) }
+                if let json = String(data: data, encoding: .utf8) {
+                    print(json)
+                }
             } else {
                 print("Logged out.")
             }
@@ -744,7 +748,9 @@ struct StatusCommand: CommanderRunnableCommand {
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
             let data = try encoder.encode(output)
-            if let json = String(data: data, encoding: .utf8) { print(json) }
+            if let json = String(data: data, encoding: .utf8) {
+                print(json)
+            }
         } else {
             print("Logged in.")
             print("Host: \(host)")

--- a/Sources/repobarcli/LocalProjectsCommands.swift
+++ b/Sources/repobarcli/LocalProjectsCommands.swift
@@ -37,8 +37,12 @@ struct LocalProjectsCommand: CommanderRunnableCommand {
     }
 
     mutating func run() async throws {
-        if self.depth < 0 { throw ValidationError("--depth must be >= 0") }
-        if let limit, limit <= 0 { throw ValidationError("--limit must be > 0") }
+        if self.depth < 0 {
+            throw ValidationError("--depth must be >= 0")
+        }
+        if let limit, limit <= 0 {
+            throw ValidationError("--limit must be > 0")
+        }
 
         let settings = cliSettingsStore().load()
         let rootPath = self.root
@@ -74,7 +78,9 @@ struct LocalProjectsCommand: CommanderRunnableCommand {
                 repositories: statuses.map { LocalRepoOutput($0, didSync: syncedPaths.contains($0.path.path)) }
             )
             let data = try encoder.encode(payload)
-            if let json = String(data: data, encoding: .utf8) { print(json) }
+            if let json = String(data: data, encoding: .utf8) {
+                print(json)
+            }
             return
         }
 

--- a/Sources/repobarcli/RecentListCommands.swift
+++ b/Sources/repobarcli/RecentListCommands.swift
@@ -28,7 +28,9 @@ struct ReleasesCommand: CommanderRunnableCommand {
     }
 
     mutating func run() async throws {
-        if self.limit <= 0 { throw ValidationError("--limit must be greater than 0") }
+        if self.limit <= 0 {
+            throw ValidationError("--limit must be greater than 0")
+        }
         let repo = try requireRepoIdentifier(self.repoName)
 
         let context = try await makeAuthenticatedClient()
@@ -79,7 +81,9 @@ struct CICommand: CommanderRunnableCommand {
     }
 
     mutating func run() async throws {
-        if self.limit <= 0 { throw ValidationError("--limit must be greater than 0") }
+        if self.limit <= 0 {
+            throw ValidationError("--limit must be greater than 0")
+        }
         let repo = try requireRepoIdentifier(self.repoName)
 
         let context = try await makeAuthenticatedClient()
@@ -130,7 +134,9 @@ struct DiscussionsCommand: CommanderRunnableCommand {
     }
 
     mutating func run() async throws {
-        if self.limit <= 0 { throw ValidationError("--limit must be greater than 0") }
+        if self.limit <= 0 {
+            throw ValidationError("--limit must be greater than 0")
+        }
         let repo = try requireRepoIdentifier(self.repoName)
 
         let context = try await makeAuthenticatedClient()
@@ -181,7 +187,9 @@ struct TagsCommand: CommanderRunnableCommand {
     }
 
     mutating func run() async throws {
-        if self.limit <= 0 { throw ValidationError("--limit must be greater than 0") }
+        if self.limit <= 0 {
+            throw ValidationError("--limit must be greater than 0")
+        }
         let repo = try requireRepoIdentifier(self.repoName)
 
         let context = try await makeAuthenticatedClient()
@@ -232,7 +240,9 @@ struct BranchesCommand: CommanderRunnableCommand {
     }
 
     mutating func run() async throws {
-        if self.limit <= 0 { throw ValidationError("--limit must be greater than 0") }
+        if self.limit <= 0 {
+            throw ValidationError("--limit must be greater than 0")
+        }
         let repo = try requireRepoIdentifier(self.repoName)
 
         let context = try await makeAuthenticatedClient()
@@ -283,7 +293,9 @@ struct ContributorsCommand: CommanderRunnableCommand {
     }
 
     mutating func run() async throws {
-        if self.limit <= 0 { throw ValidationError("--limit must be greater than 0") }
+        if self.limit <= 0 {
+            throw ValidationError("--limit must be greater than 0")
+        }
         let repo = try requireRepoIdentifier(self.repoName)
 
         let context = try await makeAuthenticatedClient()
@@ -342,7 +354,9 @@ struct CommitsCommand: CommanderRunnableCommand {
     }
 
     mutating func run() async throws {
-        if self.limit <= 0 { throw ValidationError("--limit must be greater than 0") }
+        if self.limit <= 0 {
+            throw ValidationError("--limit must be greater than 0")
+        }
         let context = try await makeAuthenticatedClient()
 
         if let target, target.contains("/") {
@@ -435,7 +449,9 @@ struct ActivityCommand: CommanderRunnableCommand {
     }
 
     mutating func run() async throws {
-        if self.limit <= 0 { throw ValidationError("--limit must be greater than 0") }
+        if self.limit <= 0 {
+            throw ValidationError("--limit must be greater than 0")
+        }
         let context = try await makeAuthenticatedClient()
 
         if let target, target.contains("/") {

--- a/Tests/RepoBarTests/OAuthLoginFlowTests.swift
+++ b/Tests/RepoBarTests/OAuthLoginFlowTests.swift
@@ -338,7 +338,9 @@ private extension OAuthLoginFlowTests {
         var buffer = [UInt8](repeating: 0, count: bufferSize)
         while stream.hasBytesAvailable {
             let read = stream.read(&buffer, maxLength: buffer.count)
-            if read <= 0 { break }
+            if read <= 0 {
+                break
+            }
             data.append(buffer, count: read)
         }
         return String(data: data, encoding: .utf8)

--- a/Tests/RepoBarTests/OAuthTokenRefresherTests.swift
+++ b/Tests/RepoBarTests/OAuthTokenRefresherTests.swift
@@ -474,7 +474,9 @@ private extension OAuthTokenRefresherTests {
         var buffer = [UInt8](repeating: 0, count: bufferSize)
         while stream.hasBytesAvailable {
             let read = stream.read(&buffer, maxLength: buffer.count)
-            if read <= 0 { break }
+            if read <= 0 {
+                break
+            }
             data.append(buffer, count: read)
         }
         return String(data: data, encoding: .utf8)


### PR DESCRIPTION
## Summary

- apply SwiftFormat 0.62.1's mechanical output across the 76 drifted Swift files
- disable `wrapMultilineStatementBraces` so formatter output remains compatible with SwiftLint's `opening_brace` rule
- make no logic or behavior changes

## Proof

- `pnpm check`: SwiftFormat idempotent, SwiftLint clean, 76 CLI tests and 589 app/core tests passed (665 total)
- second `pnpm format`: 0/355 files formatted
- Codex autoreview: clean, no accepted or actionable findings
- public model identifier gate: pass; no model identifiers changed

This unblocks the dependency refresh in https://github.com/steipete/RepoBar/pull/95.
