### PR TITLE
Add multi-account consolidation contracts

### DIFF
--- a/Sources/RepoBarCore/Models/AccountScopedIdentity.swift
+++ b/Sources/RepoBarCore/Models/AccountScopedIdentity.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Identifies the account that supplied a GitHub-backed value.
+public struct AccountSource: Codable, Equatable, Hashable, Sendable {
+    public let accountID: String
+
+    public init(accountID: String) {
+        self.accountID = accountID
+    }
+
+    public init(account: Account) {
+        self.init(accountID: account.id)
+    }
+}
+
+/// Collision-safe identity for a repository returned through a specific account.
+public struct AccountScopedRepositoryIdentity: Codable, Equatable, Hashable, Sendable {
+    public let source: AccountSource
+    public let repositoryID: String
+
+    public init(source: AccountSource, repositoryID: String) {
+        self.source = source
+        self.repositoryID = repositoryID
+    }
+
+    public init(accountID: String, repositoryID: String) {
+        self.init(source: AccountSource(accountID: accountID), repositoryID: repositoryID)
+    }
+}
+
+/// Collision-safe identity for account-scoped references that have a canonical URL.
+public struct AccountScopedURLIdentity: Codable, Equatable, Hashable, Sendable {
+    public let source: AccountSource
+    public let url: URL
+
+    public init(source: AccountSource, url: URL) {
+        self.source = source
+        self.url = url
+    }
+
+    public init(accountID: String, url: URL) {
+        self.init(source: AccountSource(accountID: accountID), url: url)
+    }
+}
+
+/// Collision-safe identity for notification and attention events.
+public struct AccountScopedEventIdentity: Codable, Equatable, Hashable, Sendable {
+    public let source: AccountSource
+    public let namespace: String
+    public let eventID: String
+
+    public init(source: AccountSource, namespace: String, eventID: String) {
+        self.source = source
+        self.namespace = namespace
+        self.eventID = eventID
+    }
+
+    public init(accountID: String, namespace: String, eventID: String) {
+        self.init(
+            source: AccountSource(accountID: accountID),
+            namespace: namespace,
+            eventID: eventID
+        )
+    }
+}
+
+/// Cache key that cannot collide across account-specific stores or request routes.
+public struct AccountScopedCacheKey: Codable, Equatable, Hashable, Sendable {
+    public let source: AccountSource
+    public let key: String
+
+    public init(source: AccountSource, key: String) {
+        self.source = source
+        self.key = key
+    }
+
+    public init(accountID: String, key: String) {
+        self.init(source: AccountSource(accountID: accountID), key: key)
+    }
+}

--- a/Sources/RepoBarCore/Settings/AttentionRule.swift
+++ b/Sources/RepoBarCore/Settings/AttentionRule.swift
@@ -92,6 +92,10 @@ public struct AttentionRule: Codable, Equatable, Hashable, Identifiable, Sendabl
     public var itemStates: [AttentionItemState]
     public var priority: AttentionPriority
 
