### PR TITLE
Add multi-account repository refresh fan-out

### DIFF
--- a/Sources/RepoBar/App/AccountRepositorySnapshotLoader.swift
+++ b/Sources/RepoBar/App/AccountRepositorySnapshotLoader.swift
@@ -1,0 +1,172 @@
+import Foundation
+import RepoBarCore
+
+struct AccountRepositoryPreferences {
+    let pinned: [String]
+    let hidden: Set<String>
+    let includeForks: Bool
+    let includeArchived: Bool
+    let ownerFilter: [String]
+}
+
+struct AccountRepositorySnapshotRequest {
+    let account: Account
+    let client: GitHubClient
+    let preferences: AccountRepositoryPreferences
+    let now: Date
+}
+
+struct AccountRepositorySnapshot {
+    let account: Account
+    let accessibleRepositories: [Repository]
+    let repositories: [Repository]
+    let capturedAt: Date
+    let diagnostics: DiagnosticsSummary
+    let cacheSummary: RepoBarCacheSummary?
+}
+
+protocol AccountRepositorySnapshotLoading: Sendable {
+    func cachedSnapshot(for request: AccountRepositorySnapshotRequest) async throws -> AccountRepositorySnapshot?
+    func snapshot(for request: AccountRepositorySnapshotRequest) async throws -> AccountRepositorySnapshot
+}
+
+struct AccountRepositorySnapshotLoader: AccountRepositorySnapshotLoading {
+    func cachedSnapshot(for request: AccountRepositorySnapshotRequest) async throws -> AccountRepositorySnapshot? {
+        let repos = try await request.client.cachedRepositoryList(limit: nil)
+        guard repos.isEmpty == false else { return nil }
+
+        return await self.makeSnapshot(repositories: repos, request: request)
+    }
+
+    func snapshot(for request: AccountRepositorySnapshotRequest) async throws -> AccountRepositorySnapshot {
+        let repos = try await request.client.repositoryList(limit: nil)
+        let withPinned = await self.mergePinnedRepositories(
+            into: repos,
+            pinned: request.preferences.pinned,
+            client: request.client
+        )
+        return await self.makeSnapshot(repositories: withPinned, request: request)
+    }
+
+    private func makeSnapshot(
+        repositories: [Repository],
+        request: AccountRepositorySnapshotRequest
+    ) async -> AccountRepositorySnapshot {
+        let accessible = RepositoryUniquing.byFullName(repositories)
+        let visible = AppState.selectVisible(
+            all: accessible,
+            options: AppState.VisibleSelectionOptions(
+                pinned: request.preferences.pinned,
+                hidden: request.preferences.hidden,
+                includeForks: request.preferences.includeForks,
+                includeArchived: request.preferences.includeArchived,
+                limit: Int.max,
+                ownerFilter: request.preferences.ownerFilter
+            )
+        )
+        let ordered = AppState.applyPinnedOrder(to: visible, pinned: request.preferences.pinned)
+        let diagnostics = await request.client.diagnostics()
+        let cacheSummary = try? RepoBarPersistentCache.summary(accountID: request.account.id, limit: 100)
+        return AccountRepositorySnapshot(
+            account: request.account,
+            accessibleRepositories: accessible,
+            repositories: ordered,
+            capturedAt: request.now,
+            diagnostics: diagnostics,
+            cacheSummary: cacheSummary
+        )
+    }
+
+    private func mergePinnedRepositories(
+        into repos: [Repository],
+        pinned: [String],
+        client: GitHubClient
+    ) async -> [Repository] {
+        guard pinned.isEmpty == false else { return repos }
+
+        let existing = Set(repos.map { $0.fullName.lowercased() })
+        let targets = Self.pinnedRepoTargets(from: pinned, excluding: existing)
+        guard targets.isEmpty == false else { return repos }
+
+        let fetched = await withTaskGroup(of: Repository?.self) { group in
+            for target in targets {
+                group.addTask {
+                    do {
+                        return try await client.fullRepository(owner: target.owner, name: target.name)
+                    } catch {
+                        return Self.placeholderRepository(
+                            owner: target.owner,
+                            name: target.name,
+                            error: error.userFacingMessage,
+                            rateLimitedUntil: (error as? GitHubAPIError)?.rateLimitedUntil
+                        )
+                    }
+                }
+            }
+            var output: [Repository] = []
+            for await repo in group {
+                if let repo {
+                    output.append(repo)
+                }
+            }
+            return output
+        }
+        return repos + fetched
+    }
+
+    private static func pinnedRepoTargets(
+        from pinned: [String],
+        excluding existing: Set<String>
+    ) -> [PinnedRepoTarget] {
+        var seen: Set<String> = []
+        var targets: [PinnedRepoTarget] = []
+        for raw in pinned {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            let parts = trimmed.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.count == 2 else { continue }
+
+            let owner = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
+            let name = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
+            guard owner.isEmpty == false, name.isEmpty == false else { continue }
+
+            let normalized = "\(owner)/\(name)".lowercased()
+            guard existing.contains(normalized) == false, seen.insert(normalized).inserted else { continue }
+
+            targets.append(PinnedRepoTarget(owner: owner, name: name))
+        }
+        return targets
+    }
+
+    private static func placeholderRepository(
+        owner: String,
+        name: String,
+        error: String?,
+        rateLimitedUntil: Date?
+    ) -> Repository {
+        Repository(
+            id: "\(owner)/\(name)",
+            name: name,
+            owner: owner,
+            sortOrder: nil,
+            error: error,
+            rateLimitedUntil: rateLimitedUntil,
+            ciStatus: .unknown,
+            ciRunCount: nil,
+            openIssues: 0,
+            openPulls: 0,
+            stars: 0,
+            forks: 0,
+            pushedAt: nil,
+            latestRelease: nil,
+            latestActivity: nil,
+            activityEvents: [],
+            traffic: nil,
+            heatmap: []
+        )
+    }
+
+    private struct PinnedRepoTarget {
+        let owner: String
+        let name: String
+    }
+}

