### PR TITLE
build(deps): update Commander and setup-node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: corepack enable
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@v6.5.0
         with:
           node-version: '22'
           cache: 'pnpm'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.8.7 - Unreleased
 
+- Update Commander to 0.2.4 while preserving declared CLI positional arguments, and update `actions/setup-node` to 6.5.0.
 - Refresh npm and Swift package resolutions, keep Commander pinned to its compatible positional-argument contract, and make SwiftPM tests load Sparkle from the Xcode 26 product layout.
 
 ## 0.8.6 - 2026-07-06

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ce363525a7fc2d5df7e60cd885b7aca447defb1fe96b98934bf21490c5eaf9c8",
+  "originHash" : "2a313dba8f5a9e0cba03579cd463dda169608a7496294454be595ff7559c4c81",
   "pins" : [
     {
       "identity" : "apollo-ios",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/steipete/Commander",
       "state" : {
-        "revision" : "ae2ce746b386ff94b26648cfe5625cfa8d02639b",
-        "version" : "0.2.2"
+        "revision" : "bd219c4ee9032fee3e009856f81fcc6ec09a85f4",
+        "version" : "0.2.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .executable(name: "repobarcli", targets: ["repobarcli"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/steipete/Commander", exact: "0.2.2"),
+        .package(url: "https://github.com/steipete/Commander", exact: "0.2.4"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.8.1"),
         .package(url: "https://github.com/orchetect/MenuBarExtraAccess", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-algorithms", from: "1.2.1"),

--- a/Sources/repobarcli/AccountsCommands.swift
+++ b/Sources/repobarcli/AccountsCommands.swift
@@ -83,6 +83,7 @@ struct AccountsListCommand: CommanderRunnableCommand {
 struct AccountsUseCommand: CommanderRunnableCommand {
     nonisolated static let commandName = "accounts-use"
 
+    @Argument
     private var target: String?
 
     static var commandDescription: CommandDescription {
@@ -112,6 +113,7 @@ struct AccountsUseCommand: CommanderRunnableCommand {
 struct AccountsRemoveCommand: CommanderRunnableCommand {
     nonisolated static let commandName = "accounts-remove"
 
+    @Argument
     private var target: String?
 
     static var commandDescription: CommandDescription {

--- a/Sources/repobarcli/ArchiveCommands.swift
+++ b/Sources/repobarcli/ArchiveCommands.swift
@@ -51,6 +51,7 @@ struct ArchivesStatusCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var name: String?
 
     static var commandDescription: CommandDescription {
@@ -104,6 +105,7 @@ struct ArchivesValidateCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var name: String?
 
     static var commandDescription: CommandDescription {
@@ -147,6 +149,7 @@ struct ArchivesUpdateCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var name: String?
 
     static var commandDescription: CommandDescription {
@@ -212,6 +215,7 @@ struct ArchivesAddCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var repository: String?
 
     static var commandDescription: CommandDescription {
@@ -368,6 +372,7 @@ struct ArchivesRemoveCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var name: String?
 
     static var commandDescription: CommandDescription {
@@ -408,6 +413,7 @@ struct ArchivesEnableCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var name: String?
 
     static var commandDescription: CommandDescription {
@@ -451,6 +457,7 @@ struct ArchivesDisableCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var name: String?
 
     static var commandDescription: CommandDescription {

--- a/Sources/repobarcli/ChangelogCommand.swift
+++ b/Sources/repobarcli/ChangelogCommand.swift
@@ -28,6 +28,7 @@ struct ChangelogCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var path: String?
 
     static var commandDescription: CommandDescription {

--- a/Sources/repobarcli/LocalActionsCommands.swift
+++ b/Sources/repobarcli/LocalActionsCommands.swift
@@ -9,6 +9,7 @@ struct LocalSyncCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var target: String?
 
     static var commandDescription: CommandDescription {
@@ -58,6 +59,7 @@ struct LocalRebaseCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var target: String?
 
     static var commandDescription: CommandDescription {
@@ -106,6 +108,7 @@ struct LocalResetCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var target: String?
 
     static var commandDescription: CommandDescription {
@@ -157,6 +160,7 @@ struct LocalBranchesCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var target: String?
 
     static var commandDescription: CommandDescription {
@@ -204,6 +208,7 @@ struct WorktreesCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var target: String?
 
     static var commandDescription: CommandDescription {
@@ -247,6 +252,7 @@ struct WorktreesCommand: CommanderRunnableCommand {
 struct OpenFinderCommand: CommanderRunnableCommand {
     nonisolated static let commandName = "open-finder"
 
+    @Argument
     private var target: String?
 
     static var commandDescription: CommandDescription {
@@ -273,6 +279,7 @@ struct OpenFinderCommand: CommanderRunnableCommand {
 struct OpenTerminalCommand: CommanderRunnableCommand {
     nonisolated static let commandName = "open-terminal"
 
+    @Argument
     private var target: String?
 
     static var commandDescription: CommandDescription {
@@ -311,6 +318,7 @@ struct CheckoutCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var repoName: String?
 
     static var commandDescription: CommandDescription {

--- a/Sources/repobarcli/MarkdownCommand.swift
+++ b/Sources/repobarcli/MarkdownCommand.swift
@@ -17,6 +17,7 @@ struct MarkdownCommand: CommanderRunnableCommand {
     @Flag(names: [.customLong("no-color")], help: "Disable color output")
     var noColor: Bool = false
 
+    @Argument
     private var path: String?
 
     static var commandDescription: CommandDescription {

--- a/Sources/repobarcli/RecentListCommands.swift
+++ b/Sources/repobarcli/RecentListCommands.swift
@@ -12,6 +12,7 @@ struct ReleasesCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var repoName: String?
 
     static var commandDescription: CommandDescription {
@@ -65,6 +66,7 @@ struct CICommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var repoName: String?
 
     static var commandDescription: CommandDescription {
@@ -118,6 +120,7 @@ struct DiscussionsCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var repoName: String?
 
     static var commandDescription: CommandDescription {
@@ -171,6 +174,7 @@ struct TagsCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var repoName: String?
 
     static var commandDescription: CommandDescription {
@@ -224,6 +228,7 @@ struct BranchesCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var repoName: String?
 
     static var commandDescription: CommandDescription {
@@ -277,6 +282,7 @@ struct ContributorsCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var repoName: String?
 
     static var commandDescription: CommandDescription {
@@ -336,6 +342,7 @@ struct CommitsCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var target: String?
 
     static var commandDescription: CommandDescription {
@@ -430,6 +437,7 @@ struct ActivityCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var target: String?
 
     static var commandDescription: CommandDescription {

--- a/Sources/repobarcli/ReferenceTranslateCommand.swift
+++ b/Sources/repobarcli/ReferenceTranslateCommand.swift
@@ -9,6 +9,7 @@ struct ReferenceTranslateCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var text: String?
 
     static var commandDescription: CommandDescription {

--- a/Sources/repobarcli/SettingsCommands.swift
+++ b/Sources/repobarcli/SettingsCommands.swift
@@ -9,6 +9,7 @@ struct PinCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var repoName: String?
 
     static var commandDescription: CommandDescription {
@@ -51,6 +52,7 @@ struct UnpinCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var repoName: String?
 
     static var commandDescription: CommandDescription {
@@ -90,6 +92,7 @@ struct HideCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var repoName: String?
 
     static var commandDescription: CommandDescription {
@@ -132,6 +135,7 @@ struct ShowCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var repoName: String?
 
     static var commandDescription: CommandDescription {
@@ -200,7 +204,10 @@ struct SettingsSetCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var key: String?
+
+    @Argument
     private var value: String?
 
     static var commandDescription: CommandDescription {

--- a/Sources/repobarcli/VerifyCommands.swift
+++ b/Sources/repobarcli/VerifyCommands.swift
@@ -74,6 +74,7 @@ struct RepoCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var repoName: String?
 
     static var commandDescription: CommandDescription {
@@ -172,6 +173,7 @@ struct IssuesCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var repoName: String?
 
     static var commandDescription: CommandDescription {
@@ -243,6 +245,7 @@ struct PullsCommand: CommanderRunnableCommand {
     @OptionGroup
     var output: OutputOptions
 
+    @Argument
     private var repoName: String?
 
     static var commandDescription: CommandDescription {

--- a/Tests/repobarcliTests/CLIArgumentNormalizerTests.swift
+++ b/Tests/repobarcliTests/CLIArgumentNormalizerTests.swift
@@ -154,6 +154,17 @@ struct CLIArgumentNormalizerTests {
     }
 
     @Test
+    @MainActor
+    func `commands without positional arguments reject stray input`() throws {
+        let argv = CLIArgumentNormalizer.normalize(["repobar", "status", "unexpected"])
+        let program = Program(descriptors: [RepoBarRoot.descriptor()])
+
+        #expect(throws: CommanderProgramError.self) {
+            _ = try program.resolve(argv: argv)
+        }
+    }
+
+    @Test
     func `normalizes open subcommands`() {
         let finderArgs = CLIArgumentNormalizer.normalize(["repobar", "open", "finder", "~/Projects"])
         #expect(finderArgs[1] == "open-finder")


### PR DESCRIPTION
## Summary

- update Commander from 0.2.2 to 0.2.4
- declare RepoBar's existing CLI positional arguments so Commander 0.2.4 can validate commands without breaking supported invocations
- reject stray positional input for commands such as `status`
- update `actions/setup-node` from 6.4.0 to 6.5.0

## Why

Commander 0.2.3 and later reject positional input when a command's reflected signature declares no arguments. RepoBar was consuming `ParsedValues.positional` manually, but its positional backing properties were not annotated, so valid commands such as `archive add openclaw/openclaw` failed as unexpected input after the dependency update.

The fix declares those already-public positional contracts with `@Argument`; existing binding and validation remain authoritative. Commands with no positional contract now correctly reject stray input.

## Proof

- `./Scripts/swiftformat.sh`
- `./Scripts/swiftlint.sh`
- `./Scripts/test.sh` — 666 tests in 109 suites passed
- `./Scripts/package_app.sh release` — universal arm64/x86_64 app and CLI built successfully
- release CLI: `repobarcli reference-translate 'openclaw/ClawSweeper#57' --json` returned the expected repository/issue match
- release CLI: `repobarcli status unexpected --plain` returned `Error: Unexpected argument: unexpected` with exit 1
- source-blind behavior contract: passed both valid reference translation and invalid-extra-argument checks against the isolated release binary
- autoreview: clean, no actionable findings (0.99 confidence)

The diff does not touch model identifiers or generated/model-produced artifacts.