+    public var isEffectivelyEnabled: Bool {
+        self.enabled && self.category.isKnown
+    }
+
     public init(
         id: AttentionRuleID,
         enabled: Bool = true,
@@ -127,8 +131,7 @@ public struct AttentionRule: Codable, Equatable, Hashable, Identifiable, Sendabl
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.id = try container.decode(AttentionRuleID.self, forKey: .id)
         self.category = try container.decode(AttentionRuleCategory.self, forKey: .category)
-        let decodedEnabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
-        self.enabled = self.category.isKnown ? decodedEnabled : false
+        self.enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
         self.accountSelection = try container.decodeIfPresent(
             AccountSelection.self,
             forKey: .accountSelection

--- a/Sources/RepoBarCore/Settings/AttentionRule.swift
+++ b/Sources/RepoBarCore/Settings/AttentionRule.swift
@@ -1,0 +1,227 @@
+import Foundation
+
+public struct AttentionRuleID: RawRepresentable, Codable, Equatable, Hashable, Sendable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        try self.init(rawValue: container.decode(String.self))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.rawValue)
+    }
+}
+
+/// Extensible category value. Unknown raw values survive decoding so a newer rule
+/// does not invalidate the complete settings payload.
+public struct AttentionRuleCategory: RawRepresentable, Codable, Equatable, Hashable, Sendable {
+    public static let reviewRequests = Self(rawValue: "reviewRequests")
+    public static let assignedIssues = Self(rawValue: "assignedIssues")
+    public static let assignedPullRequests = Self(rawValue: "assignedPullRequests")
+    public static let mentions = Self(rawValue: "mentions")
+    public static let subscribedUpdates = Self(rawValue: "subscribedUpdates")
+    public static let authoredItems = Self(rawValue: "authoredItems")
+    public static let failedWorkflows = Self(rawValue: "failedWorkflows")
+    public static let runnerHealth = Self(rawValue: "runnerHealth")
+    public static let queuePressure = Self(rawValue: "queuePressure")
+    public static let criticalAPIHealth = Self(rawValue: "criticalAPIHealth")
+
+    public static let knownCategories: Set<Self> = [
+        .reviewRequests,
+        .assignedIssues,
+        .assignedPullRequests,
+        .mentions,
+        .subscribedUpdates,
+        .authoredItems,
+        .failedWorkflows,
+        .runnerHealth,
+        .queuePressure,
+        .criticalAPIHealth
+    ]
+
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public var isKnown: Bool {
+        Self.knownCategories.contains(self)
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        try self.init(rawValue: container.decode(String.self))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.rawValue)
+    }
+}
+
+public enum AttentionItemState: String, Codable, Equatable, Hashable, Sendable {
+    case open
+    case closed
+    case merged
+    case pending
+    case failing
+    case unhealthy
+}
+
+public enum AttentionPriority: String, Codable, Equatable, Hashable, Sendable {
+    case low
+    case normal
+    case high
+    case critical
+}
+
+public struct AttentionRule: Codable, Equatable, Hashable, Identifiable, Sendable {
+    public let id: AttentionRuleID
+    public var enabled: Bool
+    public var category: AttentionRuleCategory
+    public var accountSelection: AccountSelection
+    public var ownerFilters: [String]
+    public var repositoryFilters: [String]
+    public var itemStates: [AttentionItemState]
+    public var priority: AttentionPriority
+
+    public init(
+        id: AttentionRuleID,
+        enabled: Bool = true,
+        category: AttentionRuleCategory,
+        accountSelection: AccountSelection = .all,
+        ownerFilters: [String] = [],
+        repositoryFilters: [String] = [],
+        itemStates: [AttentionItemState] = [],
+        priority: AttentionPriority = .normal
+    ) {
+        self.id = id
+        self.enabled = enabled
+        self.category = category
+        self.accountSelection = accountSelection
+        self.ownerFilters = ownerFilters
+        self.repositoryFilters = repositoryFilters
+        self.itemStates = itemStates
+        self.priority = priority
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case enabled
+        case category
+        case accountSelection
+        case ownerFilters
+        case repositoryFilters
+        case itemStates
+        case priority
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(AttentionRuleID.self, forKey: .id)
+        self.category = try container.decode(AttentionRuleCategory.self, forKey: .category)
+        let decodedEnabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
+        self.enabled = self.category.isKnown ? decodedEnabled : false
+        self.accountSelection = try container.decodeIfPresent(
+            AccountSelection.self,
+            forKey: .accountSelection
+        ) ?? .all
+        self.ownerFilters = try container.decodeIfPresent([String].self, forKey: .ownerFilters) ?? []
+        self.repositoryFilters = try container.decodeIfPresent(
+            [String].self,
+            forKey: .repositoryFilters
+        ) ?? []
+        self.itemStates = try container.decodeIfPresent([AttentionItemState].self, forKey: .itemStates) ?? []
+        self.priority = try container.decodeIfPresent(AttentionPriority.self, forKey: .priority) ?? .normal
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.id, forKey: .id)
+        try container.encode(self.enabled, forKey: .enabled)
+        try container.encode(self.category, forKey: .category)
+        if case .all = self.accountSelection {
+            // Default account inclusion is represented by omission.
+        } else {
+            try container.encode(self.accountSelection, forKey: .accountSelection)
+        }
+        if self.ownerFilters.isEmpty == false {
+            try container.encode(self.ownerFilters, forKey: .ownerFilters)
+        }
+        if self.repositoryFilters.isEmpty == false {
+            try container.encode(self.repositoryFilters, forKey: .repositoryFilters)
+        }
+        if self.itemStates.isEmpty == false {
+            try container.encode(self.itemStates, forKey: .itemStates)
+        }
+        if self.priority != .normal {
+            try container.encode(self.priority, forKey: .priority)
+        }
+    }
+}
+
+public enum AttentionRulePresets {
+    public static func conservativeDefault(
+        pinnedRepositories: [String],
+        accountSelection: AccountSelection = .all
+    ) -> [AttentionRule] {
+        let repositories = self.normalizeRepositories(pinnedRepositories)
+        guard repositories.isEmpty == false else { return [] }
+
+        return [
+            AttentionRule(
+                id: AttentionRuleID(rawValue: "default.review-requests"),
+                category: .reviewRequests,
+                accountSelection: accountSelection,
+                repositoryFilters: repositories,
+                priority: .high
+            ),
+            AttentionRule(
+                id: AttentionRuleID(rawValue: "default.assigned-issues"),
+                category: .assignedIssues,
+                accountSelection: accountSelection,
+                repositoryFilters: repositories,
+                itemStates: [.open],
+                priority: .high
+            ),
+            AttentionRule(
+                id: AttentionRuleID(rawValue: "default.assigned-pull-requests"),
+                category: .assignedPullRequests,
+                accountSelection: accountSelection,
+                repositoryFilters: repositories,
+                itemStates: [.open],
+                priority: .high
+            ),
+            AttentionRule(
+                id: AttentionRuleID(rawValue: "default.failed-workflows"),
+                category: .failedWorkflows,
+                accountSelection: accountSelection,
+                repositoryFilters: repositories,
+                itemStates: [.failing],
+                priority: .critical
+            )
+        ]
+    }
+
+    private static func normalizeRepositories(_ repositories: [String]) -> [String] {
+        var seen: Set<String> = []
+        return repositories
+            .compactMap { repository -> String? in
+                let trimmed = repository.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard trimmed.isEmpty == false else { return nil }
+
+                let normalized = trimmed.lowercased()
+                guard seen.insert(normalized).inserted else { return nil }
+
+                return normalized
+            }
+            .sorted()
+    }
+}

