### PR TITLE
chore: ignore local environment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,10 @@ fastlane/screenshots/**/*.png
 fastlane/test_output
 Config/Local.xcconfig
 
+# Local environment
+.env
+.env.local
+
 # macOS user cruft
 .DS_Store
 


### PR DESCRIPTION
## Summary

- ignore the root `.env` used by local GitHub helper scripts
- ignore `.env.local` to prevent machine-specific secrets from being committed

## Verification

- `git check-ignore -v --no-index .env .env.local`
- `CI=true pnpm check` (666 tests across 109 suites)
- Codex autoreview: clean, no accepted/actionable findings