--- a/Sources/RepoBar/App/AppState+AccountRepositoryRefresh.swift
+++ b/Sources/RepoBar/App/AppState+AccountRepositoryRefresh.swift
@@ -1,0 +1,335 @@
+import Foundation
+import RepoBarCore
+
+struct AccountRepositoryRefreshFailure: Error, LocalizedError {
+    let accountID: String
+    let message: String
+    let authenticationFailure: Bool
+    let rateLimitedUntil: Date?
+    let diagnostics: DiagnosticsSummary
+    let cacheSummary: RepoBarCacheSummary?
+
+    var errorDescription: String? {
+        self.message
+    }
+}
+
+struct AccountRepositoryRefreshOutcome {
+    let activeSession: AccountSession?
+    let activeFailure: AccountRepositoryRefreshFailure?
+    let generation: UUID
+    let published: Bool
+}
+
+extension AppState {
+    func selectedAccountIDsForRepositoryRefresh() -> [String] {
+        if self.session.settings.consolidateAccounts {
+            return self.session.settings.visibleAccountIDs
+        }
+        return self.session.settings.resolvedActiveAccount().map { [$0.id] } ?? []
+    }
+
+    func refreshAccountRepositorySnapshots(now: Date = Date()) async -> AccountRepositoryRefreshOutcome {
+        let generation = UUID()
+        self.accountRepositoryRefreshGeneration = generation
+        let settings = self.session.settings
+        let activeAccountID = settings.resolvedActiveAccount()?.id
+        let accountIDs = self.selectedAccountIDsForRepositoryRefresh()
+        let pairs = self.accountManager.accountClientSnapshots(accountIDs: accountIDs)
+
+        self.resetPublishedAccountSessions(to: pairs, activeAccountID: activeAccountID)
+        guard pairs.isEmpty == false else {
+            return AccountRepositoryRefreshOutcome(
+                activeSession: nil,
+                activeFailure: nil,
+                generation: generation,
+                published: true
+            )
+        }
+
+        let cachedResults = await self.loadAccountRepositorySnapshots(
+            pairs: pairs,
+            settings: settings,
+            now: now,
+            cached: true
+        )
+        guard self.canPublishAccountRepositoryRefresh(generation) else {
+            return AccountRepositoryRefreshOutcome(
+                activeSession: nil,
+                activeFailure: nil,
+                generation: generation,
+                published: false
+            )
+        }
+
+        self.publishCachedAccountRepositorySnapshots(
+            cachedResults,
+            pairs: pairs,
+            activeAccountID: activeAccountID,
+            now: now
+        )
+
+        let liveResults = await self.loadAccountRepositorySnapshots(
+            pairs: pairs,
+            settings: settings,
+            now: now,
+            cached: false
+        )
+        guard self.canPublishAccountRepositoryRefresh(generation) else {
+            return AccountRepositoryRefreshOutcome(
+                activeSession: nil,
+                activeFailure: nil,
+                generation: generation,
+                published: false
+            )
+        }
+
+        let activeFailure = self.publishLiveAccountRepositorySnapshots(
+            liveResults,
+            pairs: pairs,
+            activeAccountID: activeAccountID,
+            now: now
+        )
+        return AccountRepositoryRefreshOutcome(
+            activeSession: self.session.accountSessions.first(where: { $0.id == activeAccountID }),
+            activeFailure: activeFailure,
+            generation: generation,
+            published: true
+        )
+    }
+
+    func rebuildAggregatedRepositories() {
+        self.session.aggregatedRepositories = self.session.accountSessions.flatMap { accountSession in
+            accountSession.repositories.map { TaggedRepo(repo: $0, accountID: accountSession.id) }
+        }
+    }
+
+    private func resetPublishedAccountSessions(
+        to pairs: [AccountManager.AccountClientSnapshot],
+        activeAccountID: String?
+    ) {
+        let previous = Dictionary(uniqueKeysWithValues: self.session.accountSessions.map { ($0.id, $0) })
+        self.session.accountSessions = pairs.map { pair in
+            var accountSession = previous[pair.account.id] ?? AccountSession(account: pair.account)
+            accountSession.account = pair.account
+            return accountSession
+        }
+        self.rebuildAggregatedRepositories()
+        self.publishActiveAccountCompatibility(activeAccountID: activeAccountID)
+    }
+
+    private func loadAccountRepositorySnapshots(
+        pairs: [AccountManager.AccountClientSnapshot],
+        settings: UserSettings,
+        now: Date,
+        cached: Bool
+    ) async -> [String: AccountRepositoryLoadResult] {
+        var output: [String: AccountRepositoryLoadResult] = [:]
+        let limit = max(1, self.accountRepositoryRefreshConcurrencyLimit)
+        var start = 0
+        while start < pairs.count {
+            if Task.isCancelled {
+                return output
+            }
+            let end = min(start + limit, pairs.count)
+            let batch = Array(pairs[start ..< end])
+            let batchResults = await withTaskGroup(of: (String, AccountRepositoryLoadResult).self) { group in
+                for pair in batch {
+                    let request = self.snapshotRequest(pair: pair, settings: settings, now: now)
+                    let loader = self.accountRepositorySnapshotLoader
+                    group.addTask {
+                        do {
+                            if cached {
+                                if let snapshot = try await loader.cachedSnapshot(for: request) {
+                                    return (pair.account.id, .snapshot(snapshot))
+                                }
+                                return (pair.account.id, .emptyCache)
+                            }
+                            return try await (pair.account.id, .snapshot(loader.snapshot(for: request)))
+                        } catch {
+                            let diagnostics = await pair.client.diagnostics()
+                            let cacheSummary = try? RepoBarPersistentCache.summary(
+                                accountID: pair.account.id,
+                                limit: 100
+                            )
+                            return (
+                                pair.account.id,
+                                .failure(AccountRepositoryRefreshFailure(
+                                    accountID: pair.account.id,
+                                    message: error.userFacingMessage,
+                                    authenticationFailure: error.isAuthenticationFailure,
+                                    rateLimitedUntil: Self.rateLimitDate(from: error),
+                                    diagnostics: diagnostics,
+                                    cacheSummary: cacheSummary
+                                ))
+                            )
+                        }
+                    }
+                }
+                var results: [(String, AccountRepositoryLoadResult)] = []
+                for await result in group {
+                    results.append(result)
+                }
+                return results
+            }
+            for (accountID, result) in batchResults {
+                output[accountID] = result
+            }
+            start = end
+        }
+        return output
+    }
+
+    private func snapshotRequest(
+        pair: AccountManager.AccountClientSnapshot,
+        settings: UserSettings,
+        now: Date
+    ) -> AccountRepositorySnapshotRequest {
+        let accountID = pair.account.id
+        return AccountRepositorySnapshotRequest(
+            account: pair.account,
+            client: pair.client,
+            preferences: AccountRepositoryPreferences(
+                pinned: settings.accountRepoLists.pinned(
+                    for: accountID,
+                    legacy: settings.repoList.pinnedRepositories
+                ),
+                hidden: Set(settings.accountRepoLists.hidden(
+                    for: accountID,
+                    legacy: settings.repoList.hiddenRepositories
+                )),
+                includeForks: settings.repoList.showForks,
+                includeArchived: settings.repoList.showArchived,
+                ownerFilter: settings.repoList.ownerFilter
+            ),
+            now: now
+        )
+    }
+
+    private func publishCachedAccountRepositorySnapshots(
+        _ results: [String: AccountRepositoryLoadResult],
+        pairs: [AccountManager.AccountClientSnapshot],
+        activeAccountID: String?,
+        now: Date
+    ) {
+        for pair in pairs {
+            guard case let .snapshot(snapshot)? = results[pair.account.id],
+                  let index = self.session.accountSessions.firstIndex(where: { $0.id == pair.account.id })
+            else { continue }
+
+            let previous = self.session.accountSessions[index]
+            guard previous.lastSuccessfulRefreshAt == nil else { continue }
+
+            self.session.accountSessions[index] = AccountSession(
+                account: pair.account,
+                state: .loggedIn(UserIdentity(username: pair.account.username, host: pair.account.host)),
+                repositories: snapshot.repositories,
+                accessibleRepositories: snapshot.accessibleRepositories,
+                rateLimitReset: snapshot.diagnostics.rateLimitReset,
+                diagnostics: snapshot.diagnostics,
+                cacheSummary: snapshot.cacheSummary,
+                lastAttemptAt: now,
+                lastSuccessfulRefreshAt: previous.lastSuccessfulRefreshAt,
+                isStale: true,
+                lastError: nil
+            )
+        }
+        self.rebuildAggregatedRepositories()
+        self.publishActiveAccountCompatibility(activeAccountID: activeAccountID)
+    }
+
+    private func publishLiveAccountRepositorySnapshots(
+        _ results: [String: AccountRepositoryLoadResult],
+        pairs: [AccountManager.AccountClientSnapshot],
+        activeAccountID: String?,
+        now: Date
+    ) -> AccountRepositoryRefreshFailure? {
+        var activeFailure: AccountRepositoryRefreshFailure?
+        for pair in pairs {
+            guard let index = self.session.accountSessions.firstIndex(where: { $0.id == pair.account.id }),
+                  let result = results[pair.account.id]
+            else { continue }
+
+            switch result {
+            case let .snapshot(snapshot):
+                self.session.accountSessions[index] = AccountSession(
+                    account: pair.account,
+                    state: .loggedIn(UserIdentity(username: pair.account.username, host: pair.account.host)),
+                    repositories: snapshot.repositories,
+                    accessibleRepositories: snapshot.accessibleRepositories,
+                    rateLimitReset: snapshot.diagnostics.rateLimitReset,
+                    diagnostics: snapshot.diagnostics,
+                    cacheSummary: snapshot.cacheSummary,
+                    lastAttemptAt: now,
+                    lastSuccessfulRefreshAt: snapshot.capturedAt,
+                    isStale: false,
+                    lastError: nil
+                )
+            case let .failure(failure):
+                var accountSession = self.session.accountSessions[index]
+                accountSession.account = pair.account
+                accountSession.state = failure.authenticationFailure
+                    ? .loggedOut
+                    : .loggedIn(UserIdentity(username: pair.account.username, host: pair.account.host))
+                accountSession.rateLimitReset = failure.rateLimitedUntil ?? failure.diagnostics.rateLimitReset
+                accountSession.diagnostics = failure.diagnostics
+                accountSession.cacheSummary = failure.cacheSummary
+                accountSession.lastAttemptAt = now
+                accountSession.isStale = true
+                accountSession.lastError = failure.message
+                self.session.accountSessions[index] = accountSession
+                if pair.account.id == activeAccountID {
+                    activeFailure = failure
+                }
+            case .emptyCache:
+                break
+            }
+        }
+        self.rebuildAggregatedRepositories()
+        self.publishActiveAccountCompatibility(activeAccountID: activeAccountID)
+        return activeFailure
+    }
+
+    private func publishActiveAccountCompatibility(activeAccountID: String?) {
+        guard let activeAccountID,
+              let active = self.session.accountSessions.first(where: { $0.id == activeAccountID })
+        else {
+            self.session.accessibleRepositories = []
+            self.session.repositories = []
+            self.session.menuSnapshot = nil
+            self.session.menuDisplayIndex = [:]
+            self.session.hasLoadedRepositories = false
+            return
+        }
+
+        self.session.account = active.state
+        self.session.accessibleRepositories = active.accessibleRepositories
+        self.session.repositories = active.repositories
+        let capturedAt = active.lastSuccessfulRefreshAt ?? active.lastAttemptAt ?? Date()
+        self.session.menuSnapshot = MenuSnapshot(
+            repositories: active.repositories,
+            capturedAt: capturedAt
+        )
+        self.session.menuDisplayIndex = self.menuDisplayIndex(for: active.repositories, now: capturedAt)
+        self.session.hasLoadedRepositories = true
+        self.session.rateLimitReset = active.rateLimitReset
+        self.session.lastError = active.lastError
+        NotificationCenter.default.post(name: .menuRepositoriesDidChange, object: nil)
+    }
+
+    func canPublishAccountRepositoryRefresh(_ generation: UUID) -> Bool {
+        Task.isCancelled == false && self.accountRepositoryRefreshGeneration == generation
+    }
+
+    private nonisolated static func rateLimitDate(from error: Error) -> Date? {
+        guard let error = error as? GitHubAPIError else { return nil }
+
+        return error.rateLimitedUntil ?? error.retryAfter
+    }
+}
+
+private enum AccountRepositoryLoadResult {
+    case snapshot(AccountRepositorySnapshot)
+    case emptyCache
+    case failure(AccountRepositoryRefreshFailure)
+}