--- a/Sources/RepoBarCore/Settings/UserSettings.swift
+++ b/Sources/RepoBarCore/Settings/UserSettings.swift
@@ -29,6 +29,8 @@ public struct UserSettings: Equatable, Codable {
     public var activeAccountID: String?
     public var accountSelection: AccountSelection = .all
     public var accountRepoLists: AccountScopedRepositoryLists = .init()
+    public var consolidateAccounts = false
+    public var attentionRules: [AttentionRule] = []
 
     public init() {}
 
@@ -60,6 +62,8 @@ public struct UserSettings: Equatable, Codable {
         case activeAccountID
         case accountSelection
         case accountRepoLists
+        case consolidateAccounts
+        case attentionRules
     }
 
     public init(from decoder: Decoder) throws {
@@ -112,6 +116,14 @@ public struct UserSettings: Equatable, Codable {
             AccountScopedRepositoryLists.self,
             forKey: .accountRepoLists
         ) ?? AccountScopedRepositoryLists()
+        self.consolidateAccounts = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .consolidateAccounts
+        ) ?? false
+        self.attentionRules = try container.decodeIfPresent(
+            [AttentionRule].self,
+            forKey: .attentionRules
+        ) ?? []
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -152,6 +164,12 @@ public struct UserSettings: Equatable, Codable {
         }
         if self.accountRepoLists.isEmpty == false {
             try container.encode(self.accountRepoLists, forKey: .accountRepoLists)
+        }
+        if self.consolidateAccounts {
+            try container.encode(true, forKey: .consolidateAccounts)
+        }
+        if self.attentionRules.isEmpty == false {
+            try container.encode(self.attentionRules, forKey: .attentionRules)
         }
     }
 
