### PR TITLE
fix(ios): reject malformed repository names in RepoWebURLBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.8.7 - Unreleased
 
 - Refresh npm and Swift package resolutions, keep Commander pinned to its compatible positional-argument contract, and make SwiftPM tests load Sparkle from the Xcode 26 product layout.
+- Reject malformed repository names in the iOS `RepoWebURLBuilder`, which previously accepted values like `acme/widget/extra` and `acme//widget` and built incorrect URLs; the macOS builder already guarded against these.
 
 ## 0.8.6 - 2026-07-06
 

--- a/RepoBariOS/RepoBariOS.xcodeproj/project.pbxproj
+++ b/RepoBariOS/RepoBariOS.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		058B0ED7732E2B4C76CCD0A4 /* GitHubReferenceMatch+Display.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DDA676FBF67AB625794875B /* GitHubReferenceMatch+Display.swift */; };
+		08A14ABAC7D8F60F1CECB4F4 /* RepoWebURLBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A70A092BAC0A867A97415D9 /* RepoWebURLBuilderTests.swift */; };
 		0DC367D0B45B1E71D3FF0103 /* AppSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DAAD776BCFAD8C0BB42258 /* AppSession.swift */; };
 		15A96DF4CF7EA83F7745A031 /* RepositoryCardModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C23DF7BC5FCE3DB16F3D11 /* RepositoryCardModel.swift */; };
 		1843CDC27F756953CBC10286 /* IncomingReferenceURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84059B3F58ED56D01DC050FA /* IncomingReferenceURL.swift */; };
@@ -86,6 +87,7 @@
 		1E1E7701B5D0E364FF641342 /* RepoFilesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoFilesView.swift; sourceTree = "<group>"; };
 		22C23DF7BC5FCE3DB16F3D11 /* RepositoryCardModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryCardModel.swift; sourceTree = "<group>"; };
 		2540C2570FFCFA055E2A951F /* RepoBariOS.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = RepoBariOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		3A70A092BAC0A867A97415D9 /* RepoWebURLBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoWebURLBuilderTests.swift; sourceTree = "<group>"; };
 		476C6F1C986C9CC7DF6E8B12 /* AddRepoSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddRepoSheet.swift; sourceTree = "<group>"; };
 		497C519044532FBA808AFAD6 /* OAuthCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthCoordinator.swift; sourceTree = "<group>"; };
 		4D26FAB33B6A0F5D3125A8DC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -145,6 +147,7 @@
 			children = (
 				83ACEE3DBA3F2C3F05B624D8 /* IncomingReferenceURLTests.swift */,
 				4D72E27B247AA11DE617F905 /* OwnerFilterParserTests.swift */,
+				3A70A092BAC0A867A97415D9 /* RepoWebURLBuilderTests.swift */,
 			);
 			path = RepoBariOSTests;
 			sourceTree = "<group>";