--- a/Sources/RepoBar/App/AppState+Activity.swift
+++ b/Sources/RepoBar/App/AppState+Activity.swift
@@ -2,12 +2,6 @@ import Foundation
 import RepoBarCore
 
 extension AppState {
-    func fetchActivityRepos() async throws -> [Repository] {
-        let repos = try await self.github.repositoryList(limit: nil)
-        let pinned = self.session.settings.repoList.pinnedRepositories
-        return await self.mergePinnedRepositories(into: repos, pinned: pinned)
-    }
-
     func fetchGlobalActivityEvents(
         username: String,
         scope: GlobalActivityScope,
@@ -69,107 +63,5 @@ extension AppState {
 
     private func capture<T>(_ work: @escaping () async throws -> T) async -> Result<T, Error> {
         do { return try await .success(work()) } catch { return .failure(error) }
-    }
-
-    private func mergePinnedRepositories(
-        into repos: [Repository],
-        pinned: [String]
-    ) async -> [Repository] {
-        guard !pinned.isEmpty else { return repos }
-
-        let existing = Set(repos.map { $0.fullName.lowercased() })
-        let targets = self.pinnedRepoTargets(from: pinned, excluding: existing)
-        guard !targets.isEmpty else { return repos }
-
-        let fetched = await withTaskGroup(of: Repository?.self) { group in
-            for target in targets {
-                group.addTask { [github] in
-                    do {
-                        return try await github.fullRepository(owner: target.owner, name: target.name)
-                    } catch {
-                        let rateLimitedUntil = (error as? GitHubAPIError)?.rateLimitedUntil
-                        return Self.placeholderRepository(
-                            owner: target.owner,
-                            name: target.name,
-                            error: error.userFacingMessage,
-                            rateLimitedUntil: rateLimitedUntil
-                        )
-                    }
-                }
-            }
-            var out: [Repository] = []
-            for await repo in group {
-                if let repo {
-                    out.append(repo)
-                }
-            }
-            return out
-        }
-
-        return repos + fetched
-    }
-
-    private struct PinnedRepoTarget: Hashable {
-        let owner: String
-        let name: String
-
-        var fullName: String {
-            "\(self.owner)/\(self.name)"
-        }
-    }
-
-    private func pinnedRepoTargets(
-        from pinned: [String],
-        excluding existing: Set<String>
-    ) -> [PinnedRepoTarget] {
-        var seen: Set<String> = []
-        var targets: [PinnedRepoTarget] = []
-        for raw in pinned {
-            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty else { continue }
-
-            let parts = trimmed.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: false)
-            guard parts.count == 2 else { continue }
-
-            let owner = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
-            let name = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !owner.isEmpty, !name.isEmpty else { continue }
-
-            let fullName = "\(owner)/\(name)"
-            let normalized = fullName.lowercased()
-            guard !existing.contains(normalized) else { continue }
-            guard seen.insert(normalized).inserted else { continue }
-
-            targets.append(PinnedRepoTarget(owner: owner, name: name))
-        }
-        return targets
-    }
-
-    private nonisolated static func placeholderRepository(
-        owner: String,
-        name: String,
-        error: String?,
-        rateLimitedUntil: Date?
-    ) -> Repository {
-        Repository(
-            id: "\(owner)/\(name)",
-            name: name,
-            owner: owner,
-            sortOrder: nil,
-            error: error,
-            rateLimitedUntil: rateLimitedUntil,
-            ciStatus: .unknown,
-            ciRunCount: nil,
-            openIssues: 0,
-            openPulls: 0,
-            stars: 0,
-            forks: 0,
-            pushedAt: nil,
-            latestRelease: nil,
-            latestActivity: nil,
-            activityEvents: [],
-            traffic: nil,
-            heatmap: []
-        )
     }
 }

--- a/Sources/RepoBar/App/AppState+Refresh.swift
+++ b/Sources/RepoBar/App/AppState+Refresh.swift
@@ -61,20 +61,40 @@ extension AppState {
                 await self.applyLoggedOutState(localSnapshot: localSnapshot, lastError: nil)
                 return
             }
-            await self.applyCachedMenuSnapshotIfAvailable(now: now)
+            let accountRefresh = await self.refreshAccountRepositorySnapshots(now: now)
+            guard accountRefresh.published else { return }
+
+            if let failure = accountRefresh.activeFailure, self.session.settings.consolidateAccounts == false {
+                if failure.authenticationFailure {
+                    await self.handleAuthenticationFailure(failure)
+                    return
+                }
+                throw failure
+            }
+            guard let activeAccountSession = accountRefresh.activeSession else {
+                let localSnapshot = await self.snapshotForLoggedOutState(localSettings: localSettings)
+                await MainActor.run {
+                    self.session.localRepoIndex = localSnapshot.repoIndex
+                    self.session.localDiscoveredRepoCount = localSnapshot.discoveredCount
+                    self.session.localProjectsAccessDenied = localSnapshot.accessDenied
+                    self.session.localProjectsScanInProgress = false
+                }
+                return
+            }
+
             // If we have tokens but no user in session, fetch identity once per launch.
             if case .loggedOut = self.session.account {
                 if let user = try? await self.github.currentUser() {
                     await MainActor.run { self.session.account = .loggedIn(user) }
                 }
             }
-            await self.processGitHubPullRequestNotifications()
-            await self.processGitHubReleaseNotifications()
-            let repos = try await self.fetchActivityRepos()
+            if accountRefresh.activeFailure == nil {
+                await self.processGitHubPullRequestNotifications()
+                await self.processGitHubReleaseNotifications()
+            }
+            let repos = activeAccountSession.accessibleRepositories
             try Task.checkCancellation()
-            await self.updateAccessibleRepositories(repos)
-            let visible = self.applyVisibilityFilters(to: repos)
-            let ordered = self.applyPinnedOrder(to: visible)
+            let ordered = activeAccountSession.repositories
             // The lightweight repository list uses GitHub's open_issues_count, which includes PRs.
             // Only publish the menu snapshot after hydrating real issue/PR counts.
             let matchNames = self.localMatchRepoNamesForLocalProjects(repos: ordered, includePinned: true)
@@ -95,9 +115,21 @@ extension AppState {
             let targets = self.selectMenuTargets(from: ordered)
             let hydrated = await self.hydrateMenuTargets(targets, fetchHeatmap: true)
             try Task.checkCancellation()
-            await self.updateAccessibleRepositories(self.mergeHydrated(hydrated, into: repos))
+            let hydratedAccessible = self.mergeHydrated(hydrated, into: repos)
             let merged = self.mergeHydrated(hydrated, into: ordered)
-            let final = self.applyPinnedOrder(to: merged)
+            let activePinned = self.session.settings.accountRepoLists.pinned(
+                for: activeAccountSession.id,
+                legacy: self.session.settings.repoList.pinnedRepositories
+            )
+            let final = Self.applyPinnedOrder(to: merged, pinned: activePinned)
+            guard self.publishHydratedActiveRepositorySnapshot(
+                accessibleRepositories: hydratedAccessible,
+                repositories: final,
+                accountID: activeAccountSession.id,
+                generation: accountRefresh.generation,
+                now: now
+            ) else { return }
+
             let localSnapshot = await localSnapshotTask.value
             let activityUsername: String? = {
                 guard case let .loggedIn(user) = self.session.account,
@@ -116,8 +148,11 @@ extension AppState {
                     repos: final
                 )
             }
-            await self.updateSession(with: final, now: now)
             let globalActivity = await globalActivityTask.value
+            try self.checkAccountRepositoryRefreshIsCurrent(
+                generation: accountRefresh.generation,
+                accountID: activeAccountSession.id
+            )
             await MainActor.run {
                 self.session.localRepoIndex = localSnapshot.repoIndex
                 self.session.localDiscoveredRepoCount = localSnapshot.discoveredCount
@@ -130,15 +165,34 @@ extension AppState {
                 NotificationCenter.default.post(name: .menuRepositoriesDidChange, object: nil)
             }
             await self.updateMenuDisplayIndex(now: now)
+            try self.checkAccountRepositoryRefreshIsCurrent(
+                generation: accountRefresh.generation,
+                accountID: activeAccountSession.id
+            )
             self.prefetchMenuTargets(from: final, visibleCount: targets.count, token: self.refreshTaskToken)
             await self.refreshRateLimitDisplayState()
+            try self.checkAccountRepositoryRefreshIsCurrent(
+                generation: accountRefresh.generation,
+                accountID: activeAccountSession.id
+            )
             await self.refreshActionsLimitsState()
+            try self.checkAccountRepositoryRefreshIsCurrent(
+                generation: accountRefresh.generation,
+                accountID: activeAccountSession.id
+            )
             let message = await self.github.rateLimitMessage(now: now)
+            try self.checkAccountRepositoryRefreshIsCurrent(
+                generation: accountRefresh.generation,
+                accountID: activeAccountSession.id
+            )
             await MainActor.run {
-                self.session.lastError = message
+                self.session.lastError = message ?? accountRefresh.activeFailure?.message
                 NotificationCenter.default.post(name: .menuDiagnosticsDidChange, object: nil)
             }
         } catch {
+            if error is CancellationError {
+                return
+            }
             if error.isAuthenticationFailure {
                 await self.handleAuthenticationFailure(error)
                 return
@@ -158,6 +212,10 @@ extension AppState {
     }
 
     private func hasAuthenticationMaterial() async -> Bool {
+        if self.session.settings.accounts.isEmpty == false {
+            let selectedIDs = self.selectedAccountIDsForRepositoryRefresh()
+            return self.accountManager.accountClientSnapshots(accountIDs: selectedIDs).isEmpty == false
+        }
         if let accountID = self.session.settings.resolvedActiveAccount()?.id {
             return (try? TokenStore.shared.loadTokens(accountID: accountID)) != nil
                 || (try? TokenStore.shared.loadPAT(accountID: accountID)) != nil
@@ -286,6 +344,8 @@ extension AppState {
             self.session.hasStoredTokens = false
             self.session.accessibleRepositories = []
             self.session.repositories = []
+            self.session.accountSessions = []
+            self.session.aggregatedRepositories = []
             self.session.menuSnapshot = nil
             self.session.menuDisplayIndex = [:]
             self.session.hasLoadedRepositories = false
@@ -309,32 +369,41 @@ extension AppState {
         RepositoryHydration.merge(detailed, into: repos)
     }
 
-    private func applyCachedMenuSnapshotIfAvailable(now: Date) async {
-        guard let repos = try? await self.github.cachedRepositoryList(limit: nil), repos.isEmpty == false else { return }
+    @discardableResult
+    func publishHydratedActiveRepositorySnapshot(
+        accessibleRepositories: [Repository],
+        repositories: [Repository],
+        accountID: String,
+        generation: UUID,
+        now: Date
+    ) -> Bool {
+        guard self.canContinueAccountRepositoryRefresh(generation: generation, accountID: accountID),
+              let accountIndex = self.session.accountSessions.firstIndex(where: { $0.id == accountID })
+        else { return false }
 
-        await self.updateAccessibleRepositories(repos)
-        let visible = self.applyVisibilityFilters(to: repos)
-        let ordered = self.applyPinnedOrder(to: visible)
-        await self.updateSession(with: ordered, now: now)
+        let accessible = RepositoryUniquing.byFullName(accessibleRepositories)
+        self.session.accessibleRepositories = accessible
+        self.session.repositories = repositories
+        self.session.menuSnapshot = MenuSnapshot(repositories: repositories, capturedAt: now)
+        self.session.menuDisplayIndex = self.menuDisplayIndex(for: repositories, now: now)
+        self.session.hasLoadedRepositories = true
+        self.session.rateLimitReset = nil
+        self.session.lastError = nil
+        self.session.accountSessions[accountIndex].accessibleRepositories = accessible
+        self.session.accountSessions[accountIndex].repositories = repositories
+        self.rebuildAggregatedRepositories()
+        NotificationCenter.default.post(name: .menuRepositoriesDidChange, object: nil)
+        return true
     }
 
-    private func updateSession(with repos: [Repository], now: Date) async {
-        let index = self.menuDisplayIndex(for: repos, now: now)
-        await MainActor.run {
-            self.session.repositories = repos
-            self.session.menuSnapshot = MenuSnapshot(repositories: repos, capturedAt: now)
-            self.session.menuDisplayIndex = index
-            self.session.hasLoadedRepositories = true
-            self.session.rateLimitReset = nil
-            self.session.lastError = nil
-            NotificationCenter.default.post(name: .menuRepositoriesDidChange, object: nil)
-        }
+    private func canContinueAccountRepositoryRefresh(generation: UUID, accountID: String) -> Bool {
+        self.canPublishAccountRepositoryRefresh(generation)
+            && self.session.activeAccountID == accountID
     }
 
-    private func updateAccessibleRepositories(_ repos: [Repository]) async {
-        let uniqueRepos = RepositoryUniquing.byFullName(repos)
-        await MainActor.run {
-            self.session.accessibleRepositories = uniqueRepos
+    private func checkAccountRepositoryRefreshIsCurrent(generation: UUID, accountID: String) throws {
+        guard self.canContinueAccountRepositoryRefresh(generation: generation, accountID: accountID) else {
+            throw CancellationError()
         }
     }
 
@@ -347,7 +416,7 @@ extension AppState {
         }
     }
 
-    private func menuDisplayIndex(for repos: [Repository], now: Date) -> [String: RepositoryDisplayModel] {
+    func menuDisplayIndex(for repos: [Repository], now: Date) -> [String: RepositoryDisplayModel] {
         let localIndex = self.session.localRepoIndex
         let models = repos.map { repo in
             RepositoryDisplayModel(repo: repo, localStatus: localIndex.status(for: repo), now: now)

--- a/Sources/RepoBar/App/AppState+Visibility.swift
+++ b/Sources/RepoBar/App/AppState+Visibility.swift
@@ -55,15 +55,18 @@ extension AppState {
     }
 
     func applyPinnedOrder(to repos: [Repository]) -> [Repository] {
-        let pinned = self.session.settings.repoList.pinnedRepositories
+        Self.applyPinnedOrder(to: repos, pinned: self.session.settings.repoList.pinnedRepositories)
+    }
+
+    nonisolated static func applyPinnedOrder(to repos: [Repository], pinned: [String]) -> [Repository] {
         let pinnedIndex = pinned.enumerated().reduce(into: [String: Int]()) { dict, entry in
-            let key = self.normalizedFullName(entry.element)
+            let key = Self.normalizedFullName(entry.element)
             if dict[key] == nil {
                 dict[key] = entry.offset
             }
         }
         return repos.map { repo in
-            if let idx = pinnedIndex[self.normalizedFullName(repo.fullName)] {
+            if let idx = pinnedIndex[Self.normalizedFullName(repo.fullName)] {
                 return repo.withOrder(idx)
             }
             return repo
@@ -183,8 +186,12 @@ extension AppState {
         }
     }
 
-    private func normalizedFullName(_ value: String) -> String {
+    private nonisolated static func normalizedFullName(_ value: String) -> String {
         value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private func normalizedFullName(_ value: String) -> String {
+        Self.normalizedFullName(value)
     }
 }
 

--- a/Sources/RepoBar/App/AppState.swift
+++ b/Sources/RepoBar/App/AppState.swift
@@ -14,6 +14,7 @@ final class AppState {
     let legacyGitHub: GitHubClient
     var github: GitHubClient
     let accountManager: AccountManager
+    let accountRepositorySnapshotLoader: any AccountRepositorySnapshotLoading
     let refreshScheduler = RefreshScheduler()
     let settingsStore: SettingsStore
     let gitHubPullRequestNotificationRunner = GitHubPullRequestNotificationRunner()
@@ -29,7 +30,9 @@ final class AppState {
     private var gitHubReferenceResolutionID = UUID()
     private var lifecycleID = UUID()
     var refreshTaskToken = UUID()
+    var accountRepositoryRefreshGeneration = UUID()
     let hydrateConcurrencyLimit = 4
+    let accountRepositoryRefreshConcurrencyLimit = 3
     var prefetchTask: Task<Void, Never>?
     private let tokenRefreshInterval: TimeInterval = 300
     let menuRefreshDebounceInterval: TimeInterval = 1
@@ -45,13 +48,15 @@ final class AppState {
 
     init(
         settingsStore: SettingsStore = SettingsStore(),
-        accountManager: AccountManager? = nil
+        accountManager: AccountManager? = nil,
+        accountRepositorySnapshotLoader: any AccountRepositorySnapshotLoading = AccountRepositorySnapshotLoader()
     ) {
         let legacyGitHub = GitHubClient()
         self.legacyGitHub = legacyGitHub
         self.github = legacyGitHub
         self.settingsStore = settingsStore
         self.accountManager = accountManager ?? AccountManager()
+        self.accountRepositorySnapshotLoader = accountRepositorySnapshotLoader
         self.session.settings = self.settingsStore.load()
         self.reloadRateLimitCacheSummary()
         RepoBarLogging.bootstrapIfNeeded()

--- a/Sources/RepoBar/App/Session+MultiAccount.swift
+++ b/Sources/RepoBar/App/Session+MultiAccount.swift
@@ -4,13 +4,18 @@ import RepoBarCore
 /// Per-account session snapshot. Populated by `AccountManager` and consumed by
 /// `Session` to expose a multi-account view while keeping the existing
 /// single-account fast path source compatible.
-struct AccountSession: Identifiable, Equatable {
+struct AccountSession: Identifiable {
     let id: String
     var account: Account
     var state: AccountState
     var repositories: [Repository]
     var accessibleRepositories: [Repository]
     var rateLimitReset: Date?
+    var diagnostics: DiagnosticsSummary?
+    var cacheSummary: RepoBarCacheSummary?
+    var lastAttemptAt: Date?
+    var lastSuccessfulRefreshAt: Date?
+    var isStale: Bool
     var lastError: String?
 
     init(
@@ -19,6 +24,11 @@ struct AccountSession: Identifiable, Equatable {
         repositories: [Repository] = [],
         accessibleRepositories: [Repository] = [],
         rateLimitReset: Date? = nil,
+        diagnostics: DiagnosticsSummary? = nil,
+        cacheSummary: RepoBarCacheSummary? = nil,
+        lastAttemptAt: Date? = nil,
+        lastSuccessfulRefreshAt: Date? = nil,
+        isStale: Bool = false,
         lastError: String? = nil
     ) {
         self.id = account.id
@@ -27,6 +37,11 @@ struct AccountSession: Identifiable, Equatable {
         self.repositories = repositories
         self.accessibleRepositories = accessibleRepositories
         self.rateLimitReset = rateLimitReset
+        self.diagnostics = diagnostics
+        self.cacheSummary = cacheSummary
+        self.lastAttemptAt = lastAttemptAt
+        self.lastSuccessfulRefreshAt = lastSuccessfulRefreshAt
+        self.isStale = isStale
         self.lastError = lastError
     }
 }

--- a/Sources/RepoBar/Auth/AccountManager.swift
+++ b/Sources/RepoBar/Auth/AccountManager.swift
@@ -9,19 +9,27 @@ import RepoBarCore
 /// from the account-scoped `TokenStore` APIs (Phase 1).
 @MainActor
 final class AccountManager {
+    struct AccountClientSnapshot {
+        let account: Account
+        let client: GitHubClient
+    }
+
     private(set) var accounts: [Account] = []
     private(set) var activeAccountID: String?
     private var clients: [String: GitHubClient] = [:]
     private let tokenStore: TokenStore
     private let oauthRefresher: OAuthTokenRefresher
+    private let clientFactory: ((Account) -> GitHubClient)?
     private let signposter = OSSignposter(subsystem: "com.steipete.repobar", category: "account-manager")
 
     init(
         tokenStore: TokenStore = .shared,
-        oauthRefresher: OAuthTokenRefresher? = nil
+        oauthRefresher: OAuthTokenRefresher? = nil,
+        clientFactory: ((Account) -> GitHubClient)? = nil
     ) {
         self.tokenStore = tokenStore
         self.oauthRefresher = oauthRefresher ?? OAuthTokenRefresher(tokenStore: tokenStore)
+        self.clientFactory = clientFactory
     }
 
     // MARK: - Bootstrap
@@ -53,6 +61,18 @@ final class AccountManager {
         guard let activeAccountID else { return nil }
 
         return self.accounts.first(where: { $0.id == activeAccountID })
+    }
+
+    func accountClientSnapshots(accountIDs: [String]) -> [AccountClientSnapshot] {
+        let selected = Set(accountIDs)
+        return self.accounts.compactMap { account in
+            guard selected.contains(account.id),
+                  self.hasStoredCredentials(accountID: account.id),
+                  let client = self.clients[account.id]
+            else { return nil }
+
+            return AccountClientSnapshot(account: account, client: client)
+        }
     }
 
     func hasStoredCredentials(accountID: String) -> Bool {
@@ -173,7 +193,7 @@ final class AccountManager {
     // MARK: - Private
 
     private func makeClient(for account: Account) async {
-        let client = GitHubClient(accountID: account.id)
+        let client = self.clientFactory?(account) ?? GitHubClient(accountID: account.id)
         await client.setAPIHost(account.apiHost)
         let accountID = account.id
         let store = self.tokenStore

--- a/Sources/RepoBarCore/API/GitHubClient.swift
+++ b/Sources/RepoBarCore/API/GitHubClient.swift
@@ -45,6 +45,19 @@ public actor GitHubClient {
         self.archiveSettingsProvider = archiveSettingsProvider
     }
 
+    init(
+        accountID _: String,
+        archiveSettingsProvider: @Sendable @escaping () -> GitHubArchiveSettings,
+        dataLoader: HTTPDataLoader,
+        responseDiskCache: HTTPResponseDiskCache?,
+        etagCache: ETagCache = ETagCache()
+    ) {
+        self.responseDiskCache = responseDiskCache
+        self.requestRunner = GitHubRequestRunner(etagCache: etagCache, dataLoader: dataLoader)
+        self.graphQL = GraphQLClient(responseCache: nil, dataLoader: dataLoader)
+        self.archiveSettingsProvider = archiveSettingsProvider
+    }
+
     // MARK: - Config
 
     public func setAPIHost(_ host: URL) async {

--- a/Sources/RepoBarCore/API/RepoDetailCoordinator.swift
+++ b/Sources/RepoBarCore/API/RepoDetailCoordinator.swift
@@ -220,9 +220,11 @@ actor RepoDetailCoordinator {
 
     private func cachedRepository(from item: RepoItem, apiHost: URL, now: Date) -> Repository? {
         let cache = self.store.load(apiHost: apiHost, owner: item.owner.login, name: item.name)
-        guard let openPulls = cache.openPulls else { return nil }
-
         let cacheState = self.policy.state(for: cache, now: now)
+        guard let openPulls = cache.openPulls else {
+            return Repository.from(item: item, detailCacheState: cacheState)
+        }
+
         let ciDetails = cache.ciDetails
         let activitySnapshot = Self.cachedActivitySnapshot(
             latest: cache.latestActivity,

--- a/Sources/RepoBarCore/Models/AccountScopedIdentity.swift
+++ b/Sources/RepoBarCore/Models/AccountScopedIdentity.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Identifies the account that supplied a GitHub-backed value.
+public struct AccountSource: Codable, Equatable, Hashable, Sendable {
+    public let accountID: String
+
+    public init(accountID: String) {
+        self.accountID = accountID
+    }
+
+    public init(account: Account) {
+        self.init(accountID: account.id)
+    }
+}
+
+/// Collision-safe identity for a repository returned through a specific account.
+public struct AccountScopedRepositoryIdentity: Codable, Equatable, Hashable, Sendable {
+    public let source: AccountSource
+    public let repositoryID: String
+
+    public init(source: AccountSource, repositoryID: String) {
+        self.source = source
+        self.repositoryID = repositoryID
+    }
+
+    public init(accountID: String, repositoryID: String) {
+        self.init(source: AccountSource(accountID: accountID), repositoryID: repositoryID)
+    }
+}
+
+/// Collision-safe identity for account-scoped references that have a canonical URL.
+public struct AccountScopedURLIdentity: Codable, Equatable, Hashable, Sendable {
+    public let source: AccountSource
+    public let url: URL
+
+    public init(source: AccountSource, url: URL) {
+        self.source = source
+        self.url = url
+    }
+
+    public init(accountID: String, url: URL) {
+        self.init(source: AccountSource(accountID: accountID), url: url)
+    }
+}
+
+/// Collision-safe identity for notification and attention events.
+public struct AccountScopedEventIdentity: Codable, Equatable, Hashable, Sendable {
+    public let source: AccountSource
+    public let namespace: String
+    public let eventID: String
+
+    public init(source: AccountSource, namespace: String, eventID: String) {
+        self.source = source
+        self.namespace = namespace
+        self.eventID = eventID
+    }
+
+    public init(accountID: String, namespace: String, eventID: String) {
+        self.init(
+            source: AccountSource(accountID: accountID),
+            namespace: namespace,
+            eventID: eventID
+        )
+    }
+}
+
+/// Cache key that cannot collide across account-specific stores or request routes.
+public struct AccountScopedCacheKey: Codable, Equatable, Hashable, Sendable {
+    public let source: AccountSource
+    public let key: String
+
+    public init(source: AccountSource, key: String) {
+        self.source = source
+        self.key = key
+    }
+
+    public init(accountID: String, key: String) {
+        self.init(source: AccountSource(accountID: accountID), key: key)
+    }
+}

--- a/Sources/RepoBarCore/Settings/AttentionRule.swift
+++ b/Sources/RepoBarCore/Settings/AttentionRule.swift
@@ -92,6 +92,10 @@ public struct AttentionRule: Codable, Equatable, Hashable, Identifiable, Sendabl
     public var itemStates: [AttentionItemState]
     public var priority: AttentionPriority
 
+    public var isEffectivelyEnabled: Bool {
+        self.enabled && self.category.isKnown
+    }
+
     public init(
         id: AttentionRuleID,
         enabled: Bool = true,
@@ -127,8 +131,7 @@ public struct AttentionRule: Codable, Equatable, Hashable, Identifiable, Sendabl
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.id = try container.decode(AttentionRuleID.self, forKey: .id)
         self.category = try container.decode(AttentionRuleCategory.self, forKey: .category)
-        let decodedEnabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
-        self.enabled = self.category.isKnown ? decodedEnabled : false
+        self.enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
         self.accountSelection = try container.decodeIfPresent(
             AccountSelection.self,
             forKey: .accountSelection

--- a/Sources/RepoBarCore/Settings/AttentionRule.swift
+++ b/Sources/RepoBarCore/Settings/AttentionRule.swift
@@ -1,0 +1,227 @@
+import Foundation
+
+public struct AttentionRuleID: RawRepresentable, Codable, Equatable, Hashable, Sendable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        try self.init(rawValue: container.decode(String.self))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.rawValue)
+    }
+}
+
+/// Extensible category value. Unknown raw values survive decoding so a newer rule
+/// does not invalidate the complete settings payload.
+public struct AttentionRuleCategory: RawRepresentable, Codable, Equatable, Hashable, Sendable {
+    public static let reviewRequests = Self(rawValue: "reviewRequests")
+    public static let assignedIssues = Self(rawValue: "assignedIssues")
+    public static let assignedPullRequests = Self(rawValue: "assignedPullRequests")
+    public static let mentions = Self(rawValue: "mentions")
+    public static let subscribedUpdates = Self(rawValue: "subscribedUpdates")
+    public static let authoredItems = Self(rawValue: "authoredItems")
+    public static let failedWorkflows = Self(rawValue: "failedWorkflows")
+    public static let runnerHealth = Self(rawValue: "runnerHealth")
+    public static let queuePressure = Self(rawValue: "queuePressure")
+    public static let criticalAPIHealth = Self(rawValue: "criticalAPIHealth")
+
+    public static let knownCategories: Set<Self> = [
+        .reviewRequests,
+        .assignedIssues,
+        .assignedPullRequests,
+        .mentions,
+        .subscribedUpdates,
+        .authoredItems,
+        .failedWorkflows,
+        .runnerHealth,
+        .queuePressure,
+        .criticalAPIHealth
+    ]
+
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public var isKnown: Bool {
+        Self.knownCategories.contains(self)
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        try self.init(rawValue: container.decode(String.self))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.rawValue)
+    }
+}
+
+public enum AttentionItemState: String, Codable, Equatable, Hashable, Sendable {
+    case open
+    case closed
+    case merged
+    case pending
+    case failing
+    case unhealthy
+}
+
+public enum AttentionPriority: String, Codable, Equatable, Hashable, Sendable {
+    case low
+    case normal
+    case high
+    case critical
+}
+
+public struct AttentionRule: Codable, Equatable, Hashable, Identifiable, Sendable {
+    public let id: AttentionRuleID
+    public var enabled: Bool
+    public var category: AttentionRuleCategory
+    public var accountSelection: AccountSelection
+    public var ownerFilters: [String]
+    public var repositoryFilters: [String]
+    public var itemStates: [AttentionItemState]
+    public var priority: AttentionPriority
+
+    public init(
+        id: AttentionRuleID,
+        enabled: Bool = true,
+        category: AttentionRuleCategory,
+        accountSelection: AccountSelection = .all,
+        ownerFilters: [String] = [],
+        repositoryFilters: [String] = [],
+        itemStates: [AttentionItemState] = [],
+        priority: AttentionPriority = .normal
+    ) {
+        self.id = id
+        self.enabled = enabled
+        self.category = category
+        self.accountSelection = accountSelection
+        self.ownerFilters = ownerFilters
+        self.repositoryFilters = repositoryFilters
+        self.itemStates = itemStates
+        self.priority = priority
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case enabled
+        case category
+        case accountSelection
+        case ownerFilters
+        case repositoryFilters
+        case itemStates
+        case priority
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(AttentionRuleID.self, forKey: .id)
+        self.category = try container.decode(AttentionRuleCategory.self, forKey: .category)
+        let decodedEnabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
+        self.enabled = self.category.isKnown ? decodedEnabled : false
+        self.accountSelection = try container.decodeIfPresent(
+            AccountSelection.self,
+            forKey: .accountSelection
+        ) ?? .all
+        self.ownerFilters = try container.decodeIfPresent([String].self, forKey: .ownerFilters) ?? []
+        self.repositoryFilters = try container.decodeIfPresent(
+            [String].self,
+            forKey: .repositoryFilters
+        ) ?? []
+        self.itemStates = try container.decodeIfPresent([AttentionItemState].self, forKey: .itemStates) ?? []
+        self.priority = try container.decodeIfPresent(AttentionPriority.self, forKey: .priority) ?? .normal
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.id, forKey: .id)
+        try container.encode(self.enabled, forKey: .enabled)
+        try container.encode(self.category, forKey: .category)
+        if case .all = self.accountSelection {
+            // Default account inclusion is represented by omission.
+        } else {
+            try container.encode(self.accountSelection, forKey: .accountSelection)
+        }
+        if self.ownerFilters.isEmpty == false {
+            try container.encode(self.ownerFilters, forKey: .ownerFilters)
+        }
+        if self.repositoryFilters.isEmpty == false {
+            try container.encode(self.repositoryFilters, forKey: .repositoryFilters)
+        }
+        if self.itemStates.isEmpty == false {
+            try container.encode(self.itemStates, forKey: .itemStates)
+        }
+        if self.priority != .normal {
+            try container.encode(self.priority, forKey: .priority)
+        }
+    }
+}
+
+public enum AttentionRulePresets {
+    public static func conservativeDefault(
+        pinnedRepositories: [String],
+        accountSelection: AccountSelection = .all
+    ) -> [AttentionRule] {
+        let repositories = self.normalizeRepositories(pinnedRepositories)
+        guard repositories.isEmpty == false else { return [] }
+
+        return [
+            AttentionRule(
+                id: AttentionRuleID(rawValue: "default.review-requests"),
+                category: .reviewRequests,
+                accountSelection: accountSelection,
+                repositoryFilters: repositories,
+                priority: .high
+            ),
+            AttentionRule(
+                id: AttentionRuleID(rawValue: "default.assigned-issues"),
+                category: .assignedIssues,
+                accountSelection: accountSelection,
+                repositoryFilters: repositories,
+                itemStates: [.open],
+                priority: .high
+            ),
+            AttentionRule(
+                id: AttentionRuleID(rawValue: "default.assigned-pull-requests"),
+                category: .assignedPullRequests,
+                accountSelection: accountSelection,
+                repositoryFilters: repositories,
+                itemStates: [.open],
+                priority: .high
+            ),
+            AttentionRule(
+                id: AttentionRuleID(rawValue: "default.failed-workflows"),
+                category: .failedWorkflows,
+                accountSelection: accountSelection,
+                repositoryFilters: repositories,
+                itemStates: [.failing],
+                priority: .critical
+            )
+        ]
+    }
+
+    private static func normalizeRepositories(_ repositories: [String]) -> [String] {
+        var seen: Set<String> = []
+        return repositories
+            .compactMap { repository -> String? in
+                let trimmed = repository.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard trimmed.isEmpty == false else { return nil }
+
+                let normalized = trimmed.lowercased()
+                guard seen.insert(normalized).inserted else { return nil }
+
+                return normalized
+            }
+            .sorted()
+    }
+}

--- a/Sources/RepoBarCore/Settings/UserSettings.swift
+++ b/Sources/RepoBarCore/Settings/UserSettings.swift
@@ -29,6 +29,8 @@ public struct UserSettings: Equatable, Codable {
     public var activeAccountID: String?
     public var accountSelection: AccountSelection = .all
     public var accountRepoLists: AccountScopedRepositoryLists = .init()
+    public var consolidateAccounts = false
+    public var attentionRules: [AttentionRule] = []
 
     public init() {}
 
@@ -60,6 +62,8 @@ public struct UserSettings: Equatable, Codable {
         case activeAccountID
         case accountSelection
         case accountRepoLists
+        case consolidateAccounts
+        case attentionRules
     }
 
     public init(from decoder: Decoder) throws {
@@ -112,6 +116,14 @@ public struct UserSettings: Equatable, Codable {
             AccountScopedRepositoryLists.self,
             forKey: .accountRepoLists
         ) ?? AccountScopedRepositoryLists()
+        self.consolidateAccounts = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .consolidateAccounts
+        ) ?? false
+        self.attentionRules = try container.decodeIfPresent(
+            [AttentionRule].self,
+            forKey: .attentionRules
+        ) ?? []
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -152,6 +164,12 @@ public struct UserSettings: Equatable, Codable {
         }
         if self.accountRepoLists.isEmpty == false {
             try container.encode(self.accountRepoLists, forKey: .accountRepoLists)
+        }
+        if self.consolidateAccounts {
+            try container.encode(true, forKey: .consolidateAccounts)
+        }
+        if self.attentionRules.isEmpty == false {
+            try container.encode(self.attentionRules, forKey: .attentionRules)
         }
     }
 
@@ -314,6 +332,7 @@ public struct AISummarySettings: Equatable, Codable, Sendable {
 
     public var enabled = false
     public var model = defaultModel
+    public var allowNonActiveAccountContent = false
 
     public init() {}
 
@@ -327,6 +346,7 @@ public struct AISummarySettings: Equatable, Codable, Sendable {
     enum CodingKeys: String, CodingKey {
         case enabled
         case model
+        case allowNonActiveAccountContent
     }
 
     public init(from decoder: Decoder) throws {
@@ -334,6 +354,19 @@ public struct AISummarySettings: Equatable, Codable, Sendable {
         self.enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
         let decodedModel = try container.decodeIfPresent(String.self, forKey: .model) ?? Self.defaultModel
         self.model = Self.normalizedModel(decodedModel)
+        self.allowNonActiveAccountContent = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .allowNonActiveAccountContent
+        ) ?? false
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.enabled, forKey: .enabled)
+        try container.encode(self.model, forKey: .model)
+        if self.allowNonActiveAccountContent {
+            try container.encode(true, forKey: .allowNonActiveAccountContent)
+        }
     }
 }
 

--- a/Sources/RepoBarCore/Support/RepoBarCacheDatabase.swift
+++ b/Sources/RepoBarCore/Support/RepoBarCacheDatabase.swift
@@ -84,7 +84,15 @@ public enum RepoBarPersistentCache {
     }
 
     public static func summary(limit: Int = 10, fileManager: FileManager = .default) throws -> RepoBarCacheSummary {
-        guard let url = self.standardDatabaseURL(fileManager: fileManager) else {
+        try self.summary(accountID: nil, limit: limit, fileManager: fileManager)
+    }
+
+    public static func summary(
+        accountID: String?,
+        limit: Int = 10,
+        fileManager: FileManager = .default
+    ) throws -> RepoBarCacheSummary {
+        guard let url = self.databaseURL(accountID: accountID, fileManager: fileManager) else {
             throw RepoBarCacheError.missingApplicationSupportDirectory
         }
 

--- a/Tests/RepoBarTests/MultiAccountContractTests.swift
+++ b/Tests/RepoBarTests/MultiAccountContractTests.swift
@@ -86,15 +86,22 @@ struct AttentionRuleContractTests {
 
         #expect(rule.category.rawValue == "futureCategory")
         #expect(rule.category.isKnown == false)
-        #expect(rule.enabled == false)
+        #expect(rule.enabled)
+        #expect(rule.isEffectivelyEnabled == false)
         #expect(rule.repositoryFilters == ["example/repo"])
+
+        let encoded = try JSONEncoder().encode(settings)
+        let encodedObject = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        let encodedRules = try #require(encodedObject["attentionRules"] as? [[String: Any]])
+        #expect(encodedRules.first?["enabled"] as? Bool == true)
 
         let roundTrip = try JSONDecoder().decode(
             UserSettings.self,
-            from: JSONEncoder().encode(settings)
+            from: encoded
         )
         #expect(roundTrip.attentionRules.first?.category.rawValue == "futureCategory")
-        #expect(roundTrip.attentionRules.first?.enabled == false)
+        #expect(roundTrip.attentionRules.first?.enabled == true)
+        #expect(roundTrip.attentionRules.first?.isEffectivelyEnabled == false)
     }
 
     @Test

--- a/Tests/RepoBarTests/MultiAccountContractTests.swift
+++ b/Tests/RepoBarTests/MultiAccountContractTests.swift
@@ -1,0 +1,231 @@
+import Foundation
+@testable import RepoBarCore
+import Testing
+
+struct MultiAccountSettingsContractTests {
+    @Test
+    func `legacy settings decode with consolidated features disabled`() throws {
+        let legacyJSON = """
+        {
+            "githubHost": "https://github.com",
+            "aiSummaries": {
+                "enabled": true,
+                "model": "gpt-5.5"
+            }
+        }
+        """
+
+        let settings = try JSONDecoder().decode(
+            UserSettings.self,
+            from: #require(legacyJSON.data(using: .utf8))
+        )
+
+        #expect(settings.consolidateAccounts == false)
+        #expect(settings.aiSummaries.allowNonActiveAccountContent == false)
+        #expect(settings.attentionRules.isEmpty)
+    }
+
+    @Test
+    func `new settings round trip without changing account selection`() throws {
+        var settings = UserSettings()
+        settings.consolidateAccounts = true
+        settings.accountSelection = .only(["github.com#alice"])
+        settings.aiSummaries.allowNonActiveAccountContent = true
+        settings.attentionRules = [
+            AttentionRule(
+                id: AttentionRuleID(rawValue: "custom.review"),
+                category: .reviewRequests,
+                accountSelection: .only(["github.com#alice"]),
+                ownerFilters: ["example"],
+                repositoryFilters: ["example/repo"],
+                itemStates: [.open],
+                priority: .high
+            )
+        ]
+
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(UserSettings.self, from: data)
+
+        #expect(decoded == settings)
+        #expect(decoded.accountSelection == .only(["github.com#alice"]))
+    }
+
+    @Test
+    func `default settings omit new contracts`() throws {
+        let data = try JSONEncoder().encode(UserSettings())
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let aiSummaries = try #require(object["aiSummaries"] as? [String: Any])
+
+        #expect(object["consolidateAccounts"] == nil)
+        #expect(object["attentionRules"] == nil)
+        #expect(aiSummaries["allowNonActiveAccountContent"] == nil)
+    }
+}
+
+struct AttentionRuleContractTests {
+    @Test
+    func `unknown category is preserved and safely disabled`() throws {
+        let json = """
+        {
+            "attentionRules": [
+                {
+                    "id": "future.rule",
+                    "enabled": true,
+                    "category": "futureCategory",
+                    "repositoryFilters": ["example/repo"]
+                }
+            ]
+        }
+        """
+
+        let settings = try JSONDecoder().decode(
+            UserSettings.self,
+            from: #require(json.data(using: .utf8))
+        )
+        let rule = try #require(settings.attentionRules.first)
+
+        #expect(rule.category.rawValue == "futureCategory")
+        #expect(rule.category.isKnown == false)
+        #expect(rule.enabled == false)
+        #expect(rule.repositoryFilters == ["example/repo"])
+
+        let roundTrip = try JSONDecoder().decode(
+            UserSettings.self,
+            from: JSONEncoder().encode(settings)
+        )
+        #expect(roundTrip.attentionRules.first?.category.rawValue == "futureCategory")
+        #expect(roundTrip.attentionRules.first?.enabled == false)
+    }
+
+    @Test
+    func `missing optional rule fields use compatibility defaults`() throws {
+        let json = """
+        {
+            "id": "minimal.rule",
+            "category": "mentions"
+        }
+        """
+
+        let rule = try JSONDecoder().decode(
+            AttentionRule.self,
+            from: #require(json.data(using: .utf8))
+        )
+
+        #expect(rule.enabled)
+        #expect(rule.accountSelection == .all)
+        #expect(rule.ownerFilters.isEmpty)
+        #expect(rule.repositoryFilters.isEmpty)
+        #expect(rule.itemStates.isEmpty)
+        #expect(rule.priority == .normal)
+
+        let encoded = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(rule)) as? [String: Any]
+        )
+        #expect(encoded["accountSelection"] == nil)
+        #expect(encoded["ownerFilters"] == nil)
+        #expect(encoded["repositoryFilters"] == nil)
+        #expect(encoded["itemStates"] == nil)
+        #expect(encoded["priority"] == nil)
+    }
+
+    @Test
+    func `first version categories are complete and stable`() {
+        #expect(AttentionRuleCategory.knownCategories == [
+            .reviewRequests,
+            .assignedIssues,
+            .assignedPullRequests,
+            .mentions,
+            .subscribedUpdates,
+            .authoredItems,
+            .failedWorkflows,
+            .runnerHealth,
+            .queuePressure,
+            .criticalAPIHealth
+        ])
+    }
+
+    @Test
+    func `conservative preset is deterministic and pinned only`() {
+        let selection = AccountSelection.only(["github.com#alice"])
+        let first = AttentionRulePresets.conservativeDefault(
+            pinnedRepositories: [" Example/Zeta ", "example/alpha", "EXAMPLE/ZETA", ""],
+            accountSelection: selection
+        )
+        let second = AttentionRulePresets.conservativeDefault(
+            pinnedRepositories: ["example/alpha", "example/zeta"],
+            accountSelection: selection
+        )
+
+        #expect(first == second)
+        #expect(first.map(\.id.rawValue) == [
+            "default.review-requests",
+            "default.assigned-issues",
+            "default.assigned-pull-requests",
+            "default.failed-workflows"
+        ])
+        #expect(first.map(\.category) == [
+            .reviewRequests,
+            .assignedIssues,
+            .assignedPullRequests,
+            .failedWorkflows
+        ])
+        for rule in first {
+            #expect(rule.enabled)
+        }
+        #expect(first.allSatisfy { $0.accountSelection == selection })
+        #expect(first.allSatisfy { $0.repositoryFilters == ["example/alpha", "example/zeta"] })
+        #expect(AttentionRulePresets.conservativeDefault(pinnedRepositories: []).isEmpty)
+    }
+}
+
+struct AccountScopedIdentityTests {
+    @Test
+    func `same repository is distinct across account sources`() {
+        let personal = AccountScopedRepositoryIdentity(
+            accountID: "github.com#alice",
+            repositoryID: "R_123"
+        )
+        let work = AccountScopedRepositoryIdentity(
+            accountID: "github.com#alice-work",
+            repositoryID: "R_123"
+        )
+
+        #expect(personal != work)
+        #expect(Set([personal, work]).count == 2)
+    }
+
+    @Test
+    func `same URL is distinct across account sources and codable`() throws {
+        let url = try #require(URL(string: "https://github.com/example/repo/pull/1"))
+        let personal = AccountScopedURLIdentity(accountID: "github.com#alice", url: url)
+        let work = AccountScopedURLIdentity(accountID: "github.com#alice-work", url: url)
+
+        #expect(personal != work)
+        #expect(Set([personal, work]).count == 2)
+
+        let decoded = try JSONDecoder().decode(
+            AccountScopedURLIdentity.self,
+            from: JSONEncoder().encode(personal)
+        )
+        #expect(decoded == personal)
+    }
+
+    @Test
+    func `event and cache identities include account source`() {
+        let personalEvent = AccountScopedEventIdentity(
+            accountID: "github.com#alice",
+            namespace: "pull-request",
+            eventID: "42"
+        )
+        let workEvent = AccountScopedEventIdentity(
+            accountID: "github.com#alice-work",
+            namespace: "pull-request",
+            eventID: "42"
+        )
+        let personalCache = AccountScopedCacheKey(accountID: "github.com#alice", key: "repos")
+        let workCache = AccountScopedCacheKey(accountID: "github.com#alice-work", key: "repos")
+
+        #expect(personalEvent != workEvent)
+        #expect(personalCache != workCache)
+    }
+}

--- a/Tests/RepoBarTests/MultiAccountRepositoryRefreshTests.swift
+++ b/Tests/RepoBarTests/MultiAccountRepositoryRefreshTests.swift
@@ -1,0 +1,558 @@
+import Foundation
+@testable import RepoBar
+@testable import RepoBarCore
+import Testing
+
+@MainActor
+struct MultiAccountRepositoryRefreshTests {
+    @Test
+    func `consolidation off refreshes active account only`() async throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob")
+        let aliceTransport = AccountRepositoryTransport(repositories: [.init(id: 1, owner: "alice", name: "one")])
+        let bobTransport = AccountRepositoryTransport(repositories: [.init(id: 2, owner: "bob", name: "two")])
+        let environment = try await Self.environment(
+            accounts: [alice, bob],
+            activeAccountID: alice.id,
+            consolidateAccounts: false,
+            selectedAccountIDs: [alice.id, bob.id],
+            transports: [alice.id: aliceTransport, bob.id: bobTransport]
+        )
+        defer { environment.cleanup() }
+
+        _ = await environment.app.refreshAccountRepositorySnapshots(now: Date(timeIntervalSince1970: 100))
+
+        #expect(await aliceTransport.requestCount == 1)
+        #expect(await bobTransport.requestCount == 0)
+        #expect(environment.app.session.accountSessions.map(\.id) == [alice.id])
+        #expect(environment.app.session.repositories.map(\.fullName) == ["alice/one"])
+    }
+
+    @Test
+    func `consolidation on isolates same host accounts and preserves overlapping repositories`() async throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob")
+        let shared = AccountRepositoryFixture(id: 42, owner: "example", name: "shared")
+        let aliceTransport = AccountRepositoryTransport(repositories: [shared])
+        let bobTransport = AccountRepositoryTransport(repositories: [shared])
+        let environment = try await Self.environment(
+            accounts: [alice, bob],
+            activeAccountID: alice.id,
+            consolidateAccounts: true,
+            selectedAccountIDs: [alice.id, bob.id],
+            transports: [alice.id: aliceTransport, bob.id: bobTransport]
+        )
+        defer { environment.cleanup() }
+
+        _ = await environment.app.refreshAccountRepositorySnapshots(now: Date(timeIntervalSince1970: 200))
+
+        #expect(await aliceTransport.requestCount == 1)
+        #expect(await bobTransport.requestCount == 1)
+        #expect(await aliceTransport.requestedPaths == ["/user/repos"])
+        #expect(await bobTransport.requestedPaths == ["/user/repos"])
+        #expect(environment.app.session.accountSessions.map(\.id) == [alice.id, bob.id])
+        #expect(environment.app.session.aggregatedRepositories.count == 2)
+        #expect(Set(environment.app.session.aggregatedRepositories.map(\.id)).count == 2)
+        #expect(environment.app.session.repositories.count == 1)
+    }
+
+    @Test
+    func `consolidation on refreshes only included credentialed current accounts`() async throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob")
+        let credentialless = try Self.account("credentialless")
+        let removed = try Self.account("removed")
+        let aliceTransport = AccountRepositoryTransport(repositories: [.init(id: 1, owner: "alice", name: "one")])
+        let bobTransport = AccountRepositoryTransport(repositories: [.init(id: 2, owner: "bob", name: "two")])
+        let credentiallessTransport = AccountRepositoryTransport(
+            repositories: [.init(id: 3, owner: "credentialless", name: "three")]
+        )
+        let removedTransport = AccountRepositoryTransport(repositories: [.init(id: 4, owner: "removed", name: "four")])
+        let environment = try await Self.environment(
+            accounts: [alice, bob, credentialless, removed],
+            activeAccountID: alice.id,
+            consolidateAccounts: true,
+            selectedAccountIDs: [alice.id, credentialless.id, removed.id, "github.com#unknown"],
+            credentialedAccountIDs: [alice.id, bob.id, removed.id],
+            transports: [
+                alice.id: aliceTransport,
+                bob.id: bobTransport,
+                credentialless.id: credentiallessTransport,
+                removed.id: removedTransport
+            ]
+        )
+        defer { environment.cleanup() }
+        await environment.app.accountManager.remove(accountID: removed.id)
+
+        _ = await environment.app.refreshAccountRepositorySnapshots(now: Date(timeIntervalSince1970: 300))
+
+        #expect(await aliceTransport.requestCount == 1)
+        #expect(await bobTransport.requestCount == 0)
+        #expect(await credentiallessTransport.requestCount == 0)
+        #expect(await removedTransport.requestCount == 0)
+        #expect(environment.app.session.accountSessions.map(\.id) == [alice.id])
+        #expect(environment.app.session.aggregatedRepositories.map(\.accountID) == [alice.id])
+    }
+
+    @Test
+    func `partial failure retains last good account state while healthy account advances`() async throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob")
+        let aliceTransport = AccountRepositoryTransport(repositories: [.init(id: 1, owner: "alice", name: "old")])
+        let bobTransport = AccountRepositoryTransport(repositories: [.init(id: 2, owner: "bob", name: "old")])
+        let environment = try await Self.environment(
+            accounts: [alice, bob],
+            activeAccountID: alice.id,
+            consolidateAccounts: true,
+            selectedAccountIDs: [alice.id, bob.id],
+            transports: [alice.id: aliceTransport, bob.id: bobTransport]
+        )
+        defer { environment.cleanup() }
+        let firstDate = Date(timeIntervalSince1970: 400)
+        _ = await environment.app.refreshAccountRepositorySnapshots(now: firstDate)
+
+        await aliceTransport.setFailure(statusCode: 500)
+        await bobTransport.setRepositories([.init(id: 3, owner: "bob", name: "new")])
+        _ = await environment.app.refreshAccountRepositorySnapshots(now: Date(timeIntervalSince1970: 500))
+
+        let aliceSession = try #require(environment.app.session.accountSessions.first(where: { $0.id == alice.id }))
+        let bobSession = try #require(environment.app.session.accountSessions.first(where: { $0.id == bob.id }))
+        #expect(aliceSession.repositories.map(\.fullName) == ["alice/old"])
+        #expect(aliceSession.lastSuccessfulRefreshAt == firstDate)
+        #expect(aliceSession.isStale)
+        #expect(aliceSession.lastError != nil)
+        #expect(bobSession.repositories.map(\.fullName) == ["bob/new"])
+        #expect(bobSession.lastSuccessfulRefreshAt == Date(timeIntervalSince1970: 500))
+        #expect(bobSession.isStale == false)
+        #expect(environment.app.session.aggregatedRepositories.count == 2)
+    }
+
+    @Test
+    func `older generation cannot overwrite a newer refresh`() async throws {
+        let alice = try Self.account("alice")
+        let transport = AccountRepositoryTransport(repositories: [])
+        let loader = SequencedAccountRepositoryLoader(
+            responses: [
+                .init(delay: .milliseconds(200), repository: Self.repository(id: "old", owner: "alice", name: "old")),
+                .init(delay: .zero, repository: Self.repository(id: "new", owner: "alice", name: "new"))
+            ]
+        )
+        let environment = try await Self.environment(
+            accounts: [alice],
+            activeAccountID: alice.id,
+            consolidateAccounts: false,
+            selectedAccountIDs: [alice.id],
+            transports: [alice.id: transport],
+            loader: loader
+        )
+        defer { environment.cleanup() }
+
+        let first = Task { @MainActor in
+            await environment.app.refreshAccountRepositorySnapshots(now: Date(timeIntervalSince1970: 600))
+        }
+        while await loader.snapshotRequestCount == 0 {
+            await Task.yield()
+        }
+        let second = await environment.app.refreshAccountRepositorySnapshots(now: Date(timeIntervalSince1970: 700))
+        let firstOutcome = await first.value
+
+        #expect(second.published)
+        #expect(firstOutcome.published == false)
+        #expect(environment.app.session.repositories.map(\.fullName) == ["alice/new"])
+    }
+
+    @Test
+    func `cancelled refresh cannot overwrite last good state`() async throws {
+        let alice = try Self.account("alice")
+        let transport = AccountRepositoryTransport(repositories: [])
+        let loader = SequencedAccountRepositoryLoader(
+            responses: [
+                .init(delay: .zero, repository: Self.repository(id: "good", owner: "alice", name: "good")),
+                .init(delay: .seconds(1), repository: Self.repository(id: "late", owner: "alice", name: "late"))
+            ]
+        )
+        let environment = try await Self.environment(
+            accounts: [alice],
+            activeAccountID: alice.id,
+            consolidateAccounts: false,
+            selectedAccountIDs: [alice.id],
+            transports: [alice.id: transport],
+            loader: loader
+        )
+        defer { environment.cleanup() }
+        _ = await environment.app.refreshAccountRepositorySnapshots(now: Date(timeIntervalSince1970: 710))
+
+        let cancelled = Task { @MainActor in
+            await environment.app.refreshAccountRepositorySnapshots(now: Date(timeIntervalSince1970: 720))
+        }
+        while await loader.snapshotRequestCount < 2 {
+            await Task.yield()
+        }
+        cancelled.cancel()
+        let outcome = await cancelled.value
+
+        #expect(outcome.published == false)
+        #expect(environment.app.session.repositories.map(\.fullName) == ["alice/good"])
+    }
+
+    @Test
+    func `hydrated snapshot cannot cross an active account switch`() async throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob")
+        let aliceTransport = AccountRepositoryTransport(repositories: [.init(id: 1, owner: "alice", name: "one")])
+        let bobTransport = AccountRepositoryTransport(repositories: [.init(id: 2, owner: "bob", name: "two")])
+        let environment = try await Self.environment(
+            accounts: [alice, bob],
+            activeAccountID: alice.id,
+            consolidateAccounts: true,
+            selectedAccountIDs: [alice.id, bob.id],
+            transports: [alice.id: aliceTransport, bob.id: bobTransport]
+        )
+        defer { environment.cleanup() }
+        let outcome = await environment.app.refreshAccountRepositorySnapshots(now: Date(timeIntervalSince1970: 730))
+        let aliceHydrated = Self.repository(id: "alice-hydrated", owner: "alice", name: "hydrated")
+        let bobBefore = try #require(
+            environment.app.session.accountSessions.first(where: { $0.id == bob.id })?.repositories
+        )
+
+        environment.app.session.activeAccountID = bob.id
+        let published = environment.app.publishHydratedActiveRepositorySnapshot(
+            accessibleRepositories: [aliceHydrated],
+            repositories: [aliceHydrated],
+            accountID: alice.id,
+            generation: outcome.generation,
+            now: Date(timeIntervalSince1970: 740)
+        )
+
+        #expect(published == false)
+        #expect(environment.app.session.accountSessions.first(where: { $0.id == bob.id })?.repositories == bobBefore)
+    }
+
+    @Test
+    func `non active authentication failure remains account local`() async throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob")
+        let aliceTransport = AccountRepositoryTransport(repositories: [.init(id: 1, owner: "alice", name: "one")])
+        let bobTransport = AccountRepositoryTransport(repositories: [.init(id: 2, owner: "bob", name: "two")])
+        let environment = try await Self.environment(
+            accounts: [alice, bob],
+            activeAccountID: alice.id,
+            consolidateAccounts: true,
+            selectedAccountIDs: [alice.id, bob.id],
+            transports: [alice.id: aliceTransport, bob.id: bobTransport]
+        )
+        defer { environment.cleanup() }
+        await bobTransport.setFailure(statusCode: 401)
+
+        _ = await environment.app.refreshAccountRepositorySnapshots(now: Date(timeIntervalSince1970: 750))
+
+        let aliceSession = try #require(environment.app.session.accountSessions.first(where: { $0.id == alice.id }))
+        let bobSession = try #require(environment.app.session.accountSessions.first(where: { $0.id == bob.id }))
+        #expect(aliceSession.state.isLoggedIn)
+        #expect(bobSession.state == .loggedOut)
+        #expect(try environment.tokenStore.loadPAT(accountID: alice.id) != nil)
+        #expect(try environment.tokenStore.loadPAT(accountID: bob.id) != nil)
+    }
+
+    @Test
+    func `consolidated active failure remains visible after full refresh`() async throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob")
+        let aliceTransport = AccountRepositoryTransport(repositories: [])
+        let bobTransport = AccountRepositoryTransport(repositories: [.init(id: 2, owner: "bob", name: "two")])
+        let environment = try await Self.environment(
+            accounts: [alice, bob],
+            activeAccountID: alice.id,
+            consolidateAccounts: true,
+            selectedAccountIDs: [alice.id, bob.id],
+            transports: [alice.id: aliceTransport, bob.id: bobTransport]
+        )
+        defer { environment.cleanup() }
+        await aliceTransport.setFailure(statusCode: 500)
+
+        await environment.app.refresh()
+
+        let aliceSession = try #require(environment.app.session.accountSessions.first(where: { $0.id == alice.id }))
+        let bobSession = try #require(environment.app.session.accountSessions.first(where: { $0.id == bob.id }))
+        #expect(aliceSession.isStale)
+        #expect(aliceSession.lastError != nil)
+        #expect(environment.app.session.lastError == aliceSession.lastError)
+        #expect(bobSession.repositories.map(\.fullName) == ["bob/two"])
+    }
+
+    @Test
+    func `account caches hydrate independently before failed live requests`() async throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob")
+        let aliceTransport = AccountRepositoryTransport(repositories: [.init(id: 1, owner: "alice", name: "cached")])
+        let bobTransport = AccountRepositoryTransport(repositories: [.init(id: 2, owner: "bob", name: "cached")])
+        let first = try await Self.environment(
+            accounts: [alice, bob],
+            activeAccountID: alice.id,
+            consolidateAccounts: true,
+            selectedAccountIDs: [alice.id, bob.id],
+            transports: [alice.id: aliceTransport, bob.id: bobTransport]
+        )
+        _ = await first.app.refreshAccountRepositorySnapshots(now: Date(timeIntervalSince1970: 800))
+        #expect(first.caches[alice.id]?.count() == 1)
+        #expect(first.caches[bob.id]?.count() == 1)
+        let firstAliceClient = try #require(first.app.accountManager.client(for: alice.id))
+        let firstBobClient = try #require(first.app.accountManager.client(for: bob.id))
+        #expect(try await firstAliceClient.cachedRepositoryList(limit: nil).map(\.fullName) == ["alice/cached"])
+        #expect(try await firstBobClient.cachedRepositoryList(limit: nil).map(\.fullName) == ["bob/cached"])
+
+        await aliceTransport.setFailure(statusCode: 503)
+        await bobTransport.setFailure(statusCode: 503)
+        let second = try await Self.environment(
+            accounts: [alice, bob],
+            activeAccountID: alice.id,
+            consolidateAccounts: true,
+            selectedAccountIDs: [alice.id, bob.id],
+            transports: [alice.id: aliceTransport, bob.id: bobTransport],
+            cacheDirectories: first.cacheDirectories,
+            tokenStore: first.tokenStore
+        )
+        defer {
+            second.cleanup(removeCaches: false)
+            first.cleanup()
+        }
+
+        _ = await second.app.refreshAccountRepositorySnapshots(now: Date(timeIntervalSince1970: 900))
+
+        let sessions = Dictionary(uniqueKeysWithValues: second.app.session.accountSessions.map { ($0.id, $0) })
+        #expect(sessions[alice.id]?.repositories.map(\.fullName) == ["alice/cached"])
+        #expect(sessions[bob.id]?.repositories.map(\.fullName) == ["bob/cached"])
+        #expect(sessions[alice.id]?.isStale == true)
+        #expect(sessions[bob.id]?.isStale == true)
+        #expect(second.app.session.aggregatedRepositories.count == 2)
+    }
+
+    private static func account(_ username: String) throws -> Account {
+        try Account(
+            username: username,
+            host: #require(URL(string: "https://github.com")),
+            authMethod: .pat
+        )
+    }
+
+    private static func environment(
+        accounts: [Account],
+        activeAccountID: String,
+        consolidateAccounts: Bool,
+        selectedAccountIDs: Set<String>,
+        credentialedAccountIDs: Set<String>? = nil,
+        transports: [String: AccountRepositoryTransport],
+        loader: any AccountRepositorySnapshotLoading = AccountRepositorySnapshotLoader(),
+        cacheDirectories: [String: URL]? = nil,
+        tokenStore: TokenStore? = nil
+    ) async throws -> AccountRefreshTestEnvironment {
+        let store = tokenStore ?? TokenStore(service: "com.steipete.repobar.multi-account-refresh.\(UUID().uuidString)")
+        let credentialed = credentialedAccountIDs ?? Set(accounts.map(\.id))
+        for account in accounts where credentialed.contains(account.id) {
+            try store.savePAT("token-\(account.username)", accountID: account.id)
+        }
+
+        var directories = cacheDirectories ?? [:]
+        var clients: [String: GitHubClient] = [:]
+        var caches: [String: HTTPResponseDiskCache] = [:]
+        for account in accounts {
+            let directory: URL
+            if let existing = directories[account.id] {
+                directory = existing
+            } else {
+                directory = FileManager.default.temporaryDirectory
+                    .appending(path: "repobar-account-refresh-\(UUID().uuidString)", directoryHint: .isDirectory)
+                directories[account.id] = directory
+            }
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            let cache = try HTTPResponseDiskCache(path: directory.appending(path: "cache.sqlite").path)
+            caches[account.id] = cache
+            let transport = try #require(transports[account.id])
+            let dataLoader = HTTPDataLoader { request in
+                try await transport.data(for: request)
+            }
+            clients[account.id] = GitHubClient(
+                accountID: account.id,
+                archiveSettingsProvider: { GitHubArchiveSettings() },
+                dataLoader: dataLoader,
+                responseDiskCache: cache,
+                etagCache: ETagCache(persistentStore: cache)
+            )
+        }
+
+        var settings = UserSettings()
+        settings.accounts = accounts
+        settings.activeAccountID = activeAccountID
+        settings.consolidateAccounts = consolidateAccounts
+        settings.accountSelection = .only(selectedAccountIDs)
+        let defaultsName = "com.steipete.repobar.multi-account-refresh.defaults.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: defaultsName))
+        let manager = AccountManager(
+            tokenStore: store,
+            clientFactory: { account in
+                clients[account.id]!
+            }
+        )
+        let app = AppState(
+            settingsStore: SettingsStore(defaults: defaults),
+            accountManager: manager,
+            accountRepositorySnapshotLoader: loader
+        )
+        app.session.settings = settings
+        await app.bootstrapAccounts()
+        return AccountRefreshTestEnvironment(
+            app: app,
+            tokenStore: store,
+            accounts: accounts,
+            cacheDirectories: directories,
+            caches: caches,
+            defaultsName: defaultsName
+        )
+    }
+
+    private static func repository(id: String, owner: String, name: String) -> Repository {
+        Repository(
+            id: id,
+            name: name,
+            owner: owner,
+            sortOrder: nil,
+            error: nil,
+            rateLimitedUntil: nil,
+            ciStatus: .unknown,
+            ciRunCount: nil,
+            openIssues: 0,
+            openPulls: 0,
+            stars: 0,
+            forks: 0,
+            pushedAt: nil,
+            latestRelease: nil,
+            latestActivity: nil,
+            activityEvents: [],
+            traffic: nil,
+            heatmap: []
+        )
+    }
+}
+
+@MainActor
+private struct AccountRefreshTestEnvironment {
+    let app: AppState
+    let tokenStore: TokenStore
+    let accounts: [Account]
+    let cacheDirectories: [String: URL]
+    let caches: [String: HTTPResponseDiskCache]
+    let defaultsName: String
+
+    func cleanup(removeCaches: Bool = true) {
+        for account in self.accounts {
+            self.tokenStore.clear(accountID: account.id)
+        }
+        UserDefaults.standard.removePersistentDomain(forName: self.defaultsName)
+        if removeCaches {
+            for directory in self.cacheDirectories.values {
+                try? FileManager.default.removeItem(at: directory)
+            }
+        }
+    }
+}
+
+private struct AccountRepositoryFixture {
+    let id: Int
+    let owner: String
+    let name: String
+}
+
+private actor AccountRepositoryTransport {
+    private var repositories: [AccountRepositoryFixture]
+    private var statusCode = 200
+    private(set) var requests: [URLRequest] = []
+
+    init(repositories: [AccountRepositoryFixture]) {
+        self.repositories = repositories
+    }
+
+    var requestCount: Int {
+        self.requests.count
+    }
+
+    var requestedPaths: [String] {
+        self.requests.compactMap(\.url?.path)
+    }
+
+    func setRepositories(_ repositories: [AccountRepositoryFixture]) {
+        self.repositories = repositories
+        self.statusCode = 200
+    }
+
+    func setFailure(statusCode: Int) {
+        self.statusCode = statusCode
+    }
+
+    func data(for request: URLRequest) throws -> (Data, URLResponse) {
+        self.requests.append(request)
+        let data: Data
+        if self.statusCode == 200 {
+            let objects: [[String: Any]] = self.repositories.map { repo in
+                [
+                    "id": repo.id,
+                    "name": repo.name,
+                    "full_name": "\(repo.owner)/\(repo.name)",
+                    "description": NSNull(),
+                    "language": NSNull(),
+                    "topics": [],
+                    "fork": false,
+                    "archived": false,
+                    "has_discussions": true,
+                    "open_issues_count": 0,
+                    "stargazers_count": 0,
+                    "forks_count": 0,
+                    "pushed_at": NSNull(),
+                    "permissions": ["pull": true],
+                    "owner": ["login": repo.owner]
+                ]
+            }
+            data = try JSONSerialization.data(withJSONObject: objects)
+        } else {
+            data = Data(#"{"message":"injected failure"}"#.utf8)
+        }
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: self.statusCode,
+            httpVersion: nil,
+            headerFields: self.statusCode == 200 ? ["ETag": "\"refresh-test\""] : nil
+        )!
+        return (data, response)
+    }
+}
+
+private actor SequencedAccountRepositoryLoader: AccountRepositorySnapshotLoading {
+    struct Response {
+        let delay: Duration
+        let repository: Repository
+    }
+
+    private var responses: [Response]
+    private(set) var snapshotRequestCount = 0
+
+    init(responses: [Response]) {
+        self.responses = responses
+    }
+
+    func cachedSnapshot(for _: AccountRepositorySnapshotRequest) async throws -> AccountRepositorySnapshot? {
+        nil
+    }
+
+    func snapshot(for request: AccountRepositorySnapshotRequest) async throws -> AccountRepositorySnapshot {
+        self.snapshotRequestCount += 1
+        let response = self.responses.removeFirst()
+        try await Task.sleep(for: response.delay)
+        return AccountRepositorySnapshot(
+            account: request.account,
+            accessibleRepositories: [response.repository],
+            repositories: [response.repository],
+            capturedAt: request.now,
+            diagnostics: .empty,
+            cacheSummary: nil
+        )
+    }
+}

--- a/docs/multi-account-auth-plan.md
+++ b/docs/multi-account-auth-plan.md
@@ -43,7 +43,7 @@ The implementation is a sequential bottom-to-top stack:
 9. `multi-account-operations-status` — Actions & Runners, monitored owners, rate limits, contribution/global activity, and worst-health state.
 10. `multi-account-integration-proof` — integration fixtures, accessibility and UI polish, redacted personal plus EMU proof, and final README, docs, CHANGELOG, and issue updates.
 
-Only Layer 1, `multi-account-contracts`, is implemented in this change. Layers 2 through 10 remain deferred, and the new contracts do not change runtime, UI, notification, refresh, or CLI behavior.
+Layers 1 and 2 are implemented. `multi-account-refresh` adds account-scoped repository snapshot loading, bounded selected-account fan-out, cached-first hydration, last-good partial-failure handling, and the active-account compatibility projection. Layers 3 through 10 remain deferred; repository grouping, account-scoped settings writes, CLI scope changes, attention and navigator collectors, notifications, Actions, and other user-visible fan-out are unchanged.
 
 Landed:
 
@@ -55,6 +55,7 @@ Landed:
 - Phase 4 — `HTTPResponseDiskCache` and `RepoBarPersistentCache` accept an `accountID:` parameter and resolve to `~/Library/Application Support/RepoBar/Cache/<account>.sqlite` (legacy path used when `accountID` is `nil`). `GraphQLResponseDiskCache.scoped(accountID:)` follows the same pattern.
 - Phase 5 — `AccountSettingsView` shows an account list (use / visibility / verify / remove) above the legacy single-account form, which is now labelled "Add Account".
 - Phase 6 — CLI gains `repobar accounts list/use/remove`, plus `--account`/`--all` on `logout`, `--account` on `status`, and `--label` on `login`/`import-gh-token`. After successful auth both commands fetch `GET /user`, derive a stable `Account`, and persist tokens under the account-scoped keys in addition to the legacy fast-path entries.
+- Issue #101 Layer 2 — `AppState` resolves the included account/client pairs once, hydrates each scoped repository cache independently, refreshes through a bounded task group, retains per-account last-good state on failures, and rebuilds `Session.accountSessions` / `aggregatedRepositories` in settings order. Existing menu, activity, notification, and Actions surfaces remain projected from the active account.
 
 Deferred:
 

--- a/docs/multi-account-auth-plan.md
+++ b/docs/multi-account-auth-plan.md
@@ -15,6 +15,36 @@ RepoBar's current authentication code is intentionally small and clean, but it i
 
 The 0.6.6 cycle landed the bulk of the plan end-to-end behind a backward-compatible facade. The legacy single-account `TokenStore` keys (`default`, `client`, `pat`) and the `githubHost` / `enterpriseHost` / `loopbackPort` / `authMethod` `UserSettings` fields are still authoritative for installs that have not been re-auth'd; the new account-scoped keys, settings, caches, and clients are populated on first login (or via the legacy migration on bootstrap) without removing those legacy entries.
 
+### Issue #101 consolidated experience
+
+The next programme adds an optional consolidated experience on top of the existing multi-account foundations. Its accepted product contract is:
+
+1. Consolidation is opt-in through one global **Consolidate accounts** toggle that defaults off. Existing `AccountSelection` remains the source of per-account inclusion; no second account-selection list is introduced.
+2. The supported surfaces are the macOS app and bundled CLI. RepoBarCore contracts remain reusable by iOS, but iOS UI is out of scope.
+3. Every existing GitHub-backed read and monitoring surface will become account-aware. New remote GitHub mutations, including assign, label, comment, review, rerun, merge, and administration actions, are out of scope.
+4. Repositories and items visible through multiple accounts remain separate internally and visually, grouped and labelled by account. Repository display limits apply independently to each account.
+5. Existing per-account SQLite caches remain separate, and consolidated state is an in-memory union. The programme will not use SQLite `ATTACH` or add a shared `attention.sqlite` unless later profiling justifies it.
+6. When one account fails, its last-good cached rows remain visible and are marked stale or errored while healthy accounts continue. The menu-bar indicator reports the worst included-account health, while details remain per account.
+7. Notifications remain separate and account-labelled when multiple accounts observe the same pull request or release.
+8. The CLI adds explicit `--all-accounts`, retains `--account` and active-account defaults, and does not implicitly inherit the GUI consolidation toggle.
+9. Issue Navigator content from a non-active account requires a second explicit opt-in before OpenAI summaries are allowed.
+10. **Needs Attention** uses typed configurable rules for category, account, owner/repository filters, state, and priority. It does not expose arbitrary expressions or a nested AND/OR DSL. Its conservative default preset covers review requests, assignments, and failed workflows on pinned repositories.
+
+The implementation is a sequential bottom-to-top stack:
+
+1. `multi-account-contracts` — settings, account-scoped identities, attention-rule contracts, and Codable compatibility.
+2. `multi-account-refresh` — repository snapshot loader, bounded fan-out, last-good partial failures, and active-account compatibility projection.
+3. `multi-account-repo-state` — account-scoped pinned/hidden migration, cache and submenu identities, local host matching, and explicit client resolution.
+4. `multi-account-cli` — shared account scope, `--all-accounts`, stable output envelopes, and account settings/cache operations.
+5. `multi-account-dashboard` — Settings opt-in controls, grouped dashboard/menu, account headers, per-account limits, and account-aware submenus.
+6. `multi-account-attention` — typed rule evaluation, shared collectors, the default preset, normalized `AttentionItem`, and `repobar triage`.
+7. `multi-account-navigator` — Issue Navigator, Needs Attention mode, reference monitor fan-out, scopes/previews, and the AI secondary opt-in.
+8. `multi-account-notifications` — account-namespaced pull request/release polling, baselines, event IDs, labels, and click context.
+9. `multi-account-operations-status` — Actions & Runners, monitored owners, rate limits, contribution/global activity, and worst-health state.
+10. `multi-account-integration-proof` — integration fixtures, accessibility and UI polish, redacted personal plus EMU proof, and final README, docs, CHANGELOG, and issue updates.
+
+Only Layer 1, `multi-account-contracts`, is implemented in this change. Layers 2 through 10 remain deferred, and the new contracts do not change runtime, UI, notification, refresh, or CLI behavior.
+
 Landed:
 
 - Phase 0/1 — `Account`, `AccountSelection`, and `AccountScopedRepositoryLists` live in `RepoBarCore`; `UserSettings` decodes/encodes the new fields with safe defaults and omits them when empty so legacy reads stay clean.


### PR DESCRIPTION
Depends on #105

Cumulative fork-backed Layer 2 diff; it will shrink when #105 merges; native stack metadata is unavailable for cross-fork heads.

Summary: explicit-account repository snapshot loader; bounded selected-account fan-out; cached-first hydration; per-account freshness/diagnostics/cache summary; last-good partial failures; deterministic account-tagged aggregation; active-account compatibility; account-switch/generation/cancellation guards; scoped cache summary and cached inventory fallback.

Scope note: notifications, Actions, global activity, local scanning, menu/UI grouping, CLI, attention, and settings writes remain active-only/deferred.

Refs #101

Validation already run on the immutable tip:
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=all pnpm test -- --filter MultiAccountRepositoryRefreshTests` (10 passed)
- same environment plus `pnpm check` (format/lint green; 686 tests across 113 suites)

Two focused code-review passes landed the fixes for the active-account switch cross-write race and preserving consolidated active-failure errors.