@@ -314,6 +332,7 @@ public struct AISummarySettings: Equatable, Codable, Sendable {
 
     public var enabled = false
     public var model = defaultModel
+    public var allowNonActiveAccountContent = false
 
     public init() {}
 
@@ -327,6 +346,7 @@ public struct AISummarySettings: Equatable, Codable, Sendable {
     enum CodingKeys: String, CodingKey {
         case enabled
         case model
+        case allowNonActiveAccountContent
     }
 
     public init(from decoder: Decoder) throws {
@@ -334,6 +354,19 @@ public struct AISummarySettings: Equatable, Codable, Sendable {
         self.enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
         let decodedModel = try container.decodeIfPresent(String.self, forKey: .model) ?? Self.defaultModel
         self.model = Self.normalizedModel(decodedModel)
+        self.allowNonActiveAccountContent = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .allowNonActiveAccountContent
+        ) ?? false
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.enabled, forKey: .enabled)
+        try container.encode(self.model, forKey: .model)
+        if self.allowNonActiveAccountContent {
+            try container.encode(true, forKey: .allowNonActiveAccountContent)
+        }
     }
 }
 

--- a/Tests/RepoBarTests/MultiAccountContractTests.swift
+++ b/Tests/RepoBarTests/MultiAccountContractTests.swift
@@ -86,15 +86,22 @@ struct AttentionRuleContractTests {
 
         #expect(rule.category.rawValue == "futureCategory")
         #expect(rule.category.isKnown == false)
-        #expect(rule.enabled == false)
+        #expect(rule.enabled)
+        #expect(rule.isEffectivelyEnabled == false)
         #expect(rule.repositoryFilters == ["example/repo"])
+
+        let encoded = try JSONEncoder().encode(settings)
+        let encodedObject = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        let encodedRules = try #require(encodedObject["attentionRules"] as? [[String: Any]])
+        #expect(encodedRules.first?["enabled"] as? Bool == true)
 
         let roundTrip = try JSONDecoder().decode(
             UserSettings.self,
-            from: JSONEncoder().encode(settings)
+            from: encoded
         )
         #expect(roundTrip.attentionRules.first?.category.rawValue == "futureCategory")
-        #expect(roundTrip.attentionRules.first?.enabled == false)
+        #expect(roundTrip.attentionRules.first?.enabled == true)
+        #expect(roundTrip.attentionRules.first?.isEffectivelyEnabled == false)
     }
 
     @Test