@@ -429,6 +432,7 @@
 			files = (
 				5FCE45A91ABA50AA40CEB4E4 /* IncomingReferenceURLTests.swift in Sources */,
 				F61F21A79415EE0B0A123D30 /* OwnerFilterParserTests.swift in Sources */,
+				08A14ABAC7D8F60F1CECB4F4 /* RepoWebURLBuilderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RepoBariOS/Sources/Support/RepoWebURLBuilder.swift
+++ b/RepoBariOS/Sources/Support/RepoWebURLBuilder.swift
@@ -4,8 +4,9 @@ struct RepoWebURLBuilder {
     let host: URL
 
     func repoURL(fullName: String) -> URL? {
-        let parts = fullName.split(separator: "/", maxSplits: 1)
-        guard parts.count == 2 else { return nil }
+        let parts = fullName.split(separator: "/", omittingEmptySubsequences: false)
+        guard parts.count == 2, parts.allSatisfy({ !$0.isEmpty }) else { return nil }
+
         return self.repoPathURL(components: [String(parts[0]), String(parts[1])])
     }
 

--- a/RepoBariOS/Tests/RepoBariOSTests/RepoWebURLBuilderTests.swift
+++ b/RepoBariOS/Tests/RepoBariOSTests/RepoWebURLBuilderTests.swift
@@ -1,0 +1,29 @@
+@testable import RepoBariOS
+import XCTest
+
+final class RepoWebURLBuilderTests: XCTestCase {
+    private func builder(host: String = "https://github.com") throws -> RepoWebURLBuilder {
+        let url = try XCTUnwrap(URL(string: host))
+        return RepoWebURLBuilder(host: url)
+    }
+
+    func testBuildsRepoURL() throws {
+        let builder = try self.builder(host: "https://github.example.com")
+        XCTAssertEqual(
+            builder.repoURL(fullName: "acme/widget")?.absoluteString,
+            "https://github.example.com/acme/widget"
+        )
+    }
+
+    func testRejectsMalformedRepositoryNames() throws {
+        let builder = try self.builder()
+
+        XCTAssertNil(builder.repoURL(fullName: "widget"))
+        XCTAssertNil(builder.repoURL(fullName: "acme/widget/extra"))
+        XCTAssertNil(builder.repoURL(fullName: "acme//widget"))
+        XCTAssertNil(builder.repoURL(fullName: "acme/widget/"))
+        XCTAssertNil(builder.repoURL(fullName: "acme//"))
+        XCTAssertNil(builder.repoURL(fullName: "/widget"))
+        XCTAssertNil(builder.repoURL(fullName: ""))
+    }
+}

--- a/RepoBariOS/Tests/RepoBariOSTests/RepoWebURLBuilderTests.swift
+++ b/RepoBariOS/Tests/RepoBariOSTests/RepoWebURLBuilderTests.swift
@@ -1,29 +1,32 @@
 @testable import RepoBariOS
-import XCTest
+import Foundation
+import Testing
 
-final class RepoWebURLBuilderTests: XCTestCase {
+struct RepoWebURLBuilderTests {
     private func builder(host: String = "https://github.com") throws -> RepoWebURLBuilder {
-        let url = try XCTUnwrap(URL(string: host))
+        let url = try #require(URL(string: host))
         return RepoWebURLBuilder(host: url)
     }
 
-    func testBuildsRepoURL() throws {
+    @Test
+    func test_buildsRepoURL() throws {
         let builder = try self.builder(host: "https://github.example.com")
-        XCTAssertEqual(
-            builder.repoURL(fullName: "acme/widget")?.absoluteString,
-            "https://github.example.com/acme/widget"
+        #expect(
+            builder.repoURL(fullName: "acme/widget")?.absoluteString
+                == "https://github.example.com/acme/widget"
         )
     }
 
-    func testRejectsMalformedRepositoryNames() throws {
+    @Test
+    func test_rejectsMalformedRepositoryNames() throws {
         let builder = try self.builder()
 
-        XCTAssertNil(builder.repoURL(fullName: "widget"))
-        XCTAssertNil(builder.repoURL(fullName: "acme/widget/extra"))
-        XCTAssertNil(builder.repoURL(fullName: "acme//widget"))
-        XCTAssertNil(builder.repoURL(fullName: "acme/widget/"))
-        XCTAssertNil(builder.repoURL(fullName: "acme//"))
-        XCTAssertNil(builder.repoURL(fullName: "/widget"))
-        XCTAssertNil(builder.repoURL(fullName: ""))
+        #expect(builder.repoURL(fullName: "widget") == nil)
+        #expect(builder.repoURL(fullName: "acme/widget/extra") == nil)
+        #expect(builder.repoURL(fullName: "acme//widget") == nil)
+        #expect(builder.repoURL(fullName: "acme/widget/") == nil)
+        #expect(builder.repoURL(fullName: "acme//") == nil)
+        #expect(builder.repoURL(fullName: "/widget") == nil)
+        #expect(builder.repoURL(fullName: "") == nil)
     }
 }


### PR DESCRIPTION
## Problem

`RepoBariOS/Sources/Support/RepoWebURLBuilder.swift` and `Sources/RepoBar/Support/RepoWebURLBuilder.swift` are otherwise identical files, differing only in `repoURL(fullName:)`. The macOS one was hardened; the iOS one was not.

```swift
// macOS
let parts = fullName.split(separator: "/", omittingEmptySubsequences: false)
guard parts.count == 2, parts.allSatisfy({ !$0.isEmpty }) else { return nil }

// iOS
let parts = fullName.split(separator: "/", maxSplits: 1)
guard parts.count == 2 else { return nil }
```

Because `maxSplits: 1` stops after the first separator and empty subsequences are omitted, the iOS guard passes for several malformed inputs and builds a URL from them:

| `fullName` | iOS (before) | macOS / iOS (after) |
| --- | --- | --- |
| `acme/widget` | `https://github.com/acme/widget` | unchanged |
| `acme/widget/extra` | `https://github.com/acme/widget/extra` | `nil` |
| `acme//widget` | `https://github.com/acme/widget` | `nil` |
| `acme/widget/` | `https://github.com/acme/widget/` | `nil` |
| `acme//` | `https://github.com/acme/` | `nil` |
| `widget`, `/widget`, `""` | `nil` | `nil` |

`acme//widget` is the one worth highlighting: it does not fail loudly, it silently resolves to `https://github.com/acme/widget`, a different repository that looks entirely valid.

`acme/widget/extra` is already covered on the macOS side - `RepoWebURLBuilderTests.repo URL rejects malformed repository names` asserts it returns `nil`. So the iOS builder was violating a contract the project had already written a test for.

## Fix

Port the macOS guard verbatim. After this change the two files differ only by a blank line that was already inconsistent on `main`.

## Verification

The iOS simulator on my machine is broken (`CoreSimulator is out of date`), so I could not run the `RepoBariOSTests` bundle through `xcodebuild`. Instead I compiled the real `RepoWebURLBuilder.swift` - both the `main` version and the patched version - against a small driver exercising the same cases the new tests assert.

Unpatched:

```
[PASS] acme/widget (valid)        -> https://github.example.com/acme/widget
[PASS] "widget" rejected          -> nil
[FAIL] "acme/widget/extra"        -> https://github.com/acme/widget/extra
[FAIL] "acme//widget"             -> https://github.com/acme/widget
[FAIL] "acme/widget/"             -> https://github.com/acme/widget/
[FAIL] "acme//"                   -> https://github.com/acme/
[PASS] "/widget" rejected         -> nil
[PASS] "" rejected                -> nil
4 FAILURES
```

Patched: all 8 pass.

Added `RepoBariOS/Tests/RepoBariOSTests/RepoWebURLBuilderTests.swift` mirroring the macOS tests, using XCTest to match the existing iOS test target. The target's `sources: [Tests]` glob in `project.yml` picks it up with no manifest change. **Please confirm it passes in CI, since I could not run the simulator locally.**

`swiftformat --lint` and `swiftlint` are clean on both changed files. Note the source file does not pass `swiftformat --lint` on `main` either (it wants blank lines after two `guard` statements); I kept only the one inside `repoURL` that comes with the ported macOS code and left the unrelated one alone rather than reformatting untouched lines.


## Follow-up: suite registered, and moved to Swift Testing

Both review points were correct, and the first one mattered a lot: the suite genuinely never ran.

**Registration.** `RepoWebURLBuilderTests.swift` was on disk but not in the checked-in `RepoBariOS.xcodeproj`, so Xcode and `xcodebuild` skipped it. Worth noting `RepoBariOS/project.yml` does glob `sources: - Tests` for the `RepoBariOSTests` target, so an XcodeGen regeneration would have picked it up, but there is no xcodegen script in `package.json` and the `.xcodeproj` is checked in and enumerates files explicitly, so the registration was genuinely missing. Added it to all four places, following the existing `IncomingReferenceURLTests` / `OwnerFilterParserTests` entries exactly:

```
$ git diff --stat RepoBariOS/RepoBariOS.xcodeproj/project.pbxproj
 RepoBariOS/RepoBariOS.xcodeproj/project.pbxproj | 4 ++++

$ plutil -lint RepoBariOS/RepoBariOS.xcodeproj/project.pbxproj
RepoBariOS/RepoBariOS.xcodeproj/project.pbxproj: OK
```

The two new object IDs were checked against every ID already in the file, no collisions. The `RepoBariOSTests` sources phase now lists three files:

```
3EB2B8F3097E1B5960589454 /* Sources */ = {
    isa = PBXSourcesBuildPhase;
    files = (
        5FCE45A91ABA50AA40CEB4E4 /* IncomingReferenceURLTests.swift in Sources */,
        F61F21A79415EE0B0A123D30 /* OwnerFilterParserTests.swift in Sources */,
        08A14ABAC7D8F60F1CECB4F4 /* RepoWebURLBuilderTests.swift in Sources */,
    );
```

**Swift Testing.** Converted to `struct` + `@Test` + `#expect` / `#require` with `test_<behavior>()` naming per AGENTS.md. This makes it the first Swift Testing file in the iOS target (the two existing ones are XCTest), so I checked that it actually works here rather than assuming. `Testing.framework` does ship for the iPhoneSimulator platform in this Xcode, and compiling the real unmodified `RepoWebURLBuilder.swift` as module `RepoBariOS` and then the new test file against it succeeds:

```
=== Step 1: compile RepoWebURLBuilder.swift as module 'RepoBariOS' (enable-testing) for iphonesimulator26.0 ===
exit=0
=== Step 2b: typecheck+compile Swift Testing test file with plugin path ===
exit=0
```

target `arm64-apple-ios26.0-simulator`, SDK `iphonesimulator26.5`, `-swift-version 6`, matching the target's real `IPHONEOS_DEPLOYMENT_TARGET` and `SWIFT_VERSION` build settings.

**What I could not verify.** I still cannot run the suite on a simulator or device here, and I would rather say so than imply otherwise. This machine's Xcode has no iOS 26.5 platform support installed, so there is no eligible destination:

```
$ xcodebuild build-for-testing -scheme RepoBariOS -project RepoBariOS/RepoBariOS.xcodeproj -destination 'generic/platform=iOS Simulator'
xcodebuild: error: Unable to find a destination matching the provided destination specifier
    Ineligible destinations for the "RepoBariOS" scheme:
        { platform:iOS, ... error:iOS 26.5 is not installed. Please download and install the platform from Xcode > Settings > Components. }
```

That is identical before and after these edits, so it is an environment limitation on my side rather than anything this branch introduces. The compile evidence above is the strongest verification I can produce locally; a normal CI or a machine with the platform installed will now actually execute the suite, which was the point of the registration fix.