--- a/Tests/RepoBarTests/MultiAccountContractTests.swift
+++ b/Tests/RepoBarTests/MultiAccountContractTests.swift
@@ -1,0 +1,231 @@
+import Foundation
+@testable import RepoBarCore
+import Testing
+
+struct MultiAccountSettingsContractTests {
+    @Test
+    func `legacy settings decode with consolidated features disabled`() throws {
+        let legacyJSON = """
+        {
+            "githubHost": "https://github.com",
+            "aiSummaries": {
+                "enabled": true,
+                "model": "gpt-5.5"
+            }
+        }
+        """
+
+        let settings = try JSONDecoder().decode(
+            UserSettings.self,
+            from: #require(legacyJSON.data(using: .utf8))
+        )
+
+        #expect(settings.consolidateAccounts == false)
+        #expect(settings.aiSummaries.allowNonActiveAccountContent == false)
+        #expect(settings.attentionRules.isEmpty)
+    }
+
+    @Test
+    func `new settings round trip without changing account selection`() throws {
+        var settings = UserSettings()
+        settings.consolidateAccounts = true
+        settings.accountSelection = .only(["github.com#alice"])
+        settings.aiSummaries.allowNonActiveAccountContent = true
+        settings.attentionRules = [
+            AttentionRule(
+                id: AttentionRuleID(rawValue: "custom.review"),
+                category: .reviewRequests,
+                accountSelection: .only(["github.com#alice"]),
+                ownerFilters: ["example"],
+                repositoryFilters: ["example/repo"],
+                itemStates: [.open],
+                priority: .high
+            )
+        ]
+
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(UserSettings.self, from: data)
+
+        #expect(decoded == settings)
+        #expect(decoded.accountSelection == .only(["github.com#alice"]))
+    }
+
+    @Test
+    func `default settings omit new contracts`() throws {
+        let data = try JSONEncoder().encode(UserSettings())
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let aiSummaries = try #require(object["aiSummaries"] as? [String: Any])
+
+        #expect(object["consolidateAccounts"] == nil)
+        #expect(object["attentionRules"] == nil)
+        #expect(aiSummaries["allowNonActiveAccountContent"] == nil)
+    }
+}
+
+struct AttentionRuleContractTests {
+    @Test
+    func `unknown category is preserved and safely disabled`() throws {
+        let json = """
+        {
+            "attentionRules": [
+                {
+                    "id": "future.rule",
+                    "enabled": true,
+                    "category": "futureCategory",
+                    "repositoryFilters": ["example/repo"]
+                }
+            ]
+        }
+        """
+
+        let settings = try JSONDecoder().decode(
+            UserSettings.self,
+            from: #require(json.data(using: .utf8))
+        )
+        let rule = try #require(settings.attentionRules.first)
+
+        #expect(rule.category.rawValue == "futureCategory")
+        #expect(rule.category.isKnown == false)
+        #expect(rule.enabled == false)
+        #expect(rule.repositoryFilters == ["example/repo"])
+
+        let roundTrip = try JSONDecoder().decode(
+            UserSettings.self,
+            from: JSONEncoder().encode(settings)
+        )
+        #expect(roundTrip.attentionRules.first?.category.rawValue == "futureCategory")
+        #expect(roundTrip.attentionRules.first?.enabled == false)
+    }
+
+    @Test
+    func `missing optional rule fields use compatibility defaults`() throws {
+        let json = """
+        {
+            "id": "minimal.rule",
+            "category": "mentions"
+        }
+        """
+
+        let rule = try JSONDecoder().decode(
+            AttentionRule.self,
+            from: #require(json.data(using: .utf8))
+        )
+
+        #expect(rule.enabled)
+        #expect(rule.accountSelection == .all)
+        #expect(rule.ownerFilters.isEmpty)
+        #expect(rule.repositoryFilters.isEmpty)
+        #expect(rule.itemStates.isEmpty)
+        #expect(rule.priority == .normal)
+
+        let encoded = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(rule)) as? [String: Any]
+        )
+        #expect(encoded["accountSelection"] == nil)
+        #expect(encoded["ownerFilters"] == nil)
+        #expect(encoded["repositoryFilters"] == nil)
+        #expect(encoded["itemStates"] == nil)
+        #expect(encoded["priority"] == nil)
+    }
+
+    @Test
+    func `first version categories are complete and stable`() {
+        #expect(AttentionRuleCategory.knownCategories == [
+            .reviewRequests,
+            .assignedIssues,
+            .assignedPullRequests,
+            .mentions,
+            .subscribedUpdates,
+            .authoredItems,
+            .failedWorkflows,
+            .runnerHealth,
+            .queuePressure,
+            .criticalAPIHealth
+        ])
+    }
+
+    @Test
+    func `conservative preset is deterministic and pinned only`() {
+        let selection = AccountSelection.only(["github.com#alice"])
+        let first = AttentionRulePresets.conservativeDefault(
+            pinnedRepositories: [" Example/Zeta ", "example/alpha", "EXAMPLE/ZETA", ""],
+            accountSelection: selection
+        )
+        let second = AttentionRulePresets.conservativeDefault(
+            pinnedRepositories: ["example/alpha", "example/zeta"],
+            accountSelection: selection
+        )
+
+        #expect(first == second)
+        #expect(first.map(\.id.rawValue) == [
+            "default.review-requests",
+            "default.assigned-issues",
+            "default.assigned-pull-requests",
+            "default.failed-workflows"
+        ])
+        #expect(first.map(\.category) == [
+            .reviewRequests,
+            .assignedIssues,
+            .assignedPullRequests,
+            .failedWorkflows
+        ])
+        for rule in first {
+            #expect(rule.enabled)
+        }
+        #expect(first.allSatisfy { $0.accountSelection == selection })
+        #expect(first.allSatisfy { $0.repositoryFilters == ["example/alpha", "example/zeta"] })
+        #expect(AttentionRulePresets.conservativeDefault(pinnedRepositories: []).isEmpty)
+    }
+}
+
+struct AccountScopedIdentityTests {
+    @Test
+    func `same repository is distinct across account sources`() {
+        let personal = AccountScopedRepositoryIdentity(
+            accountID: "github.com#alice",
+            repositoryID: "R_123"
+        )
+        let work = AccountScopedRepositoryIdentity(
+            accountID: "github.com#alice-work",
+            repositoryID: "R_123"
+        )
+
+        #expect(personal != work)
+        #expect(Set([personal, work]).count == 2)
+    }
+
+    @Test
+    func `same URL is distinct across account sources and codable`() throws {
+        let url = try #require(URL(string: "https://github.com/example/repo/pull/1"))
+        let personal = AccountScopedURLIdentity(accountID: "github.com#alice", url: url)
+        let work = AccountScopedURLIdentity(accountID: "github.com#alice-work", url: url)
+
+        #expect(personal != work)
+        #expect(Set([personal, work]).count == 2)
+
+        let decoded = try JSONDecoder().decode(
+            AccountScopedURLIdentity.self,
+            from: JSONEncoder().encode(personal)
+        )
+        #expect(decoded == personal)
+    }
+
+    @Test
+    func `event and cache identities include account source`() {
+        let personalEvent = AccountScopedEventIdentity(
+            accountID: "github.com#alice",
+            namespace: "pull-request",
+            eventID: "42"
+        )
+        let workEvent = AccountScopedEventIdentity(
+            accountID: "github.com#alice-work",
+            namespace: "pull-request",
+            eventID: "42"
+        )
+        let personalCache = AccountScopedCacheKey(accountID: "github.com#alice", key: "repos")
+        let workCache = AccountScopedCacheKey(accountID: "github.com#alice-work", key: "repos")
+
+        #expect(personalEvent != workEvent)
+        #expect(personalCache != workCache)
+    }
+}

--- a/docs/multi-account-auth-plan.md
+++ b/docs/multi-account-auth-plan.md
@@ -15,6 +15,36 @@ RepoBar's current authentication code is intentionally small and clean, but it i
 
 The 0.6.6 cycle landed the bulk of the plan end-to-end behind a backward-compatible facade. The legacy single-account `TokenStore` keys (`default`, `client`, `pat`) and the `githubHost` / `enterpriseHost` / `loopbackPort` / `authMethod` `UserSettings` fields are still authoritative for installs that have not been re-auth'd; the new account-scoped keys, settings, caches, and clients are populated on first login (or via the legacy migration on bootstrap) without removing those legacy entries.
 
+### Issue #101 consolidated experience
+
+The next programme adds an optional consolidated experience on top of the existing multi-account foundations. Its accepted product contract is:
+
+1. Consolidation is opt-in through one global **Consolidate accounts** toggle that defaults off. Existing `AccountSelection` remains the source of per-account inclusion; no second account-selection list is introduced.
+2. The supported surfaces are the macOS app and bundled CLI. RepoBarCore contracts remain reusable by iOS, but iOS UI is out of scope.
+3. Every existing GitHub-backed read and monitoring surface will become account-aware. New remote GitHub mutations, including assign, label, comment, review, rerun, merge, and administration actions, are out of scope.
+4. Repositories and items visible through multiple accounts remain separate internally and visually, grouped and labelled by account. Repository display limits apply independently to each account.
+5. Existing per-account SQLite caches remain separate, and consolidated state is an in-memory union. The programme will not use SQLite `ATTACH` or add a shared `attention.sqlite` unless later profiling justifies it.
+6. When one account fails, its last-good cached rows remain visible and are marked stale or errored while healthy accounts continue. The menu-bar indicator reports the worst included-account health, while details remain per account.
+7. Notifications remain separate and account-labelled when multiple accounts observe the same pull request or release.
+8. The CLI adds explicit `--all-accounts`, retains `--account` and active-account defaults, and does not implicitly inherit the GUI consolidation toggle.
+9. Issue Navigator content from a non-active account requires a second explicit opt-in before OpenAI summaries are allowed.
+10. **Needs Attention** uses typed configurable rules for category, account, owner/repository filters, state, and priority. It does not expose arbitrary expressions or a nested AND/OR DSL. Its conservative default preset covers review requests, assignments, and failed workflows on pinned repositories.
+
+The implementation is a sequential bottom-to-top stack:
+
+1. `multi-account-contracts` — settings, account-scoped identities, attention-rule contracts, and Codable compatibility.
+2. `multi-account-refresh` — repository snapshot loader, bounded fan-out, last-good partial failures, and active-account compatibility projection.
+3. `multi-account-repo-state` — account-scoped pinned/hidden migration, cache and submenu identities, local host matching, and explicit client resolution.
+4. `multi-account-cli` — shared account scope, `--all-accounts`, stable output envelopes, and account settings/cache operations.
+5. `multi-account-dashboard` — Settings opt-in controls, grouped dashboard/menu, account headers, per-account limits, and account-aware submenus.
+6. `multi-account-attention` — typed rule evaluation, shared collectors, the default preset, normalized `AttentionItem`, and `repobar triage`.
+7. `multi-account-navigator` — Issue Navigator, Needs Attention mode, reference monitor fan-out, scopes/previews, and the AI secondary opt-in.
+8. `multi-account-notifications` — account-namespaced pull request/release polling, baselines, event IDs, labels, and click context.
+9. `multi-account-operations-status` — Actions & Runners, monitored owners, rate limits, contribution/global activity, and worst-health state.
+10. `multi-account-integration-proof` — integration fixtures, accessibility and UI polish, redacted personal plus EMU proof, and final README, docs, CHANGELOG, and issue updates.
+
+Only Layer 1, `multi-account-contracts`, is implemented in this change. Layers 2 through 10 remain deferred, and the new contracts do not change runtime, UI, notification, refresh, or CLI behavior.
+
 Landed:
 
 - Phase 0/1 — `Account`, `AccountSelection`, and `AccountScopedRepositoryLists` live in `RepoBarCore`; `UserSettings` decodes/encodes the new fields with safe defaults and omits them when empty so legacy reads stay clean.


### PR DESCRIPTION
## Summary

- add backward-compatible `UserSettings` opt-ins for account consolidation and non-active-account AI summaries, both defaulting off
- add reusable account-scoped repository, URL, event, cache, and request-source identities
- add typed attention-rule contracts with forward-compatible unknown categories and a deterministic pinned-repository preset
- document the accepted Issue #101 product contract and ten-layer implementation sequence

## Scope

This is Layer 1 only. It adds RepoBarCore contracts and focused tests without changing macOS app, CLI, refresh, menu/UI, notification, cache, or runtime behavior. Layers 2-10 remain deferred.

Refs #101

## Validation

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all pnpm run test --filter 'MultiAccountSettingsContractTests|AttentionRuleContractTests|AccountScopedIdentityTests'`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer GIT_CONFIG_COUNT=2 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all GIT_CONFIG_KEY_1=init.defaultBranch GIT_CONFIG_VALUE_1=main pnpm check`