### PR TITLE
Scope repository state by account

### DIFF
--- a/Sources/RepoBar/App/AccountRepositorySnapshotLoader.swift
+++ b/Sources/RepoBar/App/AccountRepositorySnapshotLoader.swift
@@ -1,0 +1,172 @@
+import Foundation
+import RepoBarCore
+
+struct AccountRepositoryPreferences {
+    let pinned: [String]
+    let hidden: Set<String>
+    let includeForks: Bool
+    let includeArchived: Bool
+    let ownerFilter: [String]
+}
+
+struct AccountRepositorySnapshotRequest {
+    let account: Account
+    let client: GitHubClient
+    let preferences: AccountRepositoryPreferences
+    let now: Date
+}
+
+struct AccountRepositorySnapshot {
+    let account: Account
+    let accessibleRepositories: [Repository]
+    let repositories: [Repository]
+    let capturedAt: Date
+    let diagnostics: DiagnosticsSummary
+    let cacheSummary: RepoBarCacheSummary?
+}
+
+protocol AccountRepositorySnapshotLoading: Sendable {
+    func cachedSnapshot(for request: AccountRepositorySnapshotRequest) async throws -> AccountRepositorySnapshot?
+    func snapshot(for request: AccountRepositorySnapshotRequest) async throws -> AccountRepositorySnapshot
+}
+
+struct AccountRepositorySnapshotLoader: AccountRepositorySnapshotLoading {
+    func cachedSnapshot(for request: AccountRepositorySnapshotRequest) async throws -> AccountRepositorySnapshot? {
+        let repos = try await request.client.cachedRepositoryList(limit: nil)
+        guard repos.isEmpty == false else { return nil }
+
+        return await self.makeSnapshot(repositories: repos, request: request)
+    }
+
+    func snapshot(for request: AccountRepositorySnapshotRequest) async throws -> AccountRepositorySnapshot {
+        let repos = try await request.client.repositoryList(limit: nil)
+        let withPinned = await self.mergePinnedRepositories(
+            into: repos,
+            pinned: request.preferences.pinned,
+            client: request.client
+        )
+        return await self.makeSnapshot(repositories: withPinned, request: request)
+    }
+
+    private func makeSnapshot(
+        repositories: [Repository],
+        request: AccountRepositorySnapshotRequest
+    ) async -> AccountRepositorySnapshot {
+        let accessible = RepositoryUniquing.byFullName(repositories)
+        let visible = AppState.selectVisible(
+            all: accessible,
+            options: AppState.VisibleSelectionOptions(
+                pinned: request.preferences.pinned,
+                hidden: request.preferences.hidden,
+                includeForks: request.preferences.includeForks,
+                includeArchived: request.preferences.includeArchived,
+                limit: Int.max,
+                ownerFilter: request.preferences.ownerFilter
+            )
+        )
+        let ordered = AppState.applyPinnedOrder(to: visible, pinned: request.preferences.pinned)
+        let diagnostics = await request.client.diagnostics()
+        let cacheSummary = try? RepoBarPersistentCache.summary(accountID: request.account.id, limit: 100)
+        return AccountRepositorySnapshot(
+            account: request.account,
+            accessibleRepositories: accessible,
+            repositories: ordered,
+            capturedAt: request.now,
+            diagnostics: diagnostics,
+            cacheSummary: cacheSummary
+        )
+    }
+
+    private func mergePinnedRepositories(
+        into repos: [Repository],
+        pinned: [String],
+        client: GitHubClient
+    ) async -> [Repository] {
+        guard pinned.isEmpty == false else { return repos }
+
+        let existing = Set(repos.map { $0.fullName.lowercased() })
+        let targets = Self.pinnedRepoTargets(from: pinned, excluding: existing)
+        guard targets.isEmpty == false else { return repos }
+
+        let fetched = await withTaskGroup(of: Repository?.self) { group in
+            for target in targets {
+                group.addTask {
+                    do {
+                        return try await client.fullRepository(owner: target.owner, name: target.name)
+                    } catch {
+                        return Self.placeholderRepository(
+                            owner: target.owner,
+                            name: target.name,
+                            error: error.userFacingMessage,
+                            rateLimitedUntil: (error as? GitHubAPIError)?.rateLimitedUntil
+                        )
+                    }
+                }
+            }
+            var output: [Repository] = []
+            for await repo in group {
+                if let repo {
+                    output.append(repo)
+                }
+            }
+            return output
+        }
+        return repos + fetched
+    }
+
+    private static func pinnedRepoTargets(
+        from pinned: [String],
+        excluding existing: Set<String>
+    ) -> [PinnedRepoTarget] {
+        var seen: Set<String> = []
+        var targets: [PinnedRepoTarget] = []
+        for raw in pinned {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            let parts = trimmed.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.count == 2 else { continue }
+
+            let owner = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
+            let name = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
+            guard owner.isEmpty == false, name.isEmpty == false else { continue }
+
+            let normalized = "\(owner)/\(name)".lowercased()
+            guard existing.contains(normalized) == false, seen.insert(normalized).inserted else { continue }
+
+            targets.append(PinnedRepoTarget(owner: owner, name: name))
+        }
+        return targets
+    }
+
+    private static func placeholderRepository(
+        owner: String,
+        name: String,
+        error: String?,
+        rateLimitedUntil: Date?
+    ) -> Repository {
+        Repository(
+            id: "\(owner)/\(name)",
+            name: name,
+            owner: owner,
+            sortOrder: nil,
+            error: error,
+            rateLimitedUntil: rateLimitedUntil,
+            ciStatus: .unknown,
+            ciRunCount: nil,
+            openIssues: 0,
+            openPulls: 0,
+            stars: 0,
+            forks: 0,
+            pushedAt: nil,
+            latestRelease: nil,
+            latestActivity: nil,
+            activityEvents: [],
+            traffic: nil,
+            heatmap: []
+        )
+    }
+
+    private struct PinnedRepoTarget {
+        let owner: String
+        let name: String
+    }
+}

--- a/Sources/RepoBar/App/AppState+AccountRepositoryRefresh.swift
+++ b/Sources/RepoBar/App/AppState+AccountRepositoryRefresh.swift
@@ -1,0 +1,335 @@
+import Foundation
+import RepoBarCore
+
+struct AccountRepositoryRefreshFailure: Error, LocalizedError {
+    let accountID: String
+    let message: String
+    let authenticationFailure: Bool
+    let rateLimitedUntil: Date?
+    let diagnostics: DiagnosticsSummary
+    let cacheSummary: RepoBarCacheSummary?
+
+    var errorDescription: String? {
+        self.message
+    }
+}
+
+struct AccountRepositoryRefreshOutcome {
+    let activeSession: AccountSession?
+    let activeFailure: AccountRepositoryRefreshFailure?
+    let generation: UUID
+    let published: Bool
+}
+
+extension AppState {
+    func selectedAccountIDsForRepositoryRefresh() -> [String] {
+        if self.session.settings.consolidateAccounts {
+            return self.session.settings.visibleAccountIDs
+        }
+        return self.session.settings.resolvedActiveAccount().map { [$0.id] } ?? []
+    }
+
+    func refreshAccountRepositorySnapshots(now: Date = Date()) async -> AccountRepositoryRefreshOutcome {
+        let generation = UUID()
+        self.accountRepositoryRefreshGeneration = generation
+        let settings = self.session.settings
+        let activeAccountID = settings.resolvedActiveAccount()?.id
+        let accountIDs = self.selectedAccountIDsForRepositoryRefresh()
+        let pairs = self.accountManager.accountClientSnapshots(accountIDs: accountIDs)
+
+        self.resetPublishedAccountSessions(to: pairs, activeAccountID: activeAccountID)
+        guard pairs.isEmpty == false else {
+            return AccountRepositoryRefreshOutcome(
+                activeSession: nil,
+                activeFailure: nil,
+                generation: generation,
+                published: true
+            )
+        }
+
+        let cachedResults = await self.loadAccountRepositorySnapshots(
+            pairs: pairs,
+            settings: settings,
+            now: now,
+            cached: true
+        )
+        guard self.canPublishAccountRepositoryRefresh(generation) else {
+            return AccountRepositoryRefreshOutcome(
+                activeSession: nil,
+                activeFailure: nil,
+                generation: generation,
+                published: false
+            )
+        }
+
+        self.publishCachedAccountRepositorySnapshots(
+            cachedResults,
+            pairs: pairs,
+            activeAccountID: activeAccountID,
+            now: now
+        )
+
+        let liveResults = await self.loadAccountRepositorySnapshots(
+            pairs: pairs,
+            settings: settings,
+            now: now,
+            cached: false
+        )
+        guard self.canPublishAccountRepositoryRefresh(generation) else {
+            return AccountRepositoryRefreshOutcome(
+                activeSession: nil,
+                activeFailure: nil,
+                generation: generation,
+                published: false
+            )
+        }
+
+        let activeFailure = self.publishLiveAccountRepositorySnapshots(
+            liveResults,
+            pairs: pairs,
+            activeAccountID: activeAccountID,
+            now: now
+        )
+        return AccountRepositoryRefreshOutcome(
+            activeSession: self.session.accountSessions.first(where: { $0.id == activeAccountID }),
+            activeFailure: activeFailure,
+            generation: generation,
+            published: true
+        )
+    }
+
+    func rebuildAggregatedRepositories() {
+        self.session.aggregatedRepositories = self.session.accountSessions.flatMap { accountSession in
+            accountSession.repositories.map { TaggedRepo(repo: $0, accountID: accountSession.id) }
+        }
+    }
+
+    private func resetPublishedAccountSessions(
+        to pairs: [AccountManager.AccountClientSnapshot],
+        activeAccountID: String?
+    ) {
+        let previous = Dictionary(uniqueKeysWithValues: self.session.accountSessions.map { ($0.id, $0) })
+        self.session.accountSessions = pairs.map { pair in
+            var accountSession = previous[pair.account.id] ?? AccountSession(account: pair.account)
+            accountSession.account = pair.account
+            return accountSession
+        }
+        self.rebuildAggregatedRepositories()
+        self.publishActiveAccountCompatibility(activeAccountID: activeAccountID)
+    }
+
+    private func loadAccountRepositorySnapshots(
+        pairs: [AccountManager.AccountClientSnapshot],
+        settings: UserSettings,
+        now: Date,
+        cached: Bool
+    ) async -> [String: AccountRepositoryLoadResult] {
+        var output: [String: AccountRepositoryLoadResult] = [:]
+        let limit = max(1, self.accountRepositoryRefreshConcurrencyLimit)
+        var start = 0
+        while start < pairs.count {
+            if Task.isCancelled {
+                return output
+            }
+            let end = min(start + limit, pairs.count)
+            let batch = Array(pairs[start ..< end])
+            let batchResults = await withTaskGroup(of: (String, AccountRepositoryLoadResult).self) { group in
+                for pair in batch {
+                    let request = self.snapshotRequest(pair: pair, settings: settings, now: now)
+                    let loader = self.accountRepositorySnapshotLoader
+                    group.addTask {
+                        do {
+                            if cached {
+                                if let snapshot = try await loader.cachedSnapshot(for: request) {
+                                    return (pair.account.id, .snapshot(snapshot))
+                                }
+                                return (pair.account.id, .emptyCache)
+                            }
+                            return try await (pair.account.id, .snapshot(loader.snapshot(for: request)))
+                        } catch {
+                            let diagnostics = await pair.client.diagnostics()
+                            let cacheSummary = try? RepoBarPersistentCache.summary(
+                                accountID: pair.account.id,
+                                limit: 100
+                            )
+                            return (
+                                pair.account.id,
+                                .failure(AccountRepositoryRefreshFailure(
+                                    accountID: pair.account.id,
+                                    message: error.userFacingMessage,
+                                    authenticationFailure: error.isAuthenticationFailure,
+                                    rateLimitedUntil: Self.rateLimitDate(from: error),
+                                    diagnostics: diagnostics,
+                                    cacheSummary: cacheSummary
+                                ))
+                            )
+                        }
+                    }
+                }
+                var results: [(String, AccountRepositoryLoadResult)] = []
+                for await result in group {
+                    results.append(result)
+                }
+                return results
+            }
+            for (accountID, result) in batchResults {
+                output[accountID] = result
+            }
+            start = end
+        }
+        return output
+    }
+
+    private func snapshotRequest(
+        pair: AccountManager.AccountClientSnapshot,
+        settings: UserSettings,
+        now: Date
+    ) -> AccountRepositorySnapshotRequest {
+        let accountID = pair.account.id
+        return AccountRepositorySnapshotRequest(
+            account: pair.account,
+            client: pair.client,
+            preferences: AccountRepositoryPreferences(
+                pinned: settings.accountRepoLists.pinned(
+                    for: accountID,
+                    legacy: settings.repoList.pinnedRepositories
+                ),
+                hidden: Set(settings.accountRepoLists.hidden(
+                    for: accountID,
+                    legacy: settings.repoList.hiddenRepositories
+                )),
+                includeForks: settings.repoList.showForks,
+                includeArchived: settings.repoList.showArchived,
+                ownerFilter: settings.repoList.ownerFilter
+            ),
+            now: now
+        )
+    }
+
+    private func publishCachedAccountRepositorySnapshots(
+        _ results: [String: AccountRepositoryLoadResult],
+        pairs: [AccountManager.AccountClientSnapshot],
+        activeAccountID: String?,
+        now: Date
+    ) {
+        for pair in pairs {
+            guard case let .snapshot(snapshot)? = results[pair.account.id],
+                  let index = self.session.accountSessions.firstIndex(where: { $0.id == pair.account.id })
+            else { continue }
+
+            let previous = self.session.accountSessions[index]
+            guard previous.lastSuccessfulRefreshAt == nil else { continue }
+
+            self.session.accountSessions[index] = AccountSession(
+                account: pair.account,
+                state: .loggedIn(UserIdentity(username: pair.account.username, host: pair.account.host)),
+                repositories: snapshot.repositories,
+                accessibleRepositories: snapshot.accessibleRepositories,
+                rateLimitReset: snapshot.diagnostics.rateLimitReset,
+                diagnostics: snapshot.diagnostics,
+                cacheSummary: snapshot.cacheSummary,
+                lastAttemptAt: now,
+                lastSuccessfulRefreshAt: previous.lastSuccessfulRefreshAt,
+                isStale: true,
+                lastError: nil
+            )
+        }
+        self.rebuildAggregatedRepositories()
+        self.publishActiveAccountCompatibility(activeAccountID: activeAccountID)
+    }
+
+    private func publishLiveAccountRepositorySnapshots(
+        _ results: [String: AccountRepositoryLoadResult],
+        pairs: [AccountManager.AccountClientSnapshot],
+        activeAccountID: String?,
+        now: Date
+    ) -> AccountRepositoryRefreshFailure? {
+        var activeFailure: AccountRepositoryRefreshFailure?
+        for pair in pairs {
+            guard let index = self.session.accountSessions.firstIndex(where: { $0.id == pair.account.id }),
+                  let result = results[pair.account.id]
+            else { continue }
+
+            switch result {
+            case let .snapshot(snapshot):
+                self.session.accountSessions[index] = AccountSession(
+                    account: pair.account,
+                    state: .loggedIn(UserIdentity(username: pair.account.username, host: pair.account.host)),
+                    repositories: snapshot.repositories,
+                    accessibleRepositories: snapshot.accessibleRepositories,
+                    rateLimitReset: snapshot.diagnostics.rateLimitReset,
+                    diagnostics: snapshot.diagnostics,
+                    cacheSummary: snapshot.cacheSummary,
+                    lastAttemptAt: now,
+                    lastSuccessfulRefreshAt: snapshot.capturedAt,
+                    isStale: false,
+                    lastError: nil
+                )
+            case let .failure(failure):
+                var accountSession = self.session.accountSessions[index]
+                accountSession.account = pair.account
+                accountSession.state = failure.authenticationFailure
+                    ? .loggedOut
+                    : .loggedIn(UserIdentity(username: pair.account.username, host: pair.account.host))
+                accountSession.rateLimitReset = failure.rateLimitedUntil ?? failure.diagnostics.rateLimitReset
+                accountSession.diagnostics = failure.diagnostics
+                accountSession.cacheSummary = failure.cacheSummary
+                accountSession.lastAttemptAt = now
+                accountSession.isStale = true
+                accountSession.lastError = failure.message
+                self.session.accountSessions[index] = accountSession
+                if pair.account.id == activeAccountID {
+                    activeFailure = failure
+                }
+            case .emptyCache:
+                break
+            }
+        }
+        self.rebuildAggregatedRepositories()
+        self.publishActiveAccountCompatibility(activeAccountID: activeAccountID)
+        return activeFailure
+    }
+
+    private func publishActiveAccountCompatibility(activeAccountID: String?) {
+        guard let activeAccountID,
+              let active = self.session.accountSessions.first(where: { $0.id == activeAccountID })
+        else {
+            self.session.accessibleRepositories = []
+            self.session.repositories = []
+            self.session.menuSnapshot = nil
+            self.session.menuDisplayIndex = [:]
+            self.session.hasLoadedRepositories = false
+            return
+        }
+
+        self.session.account = active.state
+        self.session.accessibleRepositories = active.accessibleRepositories
+        self.session.repositories = active.repositories
+        let capturedAt = active.lastSuccessfulRefreshAt ?? active.lastAttemptAt ?? Date()
+        self.session.menuSnapshot = MenuSnapshot(
+            repositories: active.repositories,
+            capturedAt: capturedAt
+        )
+        self.session.menuDisplayIndex = self.menuDisplayIndex(for: active.repositories, now: capturedAt)
+        self.session.hasLoadedRepositories = true
+        self.session.rateLimitReset = active.rateLimitReset
+        self.session.lastError = active.lastError
+        NotificationCenter.default.post(name: .menuRepositoriesDidChange, object: nil)
+    }
+
+    func canPublishAccountRepositoryRefresh(_ generation: UUID) -> Bool {
+        Task.isCancelled == false && self.accountRepositoryRefreshGeneration == generation
+    }
+
+    private nonisolated static func rateLimitDate(from error: Error) -> Date? {
+        guard let error = error as? GitHubAPIError else { return nil }
+
+        return error.rateLimitedUntil ?? error.retryAfter
+    }
+}
+
+private enum AccountRepositoryLoadResult {
+    case snapshot(AccountRepositorySnapshot)
+    case emptyCache
+    case failure(AccountRepositoryRefreshFailure)
+}

--- a/Sources/RepoBar/App/AppState+AccountRepositoryRefresh.swift
+++ b/Sources/RepoBar/App/AppState+AccountRepositoryRefresh.swift
@@ -120,7 +120,7 @@ extension AppState {
 
     private func loadAccountRepositorySnapshots(
         pairs: [AccountManager.AccountClientSnapshot],
-        settings: UserSettings,
+        settings _: UserSettings,
         now: Date,
         cached: Bool
     ) async -> [String: AccountRepositoryLoadResult] {
@@ -135,7 +135,7 @@ extension AppState {
             let batch = Array(pairs[start ..< end])
             let batchResults = await withTaskGroup(of: (String, AccountRepositoryLoadResult).self) { group in
                 for pair in batch {
-                    let request = self.snapshotRequest(pair: pair, settings: settings, now: now)
+                    let request = self.snapshotRequest(pair: pair, now: now)
                     let loader = self.accountRepositorySnapshotLoader
                     group.addTask {
                         do {
@@ -182,26 +182,13 @@ extension AppState {
 
     private func snapshotRequest(
         pair: AccountManager.AccountClientSnapshot,
-        settings: UserSettings,
         now: Date
     ) -> AccountRepositorySnapshotRequest {
         let accountID = pair.account.id
         return AccountRepositorySnapshotRequest(
             account: pair.account,
             client: pair.client,
-            preferences: AccountRepositoryPreferences(
-                pinned: settings.accountRepoLists.pinned(
-                    for: accountID,
-                    legacy: settings.repoList.pinnedRepositories
-                ),
-                hidden: Set(settings.accountRepoLists.hidden(
-                    for: accountID,
-                    legacy: settings.repoList.hiddenRepositories
-                )),
-                includeForks: settings.repoList.showForks,
-                includeArchived: settings.repoList.showArchived,
-                ownerFilter: settings.repoList.ownerFilter
-            ),
+            preferences: self.repositoryPreferences(for: accountID),
             now: now
         )
     }

--- a/Sources/RepoBar/App/AppState+Accounts.swift
+++ b/Sources/RepoBar/App/AppState+Accounts.swift
@@ -17,8 +17,10 @@ extension AppState {
             if let migrated = await self.migrateLegacyAccountIfNeeded() {
                 self.session.settings.accounts = [migrated]
                 self.session.settings.activeAccountID = migrated.id
-                self.persistSettings()
             }
+        }
+        if self.session.settings.migrateLegacyRepositoryListsToActiveAccountIfNeeded() {
+            self.persistSettings()
         }
         await manager.bootstrap(from: self.session.settings)
         await self.syncPrimaryGitHubClientToActiveAccount()
@@ -133,6 +135,9 @@ extension AppState {
     ) async {
         guard user.username.isEmpty == false else { return }
 
+        let previousActiveAccountID = self.session.settings.resolvedActiveAccount()?.id
+        _ = self.session.settings.migrateLegacyRepositoryListsToActiveAccountIfNeeded()
+
         let account = Account(
             username: user.username,
             host: host,
@@ -164,7 +169,12 @@ extension AppState {
         } else {
             self.session.settings.accounts.append(account)
         }
-        self.session.settings.activeAccountID = account.id
+        if previousActiveAccountID == nil {
+            self.session.settings.activeAccountID = account.id
+            _ = self.session.settings.migrateLegacyRepositoryListsToActiveAccountIfNeeded()
+        } else {
+            self.session.settings.prepareRepositoryListsForActiveAccountChange(to: account.id)
+        }
         self.mirrorActiveAccountIntoSettings(account)
         self.mirrorActiveAccountCredentialsToLegacy(account)
         self.session.activeAccountID = self.accountManager.activeAccountID
@@ -183,7 +193,7 @@ extension AppState {
         guard self.accountManager.setActive(accountID: accountID) else { return }
 
         self.session.activeAccountID = accountID
-        self.session.settings.activeAccountID = accountID
+        self.session.settings.prepareRepositoryListsForActiveAccountChange(to: accountID)
         if let active = self.accountManager.activeAccount() {
             self.mirrorActiveAccountIntoSettings(active)
             self.mirrorActiveAccountCredentialsToLegacy(active)
@@ -197,12 +207,26 @@ extension AppState {
 
     /// Removes an account, clears its tokens, and updates the active selection.
     func removeAccount(_ accountID: String) async {
+        let wasActive = self.session.settings.resolvedActiveAccount()?.id == accountID
+        _ = self.session.settings.migrateLegacyRepositoryListsToActiveAccountIfNeeded()
+        let nextActiveAccountID = wasActive
+            ? self.session.settings.accounts.first(where: { $0.id != accountID })?.id
+            : self.session.settings.resolvedActiveAccount()?.id
+        if wasActive, let nextActiveAccountID {
+            self.session.settings.prepareRepositoryListsForActiveAccountChange(to: nextActiveAccountID)
+        }
+
         await self.accountManager.remove(accountID: accountID)
         self.session.settings.accounts.removeAll(where: { $0.id == accountID })
         self.session.accountSessions.removeAll(where: { $0.id == accountID })
-        if self.session.settings.activeAccountID == accountID {
-            self.session.settings.activeAccountID = self.session.settings.accounts.first?.id
-            self.session.activeAccountID = self.session.settings.activeAccountID
+        self.session.settings.removeRepositoryLists(for: accountID)
+        if wasActive {
+            self.session.settings.activeAccountID = nextActiveAccountID
+            self.session.activeAccountID = nextActiveAccountID
+            if nextActiveAccountID == nil {
+                self.session.settings.repoList.pinnedRepositories = []
+                self.session.settings.repoList.hiddenRepositories = []
+            }
         }
         if let active = self.accountManager.activeAccount() {
             self.mirrorActiveAccountIntoSettings(active)
@@ -212,12 +236,8 @@ extension AppState {
         }
         await self.syncPrimaryGitHubClientToActiveAccount()
         await self.refreshSessionIdentityFromActiveClient()
-        // Drop any per-account pinned/hidden lists for the removed account.
-        var lists = self.session.settings.accountRepoLists
-        lists.pinnedByAccount.removeValue(forKey: accountID)
-        lists.hiddenByAccount.removeValue(forKey: accountID)
-        self.session.settings.accountRepoLists = lists
         self.persistSettings()
+        NotificationCenter.default.post(name: .accountRepositoryStateDidRemove, object: accountID)
         self.requestRefresh(cancelInFlight: true)
     }
 

--- a/Sources/RepoBar/App/AppState+Activity.swift
+++ b/Sources/RepoBar/App/AppState+Activity.swift
@@ -2,12 +2,6 @@ import Foundation
 import RepoBarCore
 
 extension AppState {
-    func fetchActivityRepos() async throws -> [Repository] {
-        let repos = try await self.github.repositoryList(limit: nil)
-        let pinned = self.session.settings.repoList.pinnedRepositories
-        return await self.mergePinnedRepositories(into: repos, pinned: pinned)
-    }
-
     func fetchGlobalActivityEvents(
         username: String,
         scope: GlobalActivityScope,
@@ -69,107 +63,5 @@ extension AppState {
 
     private func capture<T>(_ work: @escaping () async throws -> T) async -> Result<T, Error> {
         do { return try await .success(work()) } catch { return .failure(error) }
-    }
-
-    private func mergePinnedRepositories(
-        into repos: [Repository],
-        pinned: [String]
-    ) async -> [Repository] {
-        guard !pinned.isEmpty else { return repos }
-
-        let existing = Set(repos.map { $0.fullName.lowercased() })
-        let targets = self.pinnedRepoTargets(from: pinned, excluding: existing)
-        guard !targets.isEmpty else { return repos }
-
-        let fetched = await withTaskGroup(of: Repository?.self) { group in
-            for target in targets {
-                group.addTask { [github] in
-                    do {
-                        return try await github.fullRepository(owner: target.owner, name: target.name)
-                    } catch {
-                        let rateLimitedUntil = (error as? GitHubAPIError)?.rateLimitedUntil
-                        return Self.placeholderRepository(
-                            owner: target.owner,
-                            name: target.name,
-                            error: error.userFacingMessage,
-                            rateLimitedUntil: rateLimitedUntil
-                        )
-                    }
-                }
-            }
-            var out: [Repository] = []
-            for await repo in group {
-                if let repo {
-                    out.append(repo)
-                }
-            }
-            return out
-        }
-
-        return repos + fetched
-    }
-
-    private struct PinnedRepoTarget: Hashable {
-        let owner: String
-        let name: String
-
-        var fullName: String {
-            "\(self.owner)/\(self.name)"
-        }
-    }
-
-    private func pinnedRepoTargets(
-        from pinned: [String],
-        excluding existing: Set<String>
-    ) -> [PinnedRepoTarget] {
-        var seen: Set<String> = []
-        var targets: [PinnedRepoTarget] = []
-        for raw in pinned {
-            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty else { continue }
-
-            let parts = trimmed.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: false)
-            guard parts.count == 2 else { continue }
-
-            let owner = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
-            let name = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !owner.isEmpty, !name.isEmpty else { continue }
-
-            let fullName = "\(owner)/\(name)"
-            let normalized = fullName.lowercased()
-            guard !existing.contains(normalized) else { continue }
-            guard seen.insert(normalized).inserted else { continue }
-
-            targets.append(PinnedRepoTarget(owner: owner, name: name))
-        }
-        return targets
-    }
-
-    private nonisolated static func placeholderRepository(
-        owner: String,
-        name: String,
-        error: String?,
-        rateLimitedUntil: Date?
-    ) -> Repository {
-        Repository(
-            id: "\(owner)/\(name)",
-            name: name,
-            owner: owner,
-            sortOrder: nil,
-            error: error,
-            rateLimitedUntil: rateLimitedUntil,
-            ciStatus: .unknown,
-            ciRunCount: nil,
-            openIssues: 0,
-            openPulls: 0,
-            stars: 0,
-            forks: 0,
-            pushedAt: nil,
-            latestRelease: nil,
-            latestActivity: nil,
-            activityEvents: [],
-            traffic: nil,
-            heatmap: []
-        )
     }
 }

--- a/Sources/RepoBar/App/AppState+Refresh.swift
+++ b/Sources/RepoBar/App/AppState+Refresh.swift
@@ -117,10 +117,7 @@ extension AppState {
             try Task.checkCancellation()
             let hydratedAccessible = self.mergeHydrated(hydrated, into: repos)
             let merged = self.mergeHydrated(hydrated, into: ordered)
-            let activePinned = self.session.settings.accountRepoLists.pinned(
-                for: activeAccountSession.id,
-                legacy: self.session.settings.repoList.pinnedRepositories
-            )
+            let activePinned = self.session.settings.pinnedRepositories(for: activeAccountSession.id)
             let final = Self.applyPinnedOrder(to: merged, pinned: activePinned)
             guard self.publishHydratedActiveRepositorySnapshot(
                 accessibleRepositories: hydratedAccessible,
@@ -419,7 +416,11 @@ extension AppState {
     func menuDisplayIndex(for repos: [Repository], now: Date) -> [String: RepositoryDisplayModel] {
         let localIndex = self.session.localRepoIndex
         let models = repos.map { repo in
-            RepositoryDisplayModel(repo: repo, localStatus: localIndex.status(for: repo), now: now)
+            RepositoryDisplayModel(
+                repo: repo,
+                localStatus: localIndex.status(for: repo, host: self.session.settings.githubHost),
+                now: now
+            )
         }
         return Dictionary(
             models.map { ($0.title.lowercased(), $0) },
@@ -459,7 +460,10 @@ extension AppState {
                 let models = merged.map { repo in
                     RepositoryDisplayModel(
                         repo: repo,
-                        localStatus: self.session.localRepoIndex.status(for: repo),
+                        localStatus: self.session.localRepoIndex.status(
+                            for: repo,
+                            host: self.session.settings.githubHost
+                        ),
                         now: capturedAt
                     )
                 }

--- a/Sources/RepoBar/App/AppState+Refresh.swift
+++ b/Sources/RepoBar/App/AppState+Refresh.swift
@@ -61,20 +61,40 @@ extension AppState {
                 await self.applyLoggedOutState(localSnapshot: localSnapshot, lastError: nil)
                 return
             }
-            await self.applyCachedMenuSnapshotIfAvailable(now: now)
+            let accountRefresh = await self.refreshAccountRepositorySnapshots(now: now)
+            guard accountRefresh.published else { return }
+
+            if let failure = accountRefresh.activeFailure, self.session.settings.consolidateAccounts == false {
+                if failure.authenticationFailure {
+                    await self.handleAuthenticationFailure(failure)
+                    return
+                }
+                throw failure
+            }
+            guard let activeAccountSession = accountRefresh.activeSession else {
+                let localSnapshot = await self.snapshotForLoggedOutState(localSettings: localSettings)
+                await MainActor.run {
+                    self.session.localRepoIndex = localSnapshot.repoIndex
+                    self.session.localDiscoveredRepoCount = localSnapshot.discoveredCount
+                    self.session.localProjectsAccessDenied = localSnapshot.accessDenied
+                    self.session.localProjectsScanInProgress = false
+                }
+                return
+            }
+
             // If we have tokens but no user in session, fetch identity once per launch.
             if case .loggedOut = self.session.account {
                 if let user = try? await self.github.currentUser() {
                     await MainActor.run { self.session.account = .loggedIn(user) }
                 }
             }
-            await self.processGitHubPullRequestNotifications()
-            await self.processGitHubReleaseNotifications()
-            let repos = try await self.fetchActivityRepos()
+            if accountRefresh.activeFailure == nil {
+                await self.processGitHubPullRequestNotifications()
+                await self.processGitHubReleaseNotifications()
+            }
+            let repos = activeAccountSession.accessibleRepositories
             try Task.checkCancellation()
-            await self.updateAccessibleRepositories(repos)
-            let visible = self.applyVisibilityFilters(to: repos)
-            let ordered = self.applyPinnedOrder(to: visible)
+            let ordered = activeAccountSession.repositories
             // The lightweight repository list uses GitHub's open_issues_count, which includes PRs.
             // Only publish the menu snapshot after hydrating real issue/PR counts.
             let matchNames = self.localMatchRepoNamesForLocalProjects(repos: ordered, includePinned: true)
@@ -95,9 +115,21 @@ extension AppState {
             let targets = self.selectMenuTargets(from: ordered)
             let hydrated = await self.hydrateMenuTargets(targets, fetchHeatmap: true)
             try Task.checkCancellation()
-            await self.updateAccessibleRepositories(self.mergeHydrated(hydrated, into: repos))
+            let hydratedAccessible = self.mergeHydrated(hydrated, into: repos)
             let merged = self.mergeHydrated(hydrated, into: ordered)
-            let final = self.applyPinnedOrder(to: merged)
+            let activePinned = self.session.settings.accountRepoLists.pinned(
+                for: activeAccountSession.id,
+                legacy: self.session.settings.repoList.pinnedRepositories
+            )
+            let final = Self.applyPinnedOrder(to: merged, pinned: activePinned)
+            guard self.publishHydratedActiveRepositorySnapshot(
+                accessibleRepositories: hydratedAccessible,
+                repositories: final,
+                accountID: activeAccountSession.id,
+                generation: accountRefresh.generation,
+                now: now
+            ) else { return }
+
             let localSnapshot = await localSnapshotTask.value
             let activityUsername: String? = {
                 guard case let .loggedIn(user) = self.session.account,
@@ -116,8 +148,11 @@ extension AppState {
                     repos: final
                 )
             }
-            await self.updateSession(with: final, now: now)
             let globalActivity = await globalActivityTask.value
+            try self.checkAccountRepositoryRefreshIsCurrent(
+                generation: accountRefresh.generation,
+                accountID: activeAccountSession.id
+            )
             await MainActor.run {
                 self.session.localRepoIndex = localSnapshot.repoIndex
                 self.session.localDiscoveredRepoCount = localSnapshot.discoveredCount
@@ -130,15 +165,34 @@ extension AppState {
                 NotificationCenter.default.post(name: .menuRepositoriesDidChange, object: nil)
             }
             await self.updateMenuDisplayIndex(now: now)
+            try self.checkAccountRepositoryRefreshIsCurrent(
+                generation: accountRefresh.generation,
+                accountID: activeAccountSession.id
+            )
             self.prefetchMenuTargets(from: final, visibleCount: targets.count, token: self.refreshTaskToken)
             await self.refreshRateLimitDisplayState()
+            try self.checkAccountRepositoryRefreshIsCurrent(
+                generation: accountRefresh.generation,
+                accountID: activeAccountSession.id
+            )
             await self.refreshActionsLimitsState()
+            try self.checkAccountRepositoryRefreshIsCurrent(
+                generation: accountRefresh.generation,
+                accountID: activeAccountSession.id
+            )
             let message = await self.github.rateLimitMessage(now: now)
+            try self.checkAccountRepositoryRefreshIsCurrent(
+                generation: accountRefresh.generation,
+                accountID: activeAccountSession.id
+            )
             await MainActor.run {
-                self.session.lastError = message
+                self.session.lastError = message ?? accountRefresh.activeFailure?.message
                 NotificationCenter.default.post(name: .menuDiagnosticsDidChange, object: nil)
             }
         } catch {
+            if error is CancellationError {
+                return
+            }
             if error.isAuthenticationFailure {
                 await self.handleAuthenticationFailure(error)
                 return
@@ -158,6 +212,10 @@ extension AppState {
     }
 
     private func hasAuthenticationMaterial() async -> Bool {
+        if self.session.settings.accounts.isEmpty == false {
+            let selectedIDs = self.selectedAccountIDsForRepositoryRefresh()
+            return self.accountManager.accountClientSnapshots(accountIDs: selectedIDs).isEmpty == false
+        }
         if let accountID = self.session.settings.resolvedActiveAccount()?.id {
             return (try? TokenStore.shared.loadTokens(accountID: accountID)) != nil
                 || (try? TokenStore.shared.loadPAT(accountID: accountID)) != nil
@@ -286,6 +344,8 @@ extension AppState {
             self.session.hasStoredTokens = false
             self.session.accessibleRepositories = []
             self.session.repositories = []
+            self.session.accountSessions = []
+            self.session.aggregatedRepositories = []
             self.session.menuSnapshot = nil
             self.session.menuDisplayIndex = [:]
             self.session.hasLoadedRepositories = false
@@ -309,32 +369,41 @@ extension AppState {
         RepositoryHydration.merge(detailed, into: repos)
     }
 
-    private func applyCachedMenuSnapshotIfAvailable(now: Date) async {
-        guard let repos = try? await self.github.cachedRepositoryList(limit: nil), repos.isEmpty == false else { return }
+    @discardableResult
+    func publishHydratedActiveRepositorySnapshot(
+        accessibleRepositories: [Repository],
+        repositories: [Repository],
+        accountID: String,
+        generation: UUID,
+        now: Date
+    ) -> Bool {
+        guard self.canContinueAccountRepositoryRefresh(generation: generation, accountID: accountID),
+              let accountIndex = self.session.accountSessions.firstIndex(where: { $0.id == accountID })
+        else { return false }
 
-        await self.updateAccessibleRepositories(repos)
-        let visible = self.applyVisibilityFilters(to: repos)
-        let ordered = self.applyPinnedOrder(to: visible)
-        await self.updateSession(with: ordered, now: now)
+        let accessible = RepositoryUniquing.byFullName(accessibleRepositories)
+        self.session.accessibleRepositories = accessible
+        self.session.repositories = repositories
+        self.session.menuSnapshot = MenuSnapshot(repositories: repositories, capturedAt: now)
+        self.session.menuDisplayIndex = self.menuDisplayIndex(for: repositories, now: now)
+        self.session.hasLoadedRepositories = true
+        self.session.rateLimitReset = nil
+        self.session.lastError = nil
+        self.session.accountSessions[accountIndex].accessibleRepositories = accessible
+        self.session.accountSessions[accountIndex].repositories = repositories
+        self.rebuildAggregatedRepositories()
+        NotificationCenter.default.post(name: .menuRepositoriesDidChange, object: nil)
+        return true
     }
 
-    private func updateSession(with repos: [Repository], now: Date) async {
-        let index = self.menuDisplayIndex(for: repos, now: now)
-        await MainActor.run {
-            self.session.repositories = repos
-            self.session.menuSnapshot = MenuSnapshot(repositories: repos, capturedAt: now)
-            self.session.menuDisplayIndex = index
-            self.session.hasLoadedRepositories = true
-            self.session.rateLimitReset = nil
-            self.session.lastError = nil
-            NotificationCenter.default.post(name: .menuRepositoriesDidChange, object: nil)
-        }
+    private func canContinueAccountRepositoryRefresh(generation: UUID, accountID: String) -> Bool {
+        self.canPublishAccountRepositoryRefresh(generation)
+            && self.session.activeAccountID == accountID
     }
 
-    private func updateAccessibleRepositories(_ repos: [Repository]) async {
-        let uniqueRepos = RepositoryUniquing.byFullName(repos)
-        await MainActor.run {
-            self.session.accessibleRepositories = uniqueRepos
+    private func checkAccountRepositoryRefreshIsCurrent(generation: UUID, accountID: String) throws {
+        guard self.canContinueAccountRepositoryRefresh(generation: generation, accountID: accountID) else {
+            throw CancellationError()
         }
     }
 
@@ -347,7 +416,7 @@ extension AppState {
         }
     }
 
-    private func menuDisplayIndex(for repos: [Repository], now: Date) -> [String: RepositoryDisplayModel] {
+    func menuDisplayIndex(for repos: [Repository], now: Date) -> [String: RepositoryDisplayModel] {
         let localIndex = self.session.localRepoIndex
         let models = repos.map { repo in
             RepositoryDisplayModel(repo: repo, localStatus: localIndex.status(for: repo), now: now)

--- a/Sources/RepoBar/App/AppState+Refresh.swift
+++ b/Sources/RepoBar/App/AppState+Refresh.swift
@@ -418,7 +418,7 @@ extension AppState {
         let models = repos.map { repo in
             RepositoryDisplayModel(
                 repo: repo,
-                localStatus: localIndex.status(for: repo, host: self.session.settings.githubHost),
+                localStatus: localIndex.status(for: repo, host: self.session.settings.resolvedRepositoryHost),
                 now: now
             )
         }
@@ -462,7 +462,7 @@ extension AppState {
                         repo: repo,
                         localStatus: self.session.localRepoIndex.status(
                             for: repo,
-                            host: self.session.settings.githubHost
+                            host: self.session.settings.resolvedRepositoryHost
                         ),
                         now: capturedAt
                     )

--- a/Sources/RepoBar/App/AppState+Visibility.swift
+++ b/Sources/RepoBar/App/AppState+Visibility.swift
@@ -55,15 +55,18 @@ extension AppState {
     }
 
     func applyPinnedOrder(to repos: [Repository]) -> [Repository] {
-        let pinned = self.session.settings.repoList.pinnedRepositories
+        Self.applyPinnedOrder(to: repos, pinned: self.session.settings.repoList.pinnedRepositories)
+    }
+
+    nonisolated static func applyPinnedOrder(to repos: [Repository], pinned: [String]) -> [Repository] {
         let pinnedIndex = pinned.enumerated().reduce(into: [String: Int]()) { dict, entry in
-            let key = self.normalizedFullName(entry.element)
+            let key = Self.normalizedFullName(entry.element)
             if dict[key] == nil {
                 dict[key] = entry.offset
             }
         }
         return repos.map { repo in
-            if let idx = pinnedIndex[self.normalizedFullName(repo.fullName)] {
+            if let idx = pinnedIndex[Self.normalizedFullName(repo.fullName)] {
                 return repo.withOrder(idx)
             }
             return repo
@@ -183,8 +186,12 @@ extension AppState {
         }
     }
 
-    private func normalizedFullName(_ value: String) -> String {
+    private nonisolated static func normalizedFullName(_ value: String) -> String {
         value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private func normalizedFullName(_ value: String) -> String {
+        Self.normalizedFullName(value)
     }
 }
 

--- a/Sources/RepoBar/App/AppState+Visibility.swift
+++ b/Sources/RepoBar/App/AppState+Visibility.swift
@@ -6,7 +6,7 @@ extension AppState {
         var names = Set(repos.map(\.name))
         guard includePinned else { return names }
 
-        let pinned = self.session.settings.repoList.pinnedRepositories
+        let pinned = self.activePinnedRepositories
         for fullName in pinned {
             if let last = fullName.split(separator: "/").last {
                 names.insert(String(last))
@@ -16,13 +16,22 @@ extension AppState {
     }
 
     func applyVisibilityFilters(to repos: [Repository]) -> [Repository] {
+        guard let accountID = self.resolvedActiveRepositoryAccountID else {
+            return self.applyLegacyVisibilityFilters(to: repos)
+        }
+
+        return self.applyVisibilityFilters(to: repos, accountID: accountID)
+    }
+
+    func applyVisibilityFilters(to repos: [Repository], accountID: String) -> [Repository] {
+        let preferences = self.repositoryPreferences(for: accountID)
         let options = AppState.VisibleSelectionOptions(
-            pinned: self.session.settings.repoList.pinnedRepositories,
-            hidden: Set(self.session.settings.repoList.hiddenRepositories),
-            includeForks: self.session.settings.repoList.showForks,
-            includeArchived: self.session.settings.repoList.showArchived,
+            pinned: preferences.pinned,
+            hidden: preferences.hidden,
+            includeForks: preferences.includeForks,
+            includeArchived: preferences.includeArchived,
             limit: Int.max,
-            ownerFilter: self.session.settings.repoList.ownerFilter
+            ownerFilter: preferences.ownerFilter
         )
         return AppState.selectVisible(all: repos, options: options)
     }
@@ -34,6 +43,8 @@ extension AppState {
     private func menuQuery() -> RepositoryQuery {
         let selection = self.session.menuRepoSelection
         let settings = self.session.settings
+        let pinned = self.activePinnedRepositories
+        let hidden = self.activeHiddenRepositories
         let scope: RepositoryScope = selection.isPinnedScope ? .pinned : .all
         let ageCutoff = RepositoryQueryDefaults.ageCutoff(
             scope: scope,
@@ -47,15 +58,19 @@ extension AppState {
             sortKey: settings.repoList.menuSortKey,
             limit: settings.repoList.displayLimit,
             ageCutoff: ageCutoff,
-            pinned: settings.repoList.pinnedRepositories,
-            hidden: Set(settings.repoList.hiddenRepositories),
+            pinned: pinned,
+            hidden: Set(hidden),
             pinPriority: true,
             ownerFilter: settings.repoList.ownerFilter
         )
     }
 
     func applyPinnedOrder(to repos: [Repository]) -> [Repository] {
-        Self.applyPinnedOrder(to: repos, pinned: self.session.settings.repoList.pinnedRepositories)
+        Self.applyPinnedOrder(to: repos, pinned: self.activePinnedRepositories)
+    }
+
+    func applyPinnedOrder(to repos: [Repository], accountID: String) -> [Repository] {
+        Self.applyPinnedOrder(to: repos, pinned: self.session.settings.pinnedRepositories(for: accountID))
     }
 
     nonisolated static func applyPinnedOrder(to repos: [Repository], pinned: [String]) -> [Repository] {
@@ -74,75 +89,201 @@ extension AppState {
     }
 
     func addPinned(_ fullName: String) async {
-        guard self.session.settings.repoList.pinRepository(fullName) else { return }
+        guard let accountID = self.resolvedActiveRepositoryAccountID else {
+            guard self.session.settings.repoList.pinRepository(fullName) else { return }
 
-        self.settingsStore.save(self.session.settings)
-        await self.refresh()
+            self.persistSettings()
+            await self.refresh()
+            return
+        }
+
+        await self.addPinned(fullName, accountID: accountID)
+    }
+
+    func addPinned(_ fullName: String, accountID: String) async {
+        let normalized = Self.normalizedFullName(fullName)
+        guard normalized.isEmpty == false else { return }
+
+        var pinned = self.session.settings.pinnedRepositories(for: accountID)
+        var hidden = self.session.settings.hiddenRepositories(for: accountID)
+        let alreadyPinned = pinned.contains { Self.normalizedFullName($0) == normalized }
+        let wasHidden = hidden.contains { Self.normalizedFullName($0) == normalized }
+        guard alreadyPinned == false || wasHidden else { return }
+
+        if alreadyPinned == false {
+            pinned.append(fullName.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+        hidden.removeAll { Self.normalizedFullName($0) == normalized }
+        self.session.settings.setPinnedRepositories(pinned, for: accountID)
+        self.session.settings.setHiddenRepositories(hidden, for: accountID)
+        await self.finishRepositoryPreferenceMutation(accountID: accountID)
     }
 
     func removePinned(_ fullName: String) async {
-        let normalized = self.normalizedFullName(fullName)
-        self.session.settings.repoList.pinnedRepositories.removeAll {
-            self.normalizedFullName($0) == normalized
+        guard let accountID = self.resolvedActiveRepositoryAccountID else {
+            let normalized = Self.normalizedFullName(fullName)
+            self.session.settings.repoList.pinnedRepositories.removeAll {
+                Self.normalizedFullName($0) == normalized
+            }
+            self.persistSettings()
+            await self.refresh()
+            return
         }
-        self.settingsStore.save(self.session.settings)
-        await self.refresh()
+
+        await self.removePinned(fullName, accountID: accountID)
+    }
+
+    func removePinned(_ fullName: String, accountID: String) async {
+        let normalized = Self.normalizedFullName(fullName)
+        var pinned = self.session.settings.pinnedRepositories(for: accountID)
+        let previousCount = pinned.count
+        pinned.removeAll { Self.normalizedFullName($0) == normalized }
+        guard pinned.count != previousCount else { return }
+
+        self.session.settings.setPinnedRepositories(pinned, for: accountID)
+        await self.finishRepositoryPreferenceMutation(accountID: accountID)
     }
 
     func hide(_ fullName: String) async {
-        let normalized = self.normalizedFullName(fullName)
-        guard !self.session.settings.repoList.hiddenRepositories.contains(where: {
-            self.normalizedFullName($0) == normalized
-        }) else { return }
+        guard let accountID = self.resolvedActiveRepositoryAccountID else {
+            let normalized = Self.normalizedFullName(fullName)
+            guard !self.session.settings.repoList.hiddenRepositories.contains(where: {
+                Self.normalizedFullName($0) == normalized
+            }) else { return }
 
-        self.session.settings.repoList.hiddenRepositories.append(fullName)
-        // If hidden, also unpin to avoid stale pin list.
-        self.session.settings.repoList.pinnedRepositories.removeAll {
-            self.normalizedFullName($0) == normalized
+            self.session.settings.repoList.hiddenRepositories.append(fullName)
+            self.session.settings.repoList.pinnedRepositories.removeAll {
+                Self.normalizedFullName($0) == normalized
+            }
+            self.persistSettings()
+            self.session.repositories.removeAll {
+                Self.normalizedFullName($0.fullName) == normalized
+            }
+            await self.refresh()
+            return
         }
-        self.settingsStore.save(self.session.settings)
-        self.session.repositories.removeAll {
-            self.normalizedFullName($0.fullName) == normalized
+
+        await self.hide(fullName, accountID: accountID)
+    }
+
+    func hide(_ fullName: String, accountID: String) async {
+        let trimmed = fullName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalized = Self.normalizedFullName(trimmed)
+        guard normalized.isEmpty == false else { return }
+
+        var pinned = self.session.settings.pinnedRepositories(for: accountID)
+        var hidden = self.session.settings.hiddenRepositories(for: accountID)
+        let alreadyHidden = hidden.contains { Self.normalizedFullName($0) == normalized }
+        let wasPinned = pinned.contains { Self.normalizedFullName($0) == normalized }
+        guard alreadyHidden == false || wasPinned else { return }
+
+        if alreadyHidden == false {
+            hidden.append(trimmed)
         }
-        await self.refresh()
+        pinned.removeAll { Self.normalizedFullName($0) == normalized }
+        self.session.settings.setPinnedRepositories(pinned, for: accountID)
+        self.session.settings.setHiddenRepositories(hidden, for: accountID)
+        if self.isActiveRepositoryAccount(accountID) {
+            self.session.repositories.removeAll {
+                Self.normalizedFullName($0.fullName) == normalized
+            }
+        }
+        await self.finishRepositoryPreferenceMutation(accountID: accountID)
     }
 
     func unhide(_ fullName: String) async {
-        let normalized = self.normalizedFullName(fullName)
-        self.session.settings.repoList.hiddenRepositories.removeAll {
-            self.normalizedFullName($0) == normalized
+        guard let accountID = self.resolvedActiveRepositoryAccountID else {
+            let normalized = Self.normalizedFullName(fullName)
+            self.session.settings.repoList.hiddenRepositories.removeAll {
+                Self.normalizedFullName($0) == normalized
+            }
+            self.persistSettings()
+            await self.refresh()
+            return
         }
-        self.settingsStore.save(self.session.settings)
-        await self.refresh()
+
+        await self.unhide(fullName, accountID: accountID)
+    }
+
+    func unhide(_ fullName: String, accountID: String) async {
+        let normalized = Self.normalizedFullName(fullName)
+        var hidden = self.session.settings.hiddenRepositories(for: accountID)
+        let previousCount = hidden.count
+        hidden.removeAll { Self.normalizedFullName($0) == normalized }
+        guard hidden.count != previousCount else { return }
+
+        self.session.settings.setHiddenRepositories(hidden, for: accountID)
+        await self.finishRepositoryPreferenceMutation(accountID: accountID)
     }
 
     /// Sets a repository's visibility in one place, keeping pinned/hidden arrays consistent.
     func setVisibility(for fullName: String, to visibility: RepoVisibility) async {
-        // Always trim first to avoid storing whitespace variants.
+        guard let accountID = self.resolvedActiveRepositoryAccountID else {
+            await self.setLegacyVisibility(for: fullName, to: visibility)
+            return
+        }
+
+        await self.setVisibility(for: fullName, to: visibility, accountID: accountID)
+    }
+
+    func setVisibility(for fullName: String, to visibility: RepoVisibility, accountID: String) async {
         let trimmed = fullName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
 
-        let normalized = self.normalizedFullName(trimmed)
-
-        // Remove from both buckets before re-adding.
-        self.session.settings.repoList.pinnedRepositories.removeAll {
-            self.normalizedFullName($0) == normalized
-        }
-        self.session.settings.repoList.hiddenRepositories.removeAll {
-            self.normalizedFullName($0) == normalized
-        }
+        let normalized = Self.normalizedFullName(trimmed)
+        var pinned = self.session.settings.pinnedRepositories(for: accountID)
+        var hidden = self.session.settings.hiddenRepositories(for: accountID)
+        pinned.removeAll { Self.normalizedFullName($0) == normalized }
+        hidden.removeAll { Self.normalizedFullName($0) == normalized }
 
         switch visibility {
         case .pinned:
-            self.session.settings.repoList.pinnedRepositories.append(trimmed)
+            pinned.append(trimmed)
         case .hidden:
-            self.session.settings.repoList.hiddenRepositories.append(trimmed)
+            hidden.append(trimmed)
         case .visible:
             break
         }
 
-        self.settingsStore.save(self.session.settings)
-        await self.refresh()
+        self.session.settings.setPinnedRepositories(pinned, for: accountID)
+        self.session.settings.setHiddenRepositories(hidden, for: accountID)
+        await self.finishRepositoryPreferenceMutation(accountID: accountID)
+    }
+
+    func movePinned(_ fullName: String, direction: Int) async {
+        guard let accountID = self.resolvedActiveRepositoryAccountID else {
+            var pinned = self.session.settings.repoList.pinnedRepositories
+            guard Self.movePinned(fullName, direction: direction, in: &pinned) else { return }
+
+            self.session.settings.repoList.pinnedRepositories = pinned
+            self.persistSettings()
+            self.requestRefresh(cancelInFlight: true)
+            return
+        }
+
+        await self.movePinned(fullName, direction: direction, accountID: accountID)
+    }
+
+    func movePinned(_ fullName: String, direction: Int, accountID: String) async {
+        var pinned = self.session.settings.pinnedRepositories(for: accountID)
+        guard Self.movePinned(fullName, direction: direction, in: &pinned) else { return }
+
+        self.session.settings.setPinnedRepositories(pinned, for: accountID)
+        self.persistSettings()
+        if self.isActiveRepositoryAccount(accountID) {
+            self.requestRefresh(cancelInFlight: true)
+        }
+    }
+
+    func repositoryPreferences(for accountID: String) -> AccountRepositoryPreferences {
+        let settings = self.session.settings
+        return AccountRepositoryPreferences(
+            pinned: settings.pinnedRepositories(for: accountID),
+            hidden: Set(settings.hiddenRepositories(for: accountID)),
+            includeForks: settings.repoList.showForks,
+            includeArchived: settings.repoList.showArchived,
+            ownerFilter: settings.repoList.ownerFilter
+        )
     }
 
     struct VisibleSelectionOptions {
@@ -186,12 +327,93 @@ extension AppState {
         }
     }
 
-    private nonisolated static func normalizedFullName(_ value: String) -> String {
-        value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    private var resolvedActiveRepositoryAccountID: String? {
+        self.session.settings.resolvedActiveAccount()?.id
     }
 
-    private func normalizedFullName(_ value: String) -> String {
-        Self.normalizedFullName(value)
+    var activePinnedRepositories: [String] {
+        guard let accountID = self.resolvedActiveRepositoryAccountID else {
+            return self.session.settings.repoList.pinnedRepositories
+        }
+
+        return self.session.settings.pinnedRepositories(for: accountID)
+    }
+
+    var activeHiddenRepositories: [String] {
+        guard let accountID = self.resolvedActiveRepositoryAccountID else {
+            return self.session.settings.repoList.hiddenRepositories
+        }
+
+        return self.session.settings.hiddenRepositories(for: accountID)
+    }
+
+    private func isActiveRepositoryAccount(_ accountID: String) -> Bool {
+        self.resolvedActiveRepositoryAccountID == accountID
+    }
+
+    private func applyLegacyVisibilityFilters(to repos: [Repository]) -> [Repository] {
+        let settings = self.session.settings
+        return Self.selectVisible(
+            all: repos,
+            options: VisibleSelectionOptions(
+                pinned: settings.repoList.pinnedRepositories,
+                hidden: Set(settings.repoList.hiddenRepositories),
+                includeForks: settings.repoList.showForks,
+                includeArchived: settings.repoList.showArchived,
+                limit: Int.max,
+                ownerFilter: settings.repoList.ownerFilter
+            )
+        )
+    }
+
+    private func setLegacyVisibility(for fullName: String, to visibility: RepoVisibility) async {
+        let trimmed = fullName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.isEmpty == false else { return }
+
+        let normalized = Self.normalizedFullName(trimmed)
+        self.session.settings.repoList.pinnedRepositories.removeAll {
+            Self.normalizedFullName($0) == normalized
+        }
+        self.session.settings.repoList.hiddenRepositories.removeAll {
+            Self.normalizedFullName($0) == normalized
+        }
+        switch visibility {
+        case .pinned:
+            self.session.settings.repoList.pinnedRepositories.append(trimmed)
+        case .hidden:
+            self.session.settings.repoList.hiddenRepositories.append(trimmed)
+        case .visible:
+            break
+        }
+        self.persistSettings()
+        await self.refresh()
+    }
+
+    private func finishRepositoryPreferenceMutation(accountID: String) async {
+        self.persistSettings()
+        if self.isActiveRepositoryAccount(accountID) {
+            await self.refresh()
+        }
+    }
+
+    private nonisolated static func movePinned(_ fullName: String, direction: Int, in pinned: inout [String]) -> Bool {
+        guard let currentIndex = pinned.firstIndex(where: {
+            $0.caseInsensitiveCompare(fullName) == .orderedSame
+        }) else { return false }
+
+        let maxIndex = max(pinned.count - 1, 0)
+        let target = max(0, min(maxIndex, currentIndex + direction))
+        guard target != currentIndex else { return false }
+
+        pinned.move(
+            fromOffsets: IndexSet(integer: currentIndex),
+            toOffset: target > currentIndex ? target + 1 : target
+        )
+        return true
+    }
+
+    private nonisolated static func normalizedFullName(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 }
 

--- a/Sources/RepoBar/App/AppState.swift
+++ b/Sources/RepoBar/App/AppState.swift
@@ -14,6 +14,7 @@ final class AppState {
     let legacyGitHub: GitHubClient
     var github: GitHubClient
     let accountManager: AccountManager
+    let accountRepositorySnapshotLoader: any AccountRepositorySnapshotLoading
     let refreshScheduler = RefreshScheduler()
     let settingsStore: SettingsStore
     let gitHubPullRequestNotificationRunner = GitHubPullRequestNotificationRunner()
@@ -29,7 +30,9 @@ final class AppState {
     private var gitHubReferenceResolutionID = UUID()
     private var lifecycleID = UUID()
     var refreshTaskToken = UUID()
+    var accountRepositoryRefreshGeneration = UUID()
     let hydrateConcurrencyLimit = 4
+    let accountRepositoryRefreshConcurrencyLimit = 3
     var prefetchTask: Task<Void, Never>?
     private let tokenRefreshInterval: TimeInterval = 300
     let menuRefreshDebounceInterval: TimeInterval = 1
@@ -45,13 +48,15 @@ final class AppState {
 
     init(
         settingsStore: SettingsStore = SettingsStore(),
-        accountManager: AccountManager? = nil
+        accountManager: AccountManager? = nil,
+        accountRepositorySnapshotLoader: any AccountRepositorySnapshotLoading = AccountRepositorySnapshotLoader()
     ) {
         let legacyGitHub = GitHubClient()
         self.legacyGitHub = legacyGitHub
         self.github = legacyGitHub
         self.settingsStore = settingsStore
         self.accountManager = accountManager ?? AccountManager()
+        self.accountRepositorySnapshotLoader = accountRepositorySnapshotLoader
         self.session.settings = self.settingsStore.load()
         self.reloadRateLimitCacheSummary()
         RepoBarLogging.bootstrapIfNeeded()

--- a/Sources/RepoBar/App/Session+MultiAccount.swift
+++ b/Sources/RepoBar/App/Session+MultiAccount.swift
@@ -4,13 +4,18 @@ import RepoBarCore
 /// Per-account session snapshot. Populated by `AccountManager` and consumed by
 /// `Session` to expose a multi-account view while keeping the existing
 /// single-account fast path source compatible.
-struct AccountSession: Identifiable, Equatable {
+struct AccountSession: Identifiable {
     let id: String
     var account: Account
     var state: AccountState
     var repositories: [Repository]
     var accessibleRepositories: [Repository]
     var rateLimitReset: Date?
+    var diagnostics: DiagnosticsSummary?
+    var cacheSummary: RepoBarCacheSummary?
+    var lastAttemptAt: Date?
+    var lastSuccessfulRefreshAt: Date?
+    var isStale: Bool
     var lastError: String?
 
     init(
@@ -19,6 +24,11 @@ struct AccountSession: Identifiable, Equatable {
         repositories: [Repository] = [],
         accessibleRepositories: [Repository] = [],
         rateLimitReset: Date? = nil,
+        diagnostics: DiagnosticsSummary? = nil,
+        cacheSummary: RepoBarCacheSummary? = nil,
+        lastAttemptAt: Date? = nil,
+        lastSuccessfulRefreshAt: Date? = nil,
+        isStale: Bool = false,
         lastError: String? = nil
     ) {
         self.id = account.id
@@ -27,6 +37,11 @@ struct AccountSession: Identifiable, Equatable {
         self.repositories = repositories
         self.accessibleRepositories = accessibleRepositories
         self.rateLimitReset = rateLimitReset
+        self.diagnostics = diagnostics
+        self.cacheSummary = cacheSummary
+        self.lastAttemptAt = lastAttemptAt
+        self.lastSuccessfulRefreshAt = lastSuccessfulRefreshAt
+        self.isStale = isStale
         self.lastError = lastError
     }
 }

--- a/Sources/RepoBar/Auth/AccountManager.swift
+++ b/Sources/RepoBar/Auth/AccountManager.swift
@@ -2,6 +2,20 @@ import Foundation
 import OSLog
 import RepoBarCore
 
+enum AccountManagerError: LocalizedError, Equatable {
+    case unknownAccount(String)
+    case clientUnavailable(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .unknownAccount(accountID):
+            "Unknown GitHub account: \(accountID)"
+        case let .clientUnavailable(accountID):
+            "GitHub client is unavailable for account: \(accountID)"
+        }
+    }
+}
+
 /// Owns per-account `GitHubClient` instances and their auth state.
 ///
 /// Bootstrapped from `UserSettings.accounts`. Each account gets its own
@@ -48,6 +62,17 @@ final class AccountManager {
     /// Looks up the per-account `GitHubClient`. Returns `nil` when the account is unknown.
     func client(for accountID: String) -> GitHubClient? {
         self.clients[accountID]
+    }
+
+    func resolveClient(for accountID: String) throws -> GitHubClient {
+        guard self.accounts.contains(where: { $0.id == accountID }) else {
+            throw AccountManagerError.unknownAccount(accountID)
+        }
+        guard let client = self.clients[accountID] else {
+            throw AccountManagerError.clientUnavailable(accountID)
+        }
+
+        return client
     }
 
     /// The `GitHubClient` for the currently active account, if any.

--- a/Sources/RepoBar/Auth/AccountManager.swift
+++ b/Sources/RepoBar/Auth/AccountManager.swift
@@ -9,19 +9,27 @@ import RepoBarCore
 /// from the account-scoped `TokenStore` APIs (Phase 1).
 @MainActor
 final class AccountManager {
+    struct AccountClientSnapshot {
+        let account: Account
+        let client: GitHubClient
+    }
+
     private(set) var accounts: [Account] = []
     private(set) var activeAccountID: String?
     private var clients: [String: GitHubClient] = [:]
     private let tokenStore: TokenStore
     private let oauthRefresher: OAuthTokenRefresher
+    private let clientFactory: ((Account) -> GitHubClient)?
     private let signposter = OSSignposter(subsystem: "com.steipete.repobar", category: "account-manager")
 
     init(
         tokenStore: TokenStore = .shared,
-        oauthRefresher: OAuthTokenRefresher? = nil
+        oauthRefresher: OAuthTokenRefresher? = nil,
+        clientFactory: ((Account) -> GitHubClient)? = nil
     ) {
         self.tokenStore = tokenStore
         self.oauthRefresher = oauthRefresher ?? OAuthTokenRefresher(tokenStore: tokenStore)
+        self.clientFactory = clientFactory
     }
 
     // MARK: - Bootstrap
@@ -53,6 +61,18 @@ final class AccountManager {
         guard let activeAccountID else { return nil }
 
         return self.accounts.first(where: { $0.id == activeAccountID })
+    }
+
+    func accountClientSnapshots(accountIDs: [String]) -> [AccountClientSnapshot] {
+        let selected = Set(accountIDs)
+        return self.accounts.compactMap { account in
+            guard selected.contains(account.id),
+                  self.hasStoredCredentials(accountID: account.id),
+                  let client = self.clients[account.id]
+            else { return nil }
+
+            return AccountClientSnapshot(account: account, client: client)
+        }
     }
 
     func hasStoredCredentials(accountID: String) -> Bool {
@@ -173,7 +193,7 @@ final class AccountManager {
     // MARK: - Private
 
     private func makeClient(for account: Account) async {
-        let client = GitHubClient(accountID: account.id)
+        let client = self.clientFactory?(account) ?? GitHubClient(accountID: account.id)
         await client.setAPIHost(account.apiHost)
         let accountID = account.id
         let store = self.tokenStore

--- a/Sources/RepoBar/StatusBar/ChangelogMenuCoordinator.swift
+++ b/Sources/RepoBar/StatusBar/ChangelogMenuCoordinator.swift
@@ -9,9 +9,9 @@ final class ChangelogMenuCoordinator {
     private let menuBuilder: StatusBarMenuBuilder
     private let menuItemFactory: MenuItemViewFactory
     private var menus: [ObjectIdentifier: ChangelogMenuEntry] = [:]
-    private var cache: [String: ChangelogCacheEntry] = [:]
-    private var cacheOrder: [String] = []
-    private var inflight: [String: Task<ChangelogFetchResult, Never>] = [:]
+    private var cache: [AccountScopedCacheKey: ChangelogCacheEntry] = [:]
+    private var cacheOrder: [AccountScopedCacheKey] = []
+    private var inflight: [AccountScopedCacheKey: Task<ChangelogFetchResult, Never>] = [:]
 
     init(appState: AppState, menuBuilder: StatusBarMenuBuilder, menuItemFactory: MenuItemViewFactory) {
         self.appState = appState
@@ -19,9 +19,15 @@ final class ChangelogMenuCoordinator {
         self.menuItemFactory = menuItemFactory
     }
 
-    func registerChangelogMenu(_ menu: NSMenu, fullName: String, localStatus: LocalRepoStatus?) {
+    func registerChangelogMenu(
+        _ menu: NSMenu,
+        accountID: String,
+        fullName: String,
+        localStatus: LocalRepoStatus?
+    ) {
         self.menus[ObjectIdentifier(menu)] = ChangelogMenuEntry(
             menu: menu,
+            accountID: accountID,
             fullName: fullName,
             localPath: localStatus?.path
         )
@@ -44,70 +50,88 @@ final class ChangelogMenuCoordinator {
     }
 
     func cachedPresentation(fullName: String, releaseTag: String?) -> ChangelogRowPresentation? {
-        guard var entry = self.cache[fullName],
+        guard let accountID = self.appState.session.settings.resolvedActiveAccount()?.id else { return nil }
+
+        let cacheKey = AccountScopedCacheKey(accountID: accountID, key: fullName)
+        guard var entry = self.cache[cacheKey],
               let parsed = entry.parsed
         else { return nil }
 
         let key = releaseTag ?? "__none__"
         if let cached = entry.presentationCache[key] {
-            self.touchCache(fullName)
+            self.touchCache(cacheKey)
             return cached
         }
         guard let presentation = ChangelogParser.presentation(parsed: parsed, releaseTag: releaseTag) else { return nil }
 
         entry.presentationCache[key] = presentation
-        self.cache[fullName] = entry
-        self.touchCache(fullName)
+        self.cache[cacheKey] = entry
+        self.touchCache(cacheKey)
         return presentation
     }
 
     func cachedHeadline(fullName: String) -> String? {
-        guard let parsed = self.cache[fullName]?.parsed else { return nil }
+        guard let accountID = self.appState.session.settings.resolvedActiveAccount()?.id else { return nil }
 
-        self.touchCache(fullName)
+        let cacheKey = AccountScopedCacheKey(accountID: accountID, key: fullName)
+        guard let parsed = self.cache[cacheKey]?.parsed else { return nil }
+
+        self.touchCache(cacheKey)
         return ChangelogParser.headline(parsed: parsed)
     }
 
     func prefetchChangelog(fullName: String, localPath: URL?, releaseTag: String?) {
+        guard let accountID = self.appState.session.settings.resolvedActiveAccount()?.id else { return }
+
         Task { @MainActor [weak self] in
             guard let self else { return }
 
+            let cacheKey = AccountScopedCacheKey(accountID: accountID, key: fullName)
             let now = Date()
-            if let cached = self.cache[fullName] {
+            if let cached = self.cache[cacheKey] {
                 let isFresh = now.timeIntervalSince(cached.fetchedAt) <= AppLimits.Changelog.cacheTTL
                 if isFresh {
-                    self.touchCache(fullName)
+                    self.touchCache(cacheKey)
                     self.menuBuilder.updateChangelogRow(fullName: fullName, releaseTag: releaseTag)
                     return
                 }
             }
 
-            let fetch = await self.loadChangelog(fullName: fullName, localPath: localPath)
-            self.storeCacheEntry(self.makeCacheEntry(fetch: fetch), for: fullName)
+            let fetch = await self.loadChangelog(
+                accountID: accountID,
+                fullName: fullName,
+                localPath: localPath
+            )
+            self.storeCacheEntry(self.makeCacheEntry(fetch: fetch), for: cacheKey)
             self.menuBuilder.updateChangelogRow(fullName: fullName, releaseTag: releaseTag)
         }
     }
 
     private func refreshChangelogMenu(menu: NSMenu, entry: ChangelogMenuEntry) async {
+        let cacheKey = AccountScopedCacheKey(accountID: entry.accountID, key: entry.fullName)
         let now = Date()
-        if let cached = self.cache[entry.fullName] {
+        if let cached = self.cache[cacheKey] {
             let isFresh = now.timeIntervalSince(cached.fetchedAt) <= AppLimits.Changelog.cacheTTL
             if isFresh {
-                self.touchCache(entry.fullName)
+                self.touchCache(cacheKey)
                 self.applyResult(cached.result, to: menu)
                 self.updateChangelogRow(fullName: entry.fullName)
                 return
             }
         }
 
-        if let cached = self.cache[entry.fullName] {
+        if let cached = self.cache[cacheKey] {
             self.applyResult(cached.result, to: menu)
         } else {
             self.applyLoading(to: menu)
         }
 
-        let fetch = await self.loadChangelog(fullName: entry.fullName, localPath: entry.localPath)
-        self.storeCacheEntry(self.makeCacheEntry(fetch: fetch), for: entry.fullName)
+        let fetch = await self.loadChangelog(
+            accountID: entry.accountID,
+            fullName: entry.fullName,
+            localPath: entry.localPath
+        )
+        self.storeCacheEntry(self.makeCacheEntry(fetch: fetch), for: cacheKey)
         self.applyResult(fetch.result, to: menu)
         self.updateChangelogRow(fullName: entry.fullName)
     }
@@ -138,16 +162,17 @@ final class ChangelogMenuCoordinator {
         menu.update()
     }
 
-    private func loadChangelog(fullName: String, localPath: URL?) async -> ChangelogFetchResult {
-        if let task = self.inflight[fullName] {
+    private func loadChangelog(accountID: String, fullName: String, localPath: URL?) async -> ChangelogFetchResult {
+        let cacheKey = AccountScopedCacheKey(accountID: accountID, key: fullName)
+        if let task = self.inflight[cacheKey] {
             return await task.value
         }
         let task = Task { @MainActor in
-            await self.fetchChangelog(fullName: fullName, localPath: localPath)
+            await self.fetchChangelog(accountID: accountID, fullName: fullName, localPath: localPath)
         }
-        self.inflight[fullName] = task
+        self.inflight[cacheKey] = task
         let result = await task.value
-        self.inflight[fullName] = nil
+        self.inflight[cacheKey] = nil
         return result
     }
 
@@ -159,7 +184,7 @@ final class ChangelogMenuCoordinator {
         self.menuBuilder.updateChangelogRow(fullName: fullName, releaseTag: releaseTag)
     }
 
-    private func fetchChangelog(fullName: String, localPath: URL?) async -> ChangelogFetchResult {
+    private func fetchChangelog(accountID: String, fullName: String, localPath: URL?) async -> ChangelogFetchResult {
         if let localPath, let localResult = self.loadLocalChangelog(root: localPath) {
             return ChangelogFetchResult(result: .content(localResult.content), parsed: localResult.parsed)
         }
@@ -172,12 +197,13 @@ final class ChangelogMenuCoordinator {
         }
 
         do {
-            let items = try await self.appState.github.repoContents(owner: owner, name: name)
+            let github = try self.appState.accountManager.resolveClient(for: accountID)
+            let items = try await github.repoContents(owner: owner, name: name)
             guard let match = self.matchingChangelogItem(in: items) else {
                 return ChangelogFetchResult(result: .missing, parsed: nil)
             }
 
-            let data = try await self.appState.github.repoFileContents(owner: owner, name: name, path: match.path)
+            let data = try await github.repoFileContents(owner: owner, name: name, path: match.path)
             guard let text = String(bytes: data, encoding: .utf8) else {
                 return ChangelogFetchResult(result: .failure("Changelog is not UTF-8"), parsed: nil)
             }
@@ -285,28 +311,39 @@ final class ChangelogMenuCoordinator {
         )
     }
 
-    private func storeCacheEntry(_ entry: ChangelogCacheEntry, for fullName: String) {
-        self.cache[fullName] = entry
-        self.touchCache(fullName)
+    func removeCachedState(accountID: String) {
+        self.cache = self.cache.filter { $0.key.accountID != accountID }
+        self.cacheOrder.removeAll { $0.accountID == accountID }
+        let tasks = self.inflight.filter { $0.key.accountID == accountID }.map(\.value)
+        self.inflight = self.inflight.filter { $0.key.accountID != accountID }
+        tasks.forEach { $0.cancel() }
+        self.menus = self.menus.filter { $0.value.accountID != accountID }
+    }
+
+    private func storeCacheEntry(_ entry: ChangelogCacheEntry, for cacheKey: AccountScopedCacheKey) {
+        self.cache[cacheKey] = entry
+        self.touchCache(cacheKey)
         while self.cache.count > AppLimits.Changelog.cacheEntries, let oldest = self.cacheOrder.first {
             self.cacheOrder.removeFirst()
             self.cache[oldest] = nil
         }
     }
 
-    private func touchCache(_ fullName: String) {
-        self.cacheOrder.removeAll { $0 == fullName }
-        self.cacheOrder.append(fullName)
+    private func touchCache(_ cacheKey: AccountScopedCacheKey) {
+        self.cacheOrder.removeAll { $0 == cacheKey }
+        self.cacheOrder.append(cacheKey)
     }
 }
 
 private final class ChangelogMenuEntry {
     weak var menu: NSMenu?
+    let accountID: String
     let fullName: String
     let localPath: URL?
 
-    init(menu: NSMenu, fullName: String, localPath: URL?) {
+    init(menu: NSMenu, accountID: String, fullName: String, localPath: URL?) {
         self.menu = menu
+        self.accountID = accountID
         self.fullName = fullName
         self.localPath = localPath
     }

--- a/Sources/RepoBar/StatusBar/ChangelogMenuCoordinator.swift
+++ b/Sources/RepoBar/StatusBar/ChangelogMenuCoordinator.swift
@@ -8,15 +8,23 @@ final class ChangelogMenuCoordinator {
     private let appState: AppState
     private let menuBuilder: StatusBarMenuBuilder
     private let menuItemFactory: MenuItemViewFactory
+    private let fetchOverride: (@MainActor @Sendable (String, String, URL?) async -> ChangelogFetchResult)?
     private var menus: [ObjectIdentifier: ChangelogMenuEntry] = [:]
     private var cache: [AccountScopedCacheKey: ChangelogCacheEntry] = [:]
     private var cacheOrder: [AccountScopedCacheKey] = []
-    private var inflight: [AccountScopedCacheKey: Task<ChangelogFetchResult, Never>] = [:]
+    private var inflight: [AccountScopedCacheKey: ChangelogInflight] = [:]
+    private var accountGenerations: [String: UInt] = [:]
 
-    init(appState: AppState, menuBuilder: StatusBarMenuBuilder, menuItemFactory: MenuItemViewFactory) {
+    init(
+        appState: AppState,
+        menuBuilder: StatusBarMenuBuilder,
+        menuItemFactory: MenuItemViewFactory,
+        fetchOverride: (@MainActor @Sendable (String, String, URL?) async -> ChangelogFetchResult)? = nil
+    ) {
         self.appState = appState
         self.menuBuilder = menuBuilder
         self.menuItemFactory = menuItemFactory
+        self.fetchOverride = fetchOverride
     }
 
     func registerChangelogMenu(
@@ -97,12 +105,12 @@ final class ChangelogMenuCoordinator {
                 }
             }
 
-            let fetch = await self.loadChangelog(
+            guard await self.loadChangelog(
                 accountID: accountID,
                 fullName: fullName,
                 localPath: localPath
-            )
-            self.storeCacheEntry(self.makeCacheEntry(fetch: fetch), for: cacheKey)
+            ) != nil else { return }
+
             self.menuBuilder.updateChangelogRow(fullName: fullName, releaseTag: releaseTag)
         }
     }
@@ -126,12 +134,12 @@ final class ChangelogMenuCoordinator {
             self.applyLoading(to: menu)
         }
 
-        let fetch = await self.loadChangelog(
+        guard let fetch = await self.loadChangelog(
             accountID: entry.accountID,
             fullName: entry.fullName,
             localPath: entry.localPath
-        )
-        self.storeCacheEntry(self.makeCacheEntry(fetch: fetch), for: cacheKey)
+        ) else { return }
+
         self.applyResult(fetch.result, to: menu)
         self.updateChangelogRow(fullName: entry.fullName)
     }
@@ -162,16 +170,28 @@ final class ChangelogMenuCoordinator {
         menu.update()
     }
 
-    private func loadChangelog(accountID: String, fullName: String, localPath: URL?) async -> ChangelogFetchResult {
+    private func loadChangelog(
+        accountID: String,
+        fullName: String,
+        localPath: URL?
+    ) async -> ChangelogFetchResult? {
         let cacheKey = AccountScopedCacheKey(accountID: accountID, key: fullName)
-        if let task = self.inflight[cacheKey] {
-            return await task.value
+        if let existing = self.inflight[cacheKey] {
+            let result = await existing.task.value
+            guard self.accountGenerations[accountID, default: 0] == existing.generation else { return nil }
+
+            return result
         }
+        let generation = self.accountGenerations[accountID, default: 0]
         let task = Task { @MainActor in
             await self.fetchChangelog(accountID: accountID, fullName: fullName, localPath: localPath)
         }
-        self.inflight[cacheKey] = task
+        let inflight = ChangelogInflight(task: task, generation: generation, token: UUID())
+        self.inflight[cacheKey] = inflight
         let result = await task.value
+        guard self.isCurrent(inflight, for: cacheKey) else { return nil }
+
+        self.storeCacheEntry(self.makeCacheEntry(fetch: result), for: cacheKey)
         self.inflight[cacheKey] = nil
         return result
     }
@@ -185,6 +205,9 @@ final class ChangelogMenuCoordinator {
     }
 
     private func fetchChangelog(accountID: String, fullName: String, localPath: URL?) async -> ChangelogFetchResult {
+        if let fetchOverride {
+            return await fetchOverride(accountID, fullName, localPath)
+        }
         if let localPath, let localResult = self.loadLocalChangelog(root: localPath) {
             return ChangelogFetchResult(result: .content(localResult.content), parsed: localResult.parsed)
         }
@@ -312,9 +335,10 @@ final class ChangelogMenuCoordinator {
     }
 
     func removeCachedState(accountID: String) {
+        self.accountGenerations[accountID, default: 0] &+= 1
         self.cache = self.cache.filter { $0.key.accountID != accountID }
         self.cacheOrder.removeAll { $0.accountID == accountID }
-        let tasks = self.inflight.filter { $0.key.accountID == accountID }.map(\.value)
+        let tasks = self.inflight.filter { $0.key.accountID == accountID }.map(\.value.task)
         self.inflight = self.inflight.filter { $0.key.accountID != accountID }
         tasks.forEach { $0.cancel() }
         self.menus = self.menus.filter { $0.value.accountID != accountID }
@@ -332,6 +356,22 @@ final class ChangelogMenuCoordinator {
     private func touchCache(_ cacheKey: AccountScopedCacheKey) {
         self.cacheOrder.removeAll { $0 == cacheKey }
         self.cacheOrder.append(cacheKey)
+    }
+
+    func loadChangelogForTesting(accountID: String, fullName: String) async -> Bool {
+        await self.loadChangelog(accountID: accountID, fullName: fullName, localPath: nil) != nil
+    }
+
+    func hasCachedStateForTesting(accountID: String, fullName: String) -> Bool {
+        self.cache[AccountScopedCacheKey(accountID: accountID, key: fullName)] != nil
+    }
+
+    private func isCurrent(_ inflight: ChangelogInflight, for key: AccountScopedCacheKey) -> Bool {
+        guard self.accountGenerations[key.accountID, default: 0] == inflight.generation,
+              let current = self.inflight[key]
+        else { return false }
+
+        return current.generation == inflight.generation && current.token == inflight.token
     }
 }
 
@@ -356,7 +396,7 @@ private struct ChangelogCacheEntry {
     var presentationCache: [String: ChangelogRowPresentation]
 }
 
-private struct ChangelogFetchResult {
+struct ChangelogFetchResult {
     let result: ChangelogResult
     let parsed: ChangelogParsed?
 }
@@ -366,9 +406,15 @@ private struct ChangelogLocalResult {
     let parsed: ChangelogParsed
 }
 
-private enum ChangelogResult {
+enum ChangelogResult {
     case signedOut
     case missing
     case failure(String)
     case content(ChangelogContent)
+}
+
+private struct ChangelogInflight {
+    let task: Task<ChangelogFetchResult, Never>
+    let generation: UInt
+    let token: UUID
 }

--- a/Sources/RepoBar/StatusBar/LocalGitMenuCoordinator.swift
+++ b/Sources/RepoBar/StatusBar/LocalGitMenuCoordinator.swift
@@ -33,6 +33,7 @@ final class LocalGitMenuCoordinator {
     func registerLocalBranchMenu(_ menu: NSMenu, repoPath: URL, fullName: String, localStatus: LocalRepoStatus) {
         self.localBranchMenus[ObjectIdentifier(menu)] = LocalGitMenuEntry(
             menu: menu,
+            accountID: self.appState.session.settings.resolvedActiveAccount()?.id,
             repoPath: repoPath,
             fullName: fullName,
             localStatus: localStatus,
@@ -43,6 +44,7 @@ final class LocalGitMenuCoordinator {
     func registerCombinedBranchMenu(_ menu: NSMenu, repoPath: URL, fullName: String, localStatus: LocalRepoStatus) {
         self.localBranchMenus[ObjectIdentifier(menu)] = LocalGitMenuEntry(
             menu: menu,
+            accountID: self.appState.session.settings.resolvedActiveAccount()?.id,
             repoPath: repoPath,
             fullName: fullName,
             localStatus: localStatus,
@@ -53,6 +55,7 @@ final class LocalGitMenuCoordinator {
     func registerLocalWorktreeMenu(_ menu: NSMenu, repoPath: URL, fullName: String) {
         self.localWorktreeMenus[ObjectIdentifier(menu)] = LocalGitMenuEntry(
             menu: menu,
+            accountID: self.appState.session.settings.resolvedActiveAccount()?.id,
             repoPath: repoPath,
             fullName: fullName,
             localStatus: nil,
@@ -280,8 +283,36 @@ final class LocalGitMenuCoordinator {
             return
         }
         guard let descriptor = self.recentMenuService.descriptor(for: .branches) else { return }
+        guard let accountID = entry.accountID else {
+            self.populateCombinedBranchMenu(
+                menu: menu,
+                entry: entry,
+                localResult: localResult,
+                remoteState: BranchesRemoteState(
+                    branches: nil,
+                    message: "No active account",
+                    emptyTitle: descriptor.emptyTitle
+                )
+            )
+            return
+        }
 
-        let cacheContext = self.recentMenuService.cacheContext(fullName: fullName)
+        let cacheContext: (key: AccountScopedCacheKey, github: GitHubClient)
+        do {
+            cacheContext = try self.recentMenuService.cacheContext(accountID: accountID, fullName: fullName)
+        } catch {
+            self.populateCombinedBranchMenu(
+                menu: menu,
+                entry: entry,
+                localResult: localResult,
+                remoteState: BranchesRemoteState(
+                    branches: nil,
+                    message: error.userFacingMessage,
+                    emptyTitle: descriptor.emptyTitle
+                )
+            )
+            return
+        }
         let cacheKey = cacheContext.key
 
         let cachedItems = descriptor.cached(cacheKey, now, self.recentMenuService.cacheTTL)
@@ -678,6 +709,7 @@ private enum LocalGitAction {
 
 private struct LocalGitMenuEntry {
     weak var menu: NSMenu?
+    let accountID: String?
     let repoPath: URL
     let fullName: String
     let localStatus: LocalRepoStatus?

--- a/Sources/RepoBar/StatusBar/MenuNotifications.swift
+++ b/Sources/RepoBar/StatusBar/MenuNotifications.swift
@@ -12,4 +12,5 @@ extension Notification.Name {
     static let issueNavigatorOpen = Notification.Name("issueNavigatorOpen")
     static let issueNavigatorOpenRequested = Notification.Name("issueNavigatorOpenRequested")
     static let notificationBrowserOpenRequested = Notification.Name("notificationBrowserOpenRequested")
+    static let accountRepositoryStateDidRemove = Notification.Name("accountRepositoryStateDidRemove")
 }

--- a/Sources/RepoBar/StatusBar/RecentListMenuCoordinator.swift
+++ b/Sources/RepoBar/StatusBar/RecentListMenuCoordinator.swift
@@ -85,22 +85,43 @@ final class RecentListMenuCoordinator {
     func prefetchRecentLists(fullNames: Set<String>) {
         guard case .loggedIn = self.appState.session.account else { return }
         guard fullNames.isEmpty == false else { return }
+        guard let accountID = self.appState.session.settings.resolvedActiveAccount()?.id else {
+            self.logger.error("Skipping recent-list prefetch because no active account is resolved")
+            return
+        }
 
         let kinds = self.menuService.descriptors().keys
         for fullName in fullNames {
             for kind in kinds {
-                self.prefetchRecentList(fullName: fullName, kind: kind)
+                self.prefetchRecentList(accountID: accountID, fullName: fullName, kind: kind)
             }
         }
     }
 
     func prefetchRecentList(fullName: String, kind: RepoRecentMenuKind) {
+        guard let accountID = self.appState.session.settings.resolvedActiveAccount()?.id else {
+            self.logger.error("Skipping recent-list prefetch because no active account is resolved")
+            return
+        }
+
+        self.prefetchRecentList(accountID: accountID, fullName: fullName, kind: kind)
+    }
+
+    func prefetchRecentList(accountID: String, fullName: String, kind: RepoRecentMenuKind) {
         guard let (owner, name) = self.ownerAndName(from: fullName) else { return }
 
         let now = Date()
         guard let descriptor = self.menuService.descriptor(for: kind) else { return }
 
-        let cacheContext = self.menuService.cacheContext(fullName: fullName)
+        let cacheContext: (key: AccountScopedCacheKey, github: GitHubClient)
+        do {
+            cacheContext = try self.menuService.cacheContext(accountID: accountID, fullName: fullName)
+        } catch {
+            self.logger.error(
+                "Recent-list client resolution failed account=\(accountID) repo=\(fullName) error=\(error.userFacingMessage)"
+            )
+            return
+        }
         let cacheKey = cacheContext.key
         guard descriptor.needsRefresh(cacheKey, now, self.menuService.cacheTTL) else { return }
 
@@ -157,7 +178,22 @@ final class RecentListMenuCoordinator {
             systemImage: descriptor.headerIcon
         )
         let actions = self.actions(for: context.kind, fullName: context.fullName)
-        let cacheContext = self.menuService.cacheContext(fullName: context.fullName)
+        let cacheContext: (key: AccountScopedCacheKey, github: GitHubClient)
+        do {
+            cacheContext = try self.menuService.cacheContext(
+                accountID: context.accountID,
+                fullName: context.fullName
+            )
+        } catch {
+            self.populateRecentListMenu(
+                menu,
+                header: header,
+                actions: actions,
+                content: .message(Self.failureMessage(for: error))
+            )
+            menu.update()
+            return
+        }
         let cacheKey = cacheContext.key
         let cached = descriptor.cached(cacheKey, now, self.menuService.cacheTTL)
         let stale = cached ?? descriptor.stale(cacheKey)
@@ -194,7 +230,7 @@ final class RecentListMenuCoordinator {
             self.logger.info(
                 "Recent list refresh ok kind=\(String(describing: context.kind)) repo=\(context.fullName) count=\(items.count) dur=\(Self.formatDuration(since: startedAt))"
             )
-            let rateLimitExtras = await self.currentRateLimitExtras()
+            let rateLimitExtras = await self.currentRateLimitExtras(github: cacheContext.github)
             self.populateRecentListMenu(
                 menu,
                 header: header,
@@ -284,8 +320,8 @@ final class RecentListMenuCoordinator {
         self.appState.session.lastError = error.userFacingMessage
     }
 
-    private func currentRateLimitExtras() async -> [NSMenuItem] {
-        guard let reset = await self.appState.github.rateLimitReset(now: Date()) else { return [] }
+    private func currentRateLimitExtras(github: GitHubClient) async -> [NSMenuItem] {
+        guard let reset = await github.rateLimitReset(now: Date()) else { return [] }
 
         self.appState.session.rateLimitReset = reset
         return self.rateLimitExtras(

--- a/Sources/RepoBar/StatusBar/RecentMenuService.swift
+++ b/Sources/RepoBar/StatusBar/RecentMenuService.swift
@@ -8,8 +8,8 @@ final class RecentMenuService {
     let cacheTTL: TimeInterval
     let loadTimeout: TimeInterval
 
-    private let github: @MainActor () -> GitHubClient
-    private let cacheNamespace: @MainActor () -> String
+    private let clientResolver: @MainActor (String) throws -> GitHubClient
+    private let activeAccountID: @MainActor () -> String?
     private let recentIssuesCache = RecentListCache<RepoIssueSummary>()
     private let recentPullRequestsCache = RecentListCache<RepoPullRequestSummary>()
     private let recentReleasesCache = RecentListCache<RepoReleaseSummary>()
@@ -19,7 +19,7 @@ final class RecentMenuService {
     private let recentTagsCache = RecentListCache<RepoTagSummary>()
     private let recentBranchesCache = RecentListCache<RepoBranchSummary>()
     private let recentContributorsCache = RecentListCache<RepoContributorSummary>()
-    private var recentCommitCounts: [String: Int] = [:]
+    private var recentCommitCounts: [AccountScopedCacheKey: Int] = [:]
 
     init(
         github: @escaping @MainActor () -> GitHubClient,
@@ -29,8 +29,8 @@ final class RecentMenuService {
         cacheTTL: TimeInterval = AppLimits.RecentLists.cacheTTL,
         loadTimeout: TimeInterval = AppLimits.RecentLists.loadTimeout
     ) {
-        self.github = github
-        self.cacheNamespace = cacheNamespace
+        self.clientResolver = { _ in github() }
+        self.activeAccountID = { cacheNamespace() }
         self.listLimit = listLimit
         self.previewLimit = previewLimit
         self.cacheTTL = cacheTTL
@@ -39,17 +39,53 @@ final class RecentMenuService {
 
     convenience init(appState: AppState) {
         self.init(
-            github: { [appState] in appState.github },
-            cacheNamespace: { [appState] in appState.session.settings.resolvedActiveAccount()?.id ?? "legacy" }
+            clientResolver: { [appState] accountID in
+                try appState.accountManager.resolveClient(for: accountID)
+            },
+            activeAccountID: { [appState] in
+                appState.session.settings.resolvedActiveAccount()?.id
+            }
         )
     }
 
-    func cacheKey(fullName: String) -> String {
-        "\(self.cacheNamespace())|\(fullName)"
+    init(
+        clientResolver: @escaping @MainActor (String) throws -> GitHubClient,
+        activeAccountID: @escaping @MainActor () -> String?,
+        listLimit: Int = AppLimits.RecentLists.limit,
+        previewLimit: Int = AppLimits.RecentLists.previewLimit,
+        cacheTTL: TimeInterval = AppLimits.RecentLists.cacheTTL,
+        loadTimeout: TimeInterval = AppLimits.RecentLists.loadTimeout
+    ) {
+        self.clientResolver = clientResolver
+        self.activeAccountID = activeAccountID
+        self.listLimit = listLimit
+        self.previewLimit = previewLimit
+        self.cacheTTL = cacheTTL
+        self.loadTimeout = loadTimeout
     }
 
-    func cacheContext(fullName: String) -> (key: String, github: GitHubClient) {
-        (self.cacheKey(fullName: fullName), self.github())
+    func cacheKey(accountID: String, fullName: String) -> AccountScopedCacheKey {
+        AccountScopedCacheKey(accountID: accountID, key: fullName)
+    }
+
+    func cacheKey(fullName: String) -> AccountScopedCacheKey? {
+        self.activeAccountID().map { self.cacheKey(accountID: $0, fullName: fullName) }
+    }
+
+    func cacheContext(accountID: String, fullName: String) throws
+        -> (key: AccountScopedCacheKey, github: GitHubClient) {
+        try (
+            self.cacheKey(accountID: accountID, fullName: fullName),
+            self.clientResolver(accountID)
+        )
+    }
+
+    func cacheContext(fullName: String) throws -> (key: AccountScopedCacheKey, github: GitHubClient) {
+        guard let accountID = self.activeAccountID() else {
+            throw AccountManagerError.clientUnavailable("active")
+        }
+
+        return try self.cacheContext(accountID: accountID, fullName: fullName)
     }
 
     func descriptor(for kind: RepoRecentMenuKind) -> RecentMenuDescriptor? {
@@ -203,7 +239,16 @@ final class RecentMenuService {
     }
 
     func cachedRecentCommitCount(fullName: String) -> Int? {
-        let key = self.cacheKey(fullName: fullName)
+        guard let key = self.cacheKey(fullName: fullName) else { return nil }
+
+        return self.cachedRecentCommitCount(key: key)
+    }
+
+    func cachedRecentCommitCount(accountID: String, fullName: String) -> Int? {
+        self.cachedRecentCommitCount(key: self.cacheKey(accountID: accountID, fullName: fullName))
+    }
+
+    private func cachedRecentCommitCount(key: AccountScopedCacheKey) -> Int? {
         if let total = self.recentCommitCounts[key] {
             return total
         }
@@ -211,8 +256,17 @@ final class RecentMenuService {
     }
 
     func cachedCommits(fullName: String, now: Date = Date()) -> [RepoCommitSummary]? {
-        let key = self.cacheKey(fullName: fullName)
-        return self.recentCommitsCache.cached(for: key, now: now, maxAge: self.cacheTTL)
+        guard let key = self.cacheKey(fullName: fullName) else { return nil }
+
+        return self.cachedCommits(key: key, now: now)
+    }
+
+    func cachedCommits(accountID: String, fullName: String, now: Date = Date()) -> [RepoCommitSummary]? {
+        self.cachedCommits(key: self.cacheKey(accountID: accountID, fullName: fullName), now: now)
+    }
+
+    private func cachedCommits(key: AccountScopedCacheKey, now: Date) -> [RepoCommitSummary]? {
+        self.recentCommitsCache.cached(for: key, now: now, maxAge: self.cacheTTL)
             ?? self.recentCommitsCache.stale(for: key)
     }
 
@@ -226,6 +280,57 @@ final class RecentMenuService {
             hasher.combine(commit.authoredAt.timeIntervalSinceReferenceDate)
         }
         return hasher.finalize()
+    }
+
+    func removeCachedState(accountID: String) {
+        self.recentIssuesCache.remove(accountID: accountID)
+        self.recentPullRequestsCache.remove(accountID: accountID)
+        self.recentReleasesCache.remove(accountID: accountID)
+        self.recentWorkflowRunsCache.remove(accountID: accountID)
+        self.recentCommitsCache.remove(accountID: accountID)
+        self.recentDiscussionsCache.remove(accountID: accountID)
+        self.recentTagsCache.remove(accountID: accountID)
+        self.recentBranchesCache.remove(accountID: accountID)
+        self.recentContributorsCache.remove(accountID: accountID)
+        self.recentCommitCounts = self.recentCommitCounts.filter { $0.key.accountID != accountID }
+    }
+
+    func load(
+        accountID: String,
+        fullName: String,
+        kind: RepoRecentMenuKind,
+        limit: Int? = nil
+    ) async throws -> RecentMenuItems {
+        let parts = fullName.split(separator: "/", maxSplits: 1)
+        guard parts.count == 2 else {
+            throw RecentMenuServiceError.invalidRepositoryName(fullName)
+        }
+        guard let descriptor = self.descriptor(for: kind) else {
+            throw RecentMenuServiceError.unsupportedKind
+        }
+
+        let context = try self.cacheContext(accountID: accountID, fullName: fullName)
+        return try await descriptor.load(
+            context.key,
+            String(parts[0]),
+            String(parts[1]),
+            limit ?? self.listLimit,
+            context.github
+        )
+    }
+
+    private enum RecentMenuServiceError: LocalizedError {
+        case invalidRepositoryName(String)
+        case unsupportedKind
+
+        var errorDescription: String? {
+            switch self {
+            case let .invalidRepositoryName(fullName):
+                "Invalid repository name: \(fullName)"
+            case .unsupportedKind:
+                "Unsupported recent-list kind."
+            }
+        }
     }
 
     private func commitDescriptor() -> RecentMenuDescriptor {
@@ -310,10 +415,10 @@ struct RecentMenuDescriptor {
     let headerTitle: String
     let headerIcon: String?
     let emptyTitle: String
-    let cached: (String, Date, TimeInterval) -> RecentMenuItems?
-    let stale: (String) -> RecentMenuItems?
-    let needsRefresh: (String, Date, TimeInterval) -> Bool
-    let load: @MainActor (String, String, String, Int, GitHubClient) async throws -> RecentMenuItems
+    let cached: (AccountScopedCacheKey, Date, TimeInterval) -> RecentMenuItems?
+    let stale: (AccountScopedCacheKey) -> RecentMenuItems?
+    let needsRefresh: (AccountScopedCacheKey, Date, TimeInterval) -> Bool
+    let load: @MainActor (AccountScopedCacheKey, String, String, Int, GitHubClient) async throws -> RecentMenuItems
 }
 
 enum RecentMenuItems {
@@ -363,15 +468,15 @@ final class RecentListCache<Item: Sendable> {
     }
 
     private let maxEntries: Int
-    private var entries: [String: Entry] = [:]
-    private var entryOrder: [String] = []
-    private var inflight: [String: Task<[Item], Error>] = [:]
+    private var entries: [AccountScopedCacheKey: Entry] = [:]
+    private var entryOrder: [AccountScopedCacheKey] = []
+    private var inflight: [AccountScopedCacheKey: Task<[Item], Error>] = [:]
 
     init(maxEntries: Int = AppLimits.RecentLists.cacheEntries) {
         self.maxEntries = max(0, maxEntries)
     }
 
-    func cached(for key: String, now: Date, maxAge: TimeInterval) -> [Item]? {
+    func cached(for key: AccountScopedCacheKey, now: Date, maxAge: TimeInterval) -> [Item]? {
         guard let entry = self.entries[key] else { return nil }
         guard now.timeIntervalSince(entry.fetchedAt) <= maxAge else { return nil }
 
@@ -379,20 +484,23 @@ final class RecentListCache<Item: Sendable> {
         return entry.items
     }
 
-    func stale(for key: String) -> [Item]? {
+    func stale(for key: AccountScopedCacheKey) -> [Item]? {
         guard let entry = self.entries[key] else { return nil }
 
         self.touch(key)
         return entry.items
     }
 
-    func needsRefresh(for key: String, now: Date, maxAge: TimeInterval) -> Bool {
+    func needsRefresh(for key: AccountScopedCacheKey, now: Date, maxAge: TimeInterval) -> Bool {
         guard let entry = self.entries[key] else { return true }
 
         return now.timeIntervalSince(entry.fetchedAt) > maxAge
     }
 
-    func task(for key: String, factory: @escaping @Sendable () async throws -> [Item]) -> Task<[Item], Error> {
+    func task(
+        for key: AccountScopedCacheKey,
+        factory: @escaping @Sendable () async throws -> [Item]
+    ) -> Task<[Item], Error> {
         if let existing = self.inflight[key] {
             return existing
         }
@@ -401,12 +509,16 @@ final class RecentListCache<Item: Sendable> {
         return task
     }
 
-    func clearInflight(for key: String) {
+    func clearInflight(for key: AccountScopedCacheKey) {
         self.inflight[key] = nil
     }
 
     @discardableResult
-    func store(_ items: [Item], for key: String, fetchedAt: Date) -> [String] {
+    func store(
+        _ items: [Item],
+        for key: AccountScopedCacheKey,
+        fetchedAt: Date
+    ) -> [AccountScopedCacheKey] {
         guard self.maxEntries > 0 else { return [] }
 
         self.entries[key] = Entry(fetchedAt: fetchedAt, items: items)
@@ -418,13 +530,24 @@ final class RecentListCache<Item: Sendable> {
         self.entries.count
     }
 
-    private func touch(_ key: String) {
+    func remove(accountID: String) {
+        let keys = self.entries.keys.filter { $0.accountID == accountID }
+        for key in keys {
+            self.entries[key] = nil
+        }
+        self.entryOrder.removeAll { $0.accountID == accountID }
+        let tasks = self.inflight.filter { $0.key.accountID == accountID }.map(\.value)
+        self.inflight = self.inflight.filter { $0.key.accountID != accountID }
+        tasks.forEach { $0.cancel() }
+    }
+
+    private func touch(_ key: AccountScopedCacheKey) {
         self.entryOrder.removeAll { $0 == key }
         self.entryOrder.append(key)
     }
 
-    private func evictIfNeeded() -> [String] {
-        var evicted: [String] = []
+    private func evictIfNeeded() -> [AccountScopedCacheKey] {
+        var evicted: [AccountScopedCacheKey] = []
         while self.entries.count > self.maxEntries, let oldest = self.entryOrder.first {
             self.entryOrder.removeFirst()
             if self.entries.removeValue(forKey: oldest) != nil {

--- a/Sources/RepoBar/StatusBar/RecentMenuService.swift
+++ b/Sources/RepoBar/StatusBar/RecentMenuService.swift
@@ -484,10 +484,17 @@ enum RecentMenuItems {
 }
 
 final class RecentListCache<Item: Sendable> {
-    struct Load {
+    final class Load {
         let task: Task<[Item], Error>
         fileprivate let generation: UInt
         fileprivate let token: UUID
+        fileprivate var completedEvictedKeys: [AccountScopedCacheKey]?
+
+        init(task: Task<[Item], Error>, generation: UInt, token: UUID) {
+            self.task = task
+            self.generation = generation
+            self.token = token
+        }
     }
 
     struct Entry {
@@ -545,6 +552,7 @@ final class RecentListCache<Item: Sendable> {
     }
 
     func abandon(_ load: Load, for key: AccountScopedCacheKey) {
+        guard load.completedEvictedKeys == nil else { return }
         guard self.isCurrent(load, for: key) else { return }
 
         self.inflight[key] = nil
@@ -560,10 +568,17 @@ final class RecentListCache<Item: Sendable> {
         for key: AccountScopedCacheKey,
         fetchedAt: Date
     ) -> [AccountScopedCacheKey]? {
+        guard self.isCurrentGeneration(load.generation, for: key) else { return nil }
+
+        if let completedEvictedKeys = load.completedEvictedKeys {
+            return completedEvictedKeys
+        }
         guard self.isCurrent(load, for: key) else { return nil }
 
+        let evictedKeys = self.store(items, for: key, fetchedAt: fetchedAt)
+        load.completedEvictedKeys = evictedKeys
         self.inflight[key] = nil
-        return self.store(items, for: key, fetchedAt: fetchedAt)
+        return evictedKeys
     }
 
     @discardableResult

--- a/Sources/RepoBar/StatusBar/RecentMenuService.swift
+++ b/Sources/RepoBar/StatusBar/RecentMenuService.swift
@@ -349,16 +349,31 @@ final class RecentMenuService {
                 self.recentCommitsCache.needsRefresh(for: key, now: now, maxAge: ttl)
             },
             load: { key, owner, name, limit, github in
-                let task = self.recentCommitsCache.task(for: key) {
+                let load = self.recentCommitsCache.task(for: key) { generation in
                     let list = try await github.recentCommits(owner: owner, name: name, limit: limit)
                     await MainActor.run {
-                        self.recentCommitCounts[key] = list.totalCount ?? list.items.count
+                        if self.recentCommitsCache.isCurrentGeneration(generation, for: key) {
+                            self.recentCommitCounts[key] = list.totalCount ?? list.items.count
+                        }
                     }
                     return list.items
                 }
-                defer { self.recentCommitsCache.clearInflight(for: key) }
-                let items = try await AsyncTimeout.value(within: self.loadTimeout, task: task)
-                let evictedKeys = self.recentCommitsCache.store(items, for: key, fetchedAt: Date())
+                let items: [RepoCommitSummary]
+                do {
+                    items = try await AsyncTimeout.value(within: self.loadTimeout, task: load.task)
+                } catch {
+                    self.recentCommitsCache.abandon(load, for: key)
+                    throw error
+                }
+                guard let evictedKeys = self.recentCommitsCache.complete(
+                    load,
+                    items: items,
+                    for: key,
+                    fetchedAt: Date()
+                ) else {
+                    throw CancellationError()
+                }
+
                 for evictedKey in evictedKeys {
                     self.recentCommitCounts[evictedKey] = nil
                 }
@@ -387,13 +402,20 @@ final class RecentMenuService {
                 config.cache.needsRefresh(for: key, now: now, maxAge: ttl)
             },
             load: { key, owner, name, limit, github in
-                let task = config.cache.task(for: key) {
+                let load = config.cache.task(for: key) { _ in
                     try await fetch(github, owner, name, limit)
                 }
-                defer { config.cache.clearInflight(for: key) }
-                let items = try await AsyncTimeout.value(within: self.loadTimeout, task: task)
-                _ = config.cache.store(items, for: key, fetchedAt: Date())
-                return config.wrap(items)
+                do {
+                    let items = try await AsyncTimeout.value(within: self.loadTimeout, task: load.task)
+                    guard config.cache.complete(load, items: items, for: key, fetchedAt: Date()) != nil else {
+                        throw CancellationError()
+                    }
+
+                    return config.wrap(items)
+                } catch {
+                    config.cache.abandon(load, for: key)
+                    throw error
+                }
             }
         )
     }
@@ -462,6 +484,12 @@ enum RecentMenuItems {
 }
 
 final class RecentListCache<Item: Sendable> {
+    struct Load {
+        let task: Task<[Item], Error>
+        fileprivate let generation: UInt
+        fileprivate let token: UUID
+    }
+
     struct Entry {
         var fetchedAt: Date
         var items: [Item]
@@ -470,7 +498,8 @@ final class RecentListCache<Item: Sendable> {
     private let maxEntries: Int
     private var entries: [AccountScopedCacheKey: Entry] = [:]
     private var entryOrder: [AccountScopedCacheKey] = []
-    private var inflight: [AccountScopedCacheKey: Task<[Item], Error>] = [:]
+    private var inflight: [AccountScopedCacheKey: Load] = [:]
+    private var accountGenerations: [String: UInt] = [:]
 
     init(maxEntries: Int = AppLimits.RecentLists.cacheEntries) {
         self.maxEntries = max(0, maxEntries)
@@ -499,18 +528,42 @@ final class RecentListCache<Item: Sendable> {
 
     func task(
         for key: AccountScopedCacheKey,
-        factory: @escaping @Sendable () async throws -> [Item]
-    ) -> Task<[Item], Error> {
+        factory: @escaping @Sendable (UInt) async throws -> [Item]
+    ) -> Load {
         if let existing = self.inflight[key] {
             return existing
         }
-        let task = Task { try await factory() }
-        self.inflight[key] = task
-        return task
+        let generation = self.accountGenerations[key.accountID, default: 0]
+        let task = Task { try await factory(generation) }
+        let load = Load(
+            task: task,
+            generation: generation,
+            token: UUID()
+        )
+        self.inflight[key] = load
+        return load
     }
 
-    func clearInflight(for key: AccountScopedCacheKey) {
+    func abandon(_ load: Load, for key: AccountScopedCacheKey) {
+        guard self.isCurrent(load, for: key) else { return }
+
         self.inflight[key] = nil
+    }
+
+    func isCurrentGeneration(_ generation: UInt, for key: AccountScopedCacheKey) -> Bool {
+        self.accountGenerations[key.accountID, default: 0] == generation
+    }
+
+    func complete(
+        _ load: Load,
+        items: [Item],
+        for key: AccountScopedCacheKey,
+        fetchedAt: Date
+    ) -> [AccountScopedCacheKey]? {
+        guard self.isCurrent(load, for: key) else { return nil }
+
+        self.inflight[key] = nil
+        return self.store(items, for: key, fetchedAt: fetchedAt)
     }
 
     @discardableResult
@@ -531,14 +584,23 @@ final class RecentListCache<Item: Sendable> {
     }
 
     func remove(accountID: String) {
+        self.accountGenerations[accountID, default: 0] &+= 1
         let keys = self.entries.keys.filter { $0.accountID == accountID }
         for key in keys {
             self.entries[key] = nil
         }
         self.entryOrder.removeAll { $0.accountID == accountID }
-        let tasks = self.inflight.filter { $0.key.accountID == accountID }.map(\.value)
+        let tasks = self.inflight.filter { $0.key.accountID == accountID }.map(\.value.task)
         self.inflight = self.inflight.filter { $0.key.accountID != accountID }
         tasks.forEach { $0.cancel() }
+    }
+
+    private func isCurrent(_ load: Load, for key: AccountScopedCacheKey) -> Bool {
+        guard self.isCurrentGeneration(load.generation, for: key),
+              let current = self.inflight[key]
+        else { return false }
+
+        return current.generation == load.generation && current.token == load.token
     }
 
     private func touch(_ key: AccountScopedCacheKey) {

--- a/Sources/RepoBar/StatusBar/RepoRecentMenuContext.swift
+++ b/Sources/RepoBar/StatusBar/RepoRecentMenuContext.swift
@@ -13,6 +13,7 @@ enum RepoRecentMenuKind: Hashable {
 }
 
 struct RepoRecentMenuContext: Hashable {
+    let accountID: String
     let fullName: String
     let kind: RepoRecentMenuKind
 }

--- a/Sources/RepoBar/StatusBar/RepoSubmenuBuilder.swift
+++ b/Sources/RepoBar/StatusBar/RepoSubmenuBuilder.swift
@@ -8,6 +8,7 @@ enum RepoSubmenuRowKind: String, Hashable {
 }
 
 struct RepoSubmenuRowIdentifier: Hashable {
+    let accountID: String
     let fullName: String
     let kind: RepoSubmenuRowKind
 }
@@ -395,6 +396,10 @@ struct RepoSubmenuBuilder {
         localStatus: LocalRepoStatus?,
         presentation: ChangelogRowPresentation?
     ) -> NSMenuItem {
+        guard let accountID = self.appState.session.settings.resolvedActiveAccount()?.id else {
+            return self.menuBuilder.infoItem("No active account")
+        }
+
         let submenu = NSMenu()
         submenu.autoenablesItems = false
         submenu.delegate = self.target
@@ -412,7 +417,11 @@ struct RepoSubmenuBuilder {
             detailText: detailText
         )
         let item = self.menuBuilder.viewItem(for: row, enabled: true, highlightable: true, submenu: submenu)
-        item.representedObject = RepoSubmenuRowIdentifier(fullName: fullName, kind: .changelog)
+        item.representedObject = RepoSubmenuRowIdentifier(
+            accountID: accountID,
+            fullName: fullName,
+            kind: .changelog
+        )
         return item
     }
 
@@ -457,12 +466,16 @@ struct RepoSubmenuBuilder {
     }
 
     private func recentListSubmenuItem(_ config: RecentListConfig) -> NSMenuItem {
+        guard let accountID = self.appState.session.settings.resolvedActiveAccount()?.id else {
+            return self.menuBuilder.infoItem("No active account")
+        }
+
         let submenu = NSMenu()
         submenu.autoenablesItems = false
         submenu.delegate = self.target
         self.target.registerRecentListMenu(
             submenu,
-            context: RepoRecentMenuContext(fullName: config.fullName, kind: config.kind)
+            context: RepoRecentMenuContext(accountID: accountID, fullName: config.fullName, kind: config.kind)
         )
 
         submenu.addItem(self.menuBuilder.actionItem(

--- a/Sources/RepoBar/StatusBar/StatusBarMenuBuilder+MenuItems.swift
+++ b/Sources/RepoBar/StatusBar/StatusBarMenuBuilder+MenuItems.swift
@@ -12,6 +12,8 @@ extension StatusBarMenuBuilder {
     }
 
     func repoMenuItem(for repo: RepositoryDisplayModel, isPinned: Bool) -> NSMenuItem {
+        let accountID = self.appState.session.settings.resolvedActiveAccount()?.id ?? "legacy"
+        let cacheKey = AccountScopedCacheKey(accountID: accountID, key: repo.id)
         let card = RepoMenuCardView(
             repo: repo,
             isPinned: isPinned,
@@ -24,7 +26,7 @@ extension StatusBarMenuBuilder {
             }
         )
         let submenu = self.repoSubmenu(for: repo, isPinned: isPinned)
-        if let cached = self.repoMenuItemsByID[repo.id] {
+        if let cached = self.repoMenuItemsByID[cacheKey] {
             // Remove from current menu if attached (prevents crash when reusing cached items)
             cached.menu?.removeItem(cached)
             self.menuItemFactory.updateItem(cached, with: card, highlightable: true, showsSubmenuIndicator: true)
@@ -35,11 +37,13 @@ extension StatusBarMenuBuilder {
             return cached
         }
         let item = self.viewItem(for: card, enabled: true, highlightable: true, submenu: submenu)
-        self.repoMenuItemsByID[repo.id] = item
+        self.repoMenuItemsByID[cacheKey] = item
         return item
     }
 
     func repoSubmenu(for repo: RepositoryDisplayModel, isPinned: Bool) -> NSMenu {
+        let accountID = self.appState.session.settings.resolvedActiveAccount()?.id ?? "legacy"
+        let cacheKey = AccountScopedCacheKey(accountID: accountID, key: repo.title)
         let changelogPresentation = self.target.cachedChangelogPresentation(
             fullName: repo.title,
             releaseTag: repo.source.latestRelease?.tag
@@ -57,24 +61,28 @@ extension StatusBarMenuBuilder {
             changelogHeadline: changelogHeadline,
             isPinned: isPinned
         )
-        if let cached = self.repoSubmenusByFullName[repo.title], cached.signature == signature {
+        if let cached = self.repoSubmenusByFullName[cacheKey], cached.signature == signature {
             return cached.menu
         }
         let menu = self.makeRepoSubmenu(for: repo, isPinned: isPinned)
-        self.repoSubmenusByFullName[repo.title] = RepoSubmenuCacheEntry(menu: menu, signature: signature)
+        self.repoSubmenusByFullName[cacheKey] = RepoSubmenuCacheEntry(menu: menu, signature: signature)
         return menu
     }
 
     func repoFullName(for menu: NSMenu) -> String? {
-        self.repoSubmenusByFullName.first(where: { $0.value.menu === menu })?.key
+        self.repoSubmenusByFullName.first(where: { $0.value.menu === menu })?.key.key
     }
 
     func updateChangelogRow(fullName: String, releaseTag: String?) {
-        guard let cached = self.repoSubmenusByFullName[fullName] else { return }
+        let accountID = self.appState.session.settings.resolvedActiveAccount()?.id ?? "legacy"
+        let cacheKey = AccountScopedCacheKey(accountID: accountID, key: fullName)
+        guard let cached = self.repoSubmenusByFullName[cacheKey] else { return }
         guard let item = cached.menu.items.first(where: {
             guard let identifier = $0.representedObject as? RepoSubmenuRowIdentifier else { return false }
 
-            return identifier.fullName == fullName && identifier.kind == .changelog
+            return identifier.accountID == accountID
+                && identifier.fullName == fullName
+                && identifier.kind == .changelog
         }) else { return }
 
         let presentation = self.target.cachedChangelogPresentation(fullName: fullName, releaseTag: releaseTag)

--- a/Sources/RepoBar/StatusBar/StatusBarMenuBuilder.swift
+++ b/Sources/RepoBar/StatusBar/StatusBarMenuBuilder.swift
@@ -344,7 +344,7 @@ final class StatusBarMenuBuilder {
             displayIndex[repo.fullName.lowercased()]
                 ?? RepositoryDisplayModel(
                     repo: repo,
-                    localStatus: session.localRepoIndex.status(for: repo, host: settings.githubHost),
+                    localStatus: session.localRepoIndex.status(for: repo, host: settings.resolvedRepositoryHost),
                     now: now
                 )
         }
@@ -363,7 +363,7 @@ final class StatusBarMenuBuilder {
         for localStatus in localRepos {
             guard let fullName = localStatus.fullName?.lowercased(),
                   let existingModel = displayIndex[fullName],
-                  localStatus.matches(host: settings.githubHost)
+                  localStatus.matches(host: settings.resolvedRepositoryHost)
             else {
                 let model = RepositoryDisplayModel(localStatus: localStatus, now: now)
                 models.append(model)

--- a/Sources/RepoBar/StatusBar/StatusBarMenuBuilder.swift
+++ b/Sources/RepoBar/StatusBar/StatusBarMenuBuilder.swift
@@ -10,8 +10,8 @@ final class StatusBarMenuBuilder {
     let appState: AppState
     unowned let target: StatusBarMenuManager
     let signposter = OSSignposter(subsystem: "com.steipete.repobar", category: "menu")
-    var repoMenuItemsByID: [String: NSMenuItem] = [:]
-    var repoSubmenusByFullName: [String: RepoSubmenuCacheEntry] = [:]
+    var repoMenuItemsByID: [AccountScopedCacheKey: NSMenuItem] = [:]
+    var repoSubmenusByFullName: [AccountScopedCacheKey: RepoSubmenuCacheEntry] = [:]
     var systemImageCache: [String: NSImage] = [:]
     let menuItemFactory = MenuItemViewFactory()
 
@@ -202,10 +202,11 @@ final class StatusBarMenuBuilder {
                 return [self.viewItem(for: emptyState, enabled: false)]
             }
             var items: [NSMenuItem] = []
-            var usedRepoIDs: Set<String> = []
-            var usedRepoFullNames: Set<String> = []
+            let accountID = settings.resolvedActiveAccount()?.id ?? "legacy"
+            var usedRepoIDs: Set<AccountScopedCacheKey> = []
+            var usedRepoFullNames: Set<AccountScopedCacheKey> = []
             for (index, repo) in uniqueRepos.enumerated() {
-                let isPinned = settings.repoList.pinnedRepositories.contains {
+                let isPinned = self.appState.activePinnedRepositories.contains {
                     $0.trimmingCharacters(in: .whitespacesAndNewlines)
                         .caseInsensitiveCompare(repo.title) == .orderedSame
                 }
@@ -215,8 +216,8 @@ final class StatusBarMenuBuilder {
                 if index < uniqueRepos.count - 1 {
                     items.append(self.repoCardSeparator())
                 }
-                usedRepoIDs.insert(repo.id)
-                usedRepoFullNames.insert(repo.title)
+                usedRepoIDs.insert(AccountScopedCacheKey(accountID: accountID, key: repo.id))
+                usedRepoFullNames.insert(AccountScopedCacheKey(accountID: accountID, key: repo.title))
             }
             self.repoMenuItemsByID = self.repoMenuItemsByID.filter { usedRepoIDs.contains($0.key) }
             self.repoSubmenusByFullName = self.repoSubmenusByFullName.filter { usedRepoFullNames.contains($0.key) }
@@ -321,6 +322,8 @@ final class StatusBarMenuBuilder {
         }
 
         let scope: RepositoryScope = selection.isPinnedScope ? .pinned : .all
+        let pinned = self.appState.activePinnedRepositories
+        let hidden = self.appState.activeHiddenRepositories
         let query = RepositoryQuery(
             scope: scope,
             onlyWith: selection.onlyWith,
@@ -328,8 +331,8 @@ final class StatusBarMenuBuilder {
             includeArchived: settings.repoList.showArchived,
             sortKey: settings.repoList.menuSortKey,
             limit: settings.repoList.displayLimit,
-            pinned: settings.repoList.pinnedRepositories,
-            hidden: Set(settings.repoList.hiddenRepositories),
+            pinned: pinned,
+            hidden: Set(hidden),
             pinPriority: true
         )
         let baseRepos = session.repositories.isEmpty
@@ -341,7 +344,7 @@ final class StatusBarMenuBuilder {
             displayIndex[repo.fullName.lowercased()]
                 ?? RepositoryDisplayModel(
                     repo: repo,
-                    localStatus: session.localRepoIndex.status(for: repo),
+                    localStatus: session.localRepoIndex.status(for: repo, host: settings.githubHost),
                     now: now
                 )
         }

--- a/Sources/RepoBar/StatusBar/StatusBarMenuBuilder.swift
+++ b/Sources/RepoBar/StatusBar/StatusBarMenuBuilder.swift
@@ -350,7 +350,7 @@ final class StatusBarMenuBuilder {
         }
     }
 
-    private func localScopeViewModels(
+    func localScopeViewModels(
         session: Session,
         settings: UserSettings,
         now: Date
@@ -362,7 +362,8 @@ final class StatusBarMenuBuilder {
         var models: [RepositoryDisplayModel] = []
         for localStatus in localRepos {
             guard let fullName = localStatus.fullName?.lowercased(),
-                  let existingModel = displayIndex[fullName]
+                  let existingModel = displayIndex[fullName],
+                  localStatus.matches(host: settings.githubHost)
             else {
                 let model = RepositoryDisplayModel(localStatus: localStatus, now: now)
                 models.append(model)

--- a/Sources/RepoBar/StatusBar/StatusBarMenuManager+Actions.swift
+++ b/Sources/RepoBar/StatusBar/StatusBarMenuManager+Actions.swift
@@ -263,18 +263,6 @@ extension StatusBarMenuManager {
     private func moveRepo(sender: NSMenuItem, direction: Int) {
         guard let fullName = self.repoFullName(from: sender) else { return }
 
-        var pins = self.appState.session.settings.repoList.pinnedRepositories
-        guard let currentIndex = pins.firstIndex(where: {
-            $0.caseInsensitiveCompare(fullName) == .orderedSame
-        }) else { return }
-
-        let maxIndex = max(pins.count - 1, 0)
-        let target = max(0, min(maxIndex, currentIndex + direction))
-        guard target != currentIndex else { return }
-
-        pins.move(fromOffsets: IndexSet(integer: currentIndex), toOffset: target > currentIndex ? target + 1 : target)
-        self.appState.session.settings.repoList.pinnedRepositories = pins
-        self.appState.persistSettings()
-        self.appState.requestRefresh(cancelInFlight: true)
+        Task { await self.appState.movePinned(fullName, direction: direction) }
     }
 }

--- a/Sources/RepoBar/StatusBar/StatusBarMenuManager.swift
+++ b/Sources/RepoBar/StatusBar/StatusBarMenuManager.swift
@@ -315,7 +315,7 @@ final class StatusBarMenuManager: NSObject, NSMenuDelegate {
 
         let localPath = self.appState.session.localRepoIndex.status(
             forFullName: fullName,
-            host: self.appState.session.settings.githubHost
+            host: self.appState.session.settings.resolvedRepositoryHost
         )?.path
         let releaseTag = self.appState.session.repositories
             .first(where: { $0.fullName == fullName })?
@@ -571,7 +571,7 @@ final class StatusBarMenuManager: NSObject, NSMenuDelegate {
 
         let local = self.appState.session.localRepoIndex.status(
             forFullName: fullName,
-            host: self.appState.session.settings.githubHost
+            host: self.appState.session.settings.resolvedRepositoryHost
         )
         return RepositoryDisplayModel(repo: repo, localStatus: local)
     }

--- a/Sources/RepoBar/StatusBar/StatusBarMenuManager.swift
+++ b/Sources/RepoBar/StatusBar/StatusBarMenuManager.swift
@@ -98,6 +98,25 @@ final class StatusBarMenuManager: NSObject, NSMenuDelegate {
             name: .issueNavigatorOpenRequested,
             object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.accountRepositoryStateRemoved(_:)),
+            name: .accountRepositoryStateDidRemove,
+            object: nil
+        )
+    }
+
+    @objc private func accountRepositoryStateRemoved(_ notification: Notification) {
+        guard let accountID = notification.object as? String else { return }
+
+        self.recentMenuService.removeCachedState(accountID: accountID)
+        self.changelogMenuCoordinator.removeCachedState(accountID: accountID)
+        self.menuBuilder.repoMenuItemsByID = self.menuBuilder.repoMenuItemsByID.filter {
+            $0.key.accountID != accountID
+        }
+        self.menuBuilder.repoSubmenusByFullName = self.menuBuilder.repoSubmenusByFullName.filter {
+            $0.key.accountID != accountID
+        }
     }
 
     func tearDownStatusItems() {
@@ -294,7 +313,10 @@ final class StatusBarMenuManager: NSObject, NSMenuDelegate {
     private func prefetchChangelogIfNeeded(for menu: NSMenu) {
         guard let fullName = self.menuBuilder.repoFullName(for: menu) else { return }
 
-        let localPath = self.appState.session.localRepoIndex.status(forFullName: fullName)?.path
+        let localPath = self.appState.session.localRepoIndex.status(
+            forFullName: fullName,
+            host: self.appState.session.settings.githubHost
+        )?.path
         let releaseTag = self.appState.session.repositories
             .first(where: { $0.fullName == fullName })?
             .latestRelease?
@@ -420,7 +442,14 @@ final class StatusBarMenuManager: NSObject, NSMenuDelegate {
     }
 
     func registerChangelogMenu(_ menu: NSMenu, fullName: String, localStatus: LocalRepoStatus?) {
-        self.changelogMenuCoordinator.registerChangelogMenu(menu, fullName: fullName, localStatus: localStatus)
+        guard let accountID = self.appState.session.settings.resolvedActiveAccount()?.id else { return }
+
+        self.changelogMenuCoordinator.registerChangelogMenu(
+            menu,
+            accountID: accountID,
+            fullName: fullName,
+            localStatus: localStatus
+        )
     }
 
     func cachedChangelogPresentation(fullName: String, releaseTag: String?) -> ChangelogRowPresentation? {
@@ -540,7 +569,10 @@ final class StatusBarMenuManager: NSObject, NSMenuDelegate {
         guard let fullName = self.repoFullName(from: sender) else { return nil }
         guard let repo = self.appState.session.repositories.first(where: { $0.fullName == fullName }) else { return nil }
 
-        let local = self.appState.session.localRepoIndex.status(forFullName: fullName)
+        let local = self.appState.session.localRepoIndex.status(
+            forFullName: fullName,
+            host: self.appState.session.settings.githubHost
+        )
         return RepositoryDisplayModel(repo: repo, localStatus: local)
     }
 

--- a/Sources/RepoBarCore/API/GitHubClient.swift
+++ b/Sources/RepoBarCore/API/GitHubClient.swift
@@ -45,6 +45,19 @@ public actor GitHubClient {
         self.archiveSettingsProvider = archiveSettingsProvider
     }
 
+    init(
+        accountID _: String,
+        archiveSettingsProvider: @Sendable @escaping () -> GitHubArchiveSettings,
+        dataLoader: HTTPDataLoader,
+        responseDiskCache: HTTPResponseDiskCache?,
+        etagCache: ETagCache = ETagCache()
+    ) {
+        self.responseDiskCache = responseDiskCache
+        self.requestRunner = GitHubRequestRunner(etagCache: etagCache, dataLoader: dataLoader)
+        self.graphQL = GraphQLClient(responseCache: nil, dataLoader: dataLoader)
+        self.archiveSettingsProvider = archiveSettingsProvider
+    }
+
     // MARK: - Config
 
     public func setAPIHost(_ host: URL) async {

--- a/Sources/RepoBarCore/API/RepoDetailCoordinator.swift
+++ b/Sources/RepoBarCore/API/RepoDetailCoordinator.swift
@@ -220,9 +220,11 @@ actor RepoDetailCoordinator {
 
     private func cachedRepository(from item: RepoItem, apiHost: URL, now: Date) -> Repository? {
         let cache = self.store.load(apiHost: apiHost, owner: item.owner.login, name: item.name)
-        guard let openPulls = cache.openPulls else { return nil }
-
         let cacheState = self.policy.state(for: cache, now: now)
+        guard let openPulls = cache.openPulls else {
+            return Repository.from(item: item, detailCacheState: cacheState)
+        }
+
         let ciDetails = cache.ciDetails
         let activitySnapshot = Self.cachedActivitySnapshot(
             latest: cache.latestActivity,

--- a/Sources/RepoBarCore/LocalProjects/LocalProjectsService.swift
+++ b/Sources/RepoBarCore/LocalProjects/LocalProjectsService.swift
@@ -137,6 +137,7 @@
                     path: repoURL,
                     name: repoName,
                     fullName: fullName,
+                    remoteHost: remote?.host,
                     branch: branch,
                     isClean: isClean,
                     aheadCount: ahead,

--- a/Sources/RepoBarCore/LocalProjects/LocalProjectsService.swift
+++ b/Sources/RepoBarCore/LocalProjects/LocalProjectsService.swift
@@ -338,16 +338,14 @@
         }
 
         private static func parseURL(_ value: String) -> GitRemote? {
-            guard let url = URL(string: value),
-                  let host = url.host
-            else { return nil }
+            guard let url = URL(string: value), url.host != nil else { return nil }
 
             let parts = url.path.split(separator: "/").map(String.init)
             guard parts.count >= 2 else { return nil }
 
             let owner = parts[parts.count - 2]
             let name = self.stripGitSuffix(parts.last ?? "")
-            return GitRemote(host: host, owner: owner, name: name)
+            return GitRemote(host: Account.hostAuthority(for: url), owner: owner, name: name)
         }
 
         private static func parseScp(_ value: String) -> GitRemote? {

--- a/Sources/RepoBarCore/LocalProjects/LocalRepoStatus.swift
+++ b/Sources/RepoBarCore/LocalProjects/LocalRepoStatus.swift
@@ -4,6 +4,7 @@ public struct LocalRepoStatus: Equatable, Sendable {
     public let path: URL
     public let name: String
     public let fullName: String?
+    public let remoteHost: String?
     public let branch: String
     public let isClean: Bool
     public let aheadCount: Int?
@@ -19,6 +20,7 @@ public struct LocalRepoStatus: Equatable, Sendable {
         path: URL,
         name: String,
         fullName: String?,
+        remoteHost: String? = nil,
         branch: String,
         isClean: Bool,
         aheadCount: Int?,
@@ -33,6 +35,7 @@ public struct LocalRepoStatus: Equatable, Sendable {
         self.path = path
         self.name = name
         self.fullName = fullName
+        self.remoteHost = remoteHost.map(Self.normalizedHost)
         self.branch = branch
         self.isClean = isClean
         self.aheadCount = aheadCount
@@ -82,6 +85,7 @@ public struct LocalRepoStatus: Equatable, Sendable {
             path: self.path,
             name: self.name,
             fullName: self.fullName,
+            remoteHost: self.remoteHost,
             branch: self.branch,
             isClean: self.isClean,
             aheadCount: self.aheadCount,
@@ -93,6 +97,15 @@ public struct LocalRepoStatus: Equatable, Sendable {
             upstreamBranch: self.upstreamBranch,
             lastFetchAt: date
         )
+    }
+
+    private static func normalizedHost(_ host: String) -> String {
+        let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard let url = URL(string: trimmed.contains("://") ? trimmed : "https://\(trimmed)") else {
+            return trimmed
+        }
+
+        return Account.hostAuthority(for: url)
     }
 }
 
@@ -220,37 +233,45 @@ public struct LocalRepoIndex: Equatable, Sendable {
     }
 
     public func status(for repo: Repository) -> LocalRepoStatus? {
-        if let preferred = self.preferredPathsByFullName[repo.fullName], let status = self.byPath[preferred] {
-            return status
-        }
-        if let exact = self.byFullName[repo.fullName] {
-            return exact
-        }
-        if let match = self.preferredStatus(in: self.byFullNameLowercased, forKey: repo.fullName.lowercased()) {
-            return match
-        }
-        return self.uniqueStatus(forName: repo.name)
+        self.status(for: repo, host: nil)
+    }
+
+    public func status(for repo: Repository, host: URL?) -> LocalRepoStatus? {
+        self.status(forFullName: repo.fullName, repositoryName: repo.name, host: host)
     }
 
     public func status(forFullName fullName: String) -> LocalRepoStatus? {
+        self.status(forFullName: fullName, repositoryName: fullName.split(separator: "/").last.map(String.init), host: nil)
+    }
+
+    public func status(forFullName fullName: String, host: URL) -> LocalRepoStatus? {
+        self.status(forFullName: fullName, repositoryName: fullName.split(separator: "/").last.map(String.init), host: host)
+    }
+
+    private func status(forFullName fullName: String, repositoryName: String?, host: URL?) -> LocalRepoStatus? {
         if let preferred = self.preferredPathsByFullName[fullName], let status = self.byPath[preferred] {
-            return status
+            if Self.matchesHost(status, host: host) {
+                return status
+            }
         }
-        if let exact = self.byFullName[fullName] {
+        if let exact = self.byFullName[fullName], Self.matchesHost(exact, host: host) {
             return exact
         }
-        if let match = self.preferredStatus(in: self.byFullNameLowercased, forKey: fullName.lowercased()) {
+        if let match = self.preferredStatus(
+            in: self.byFullNameLowercased,
+            forKey: fullName.lowercased(),
+            host: host
+        ) {
             return match
         }
-        let name = fullName.split(separator: "/").last.map(String.init)
-        if let name {
-            return self.uniqueStatus(forName: name)
+        if let repositoryName {
+            return self.uniqueStatus(forName: repositoryName, host: host)
         }
         return nil
     }
 
     public func status(forRepositoryName name: String) -> LocalRepoStatus? {
-        self.uniqueStatus(forName: name)
+        self.uniqueStatus(forName: name, host: nil)
     }
 
     public func status(containingPath path: String) -> LocalRepoStatus? {
@@ -270,25 +291,46 @@ public struct LocalRepoIndex: Equatable, Sendable {
         }
     }
 
-    private func uniqueStatus(forName name: String) -> LocalRepoStatus? {
-        if let exact = self.uniqueStatus(in: self.byName, forKey: name) {
+    private func uniqueStatus(forName name: String, host: URL?) -> LocalRepoStatus? {
+        if let exact = self.uniqueStatus(in: self.byName, forKey: name, host: host) {
             return exact
         }
-        return self.uniqueStatus(in: self.byNameLowercased, forKey: name.lowercased())
+        return self.uniqueStatus(in: self.byNameLowercased, forKey: name.lowercased(), host: host)
     }
 
-    private func uniqueStatus(in index: [String: [LocalRepoStatus]], forKey key: String) -> LocalRepoStatus? {
-        guard let matches = index[key], matches.count == 1 else { return nil }
+    private func uniqueStatus(
+        in index: [String: [LocalRepoStatus]],
+        forKey key: String,
+        host: URL?
+    ) -> LocalRepoStatus? {
+        guard let indexed = index[key] else { return nil }
+
+        let matches = indexed.filter { Self.matchesHost($0, host: host) }
+        guard matches.count == 1 else { return nil }
 
         return matches.first
     }
 
-    private func preferredStatus(in index: [String: [LocalRepoStatus]], forKey key: String) -> LocalRepoStatus? {
-        guard let matches = index[key], matches.isEmpty == false else { return nil }
+    private func preferredStatus(
+        in index: [String: [LocalRepoStatus]],
+        forKey key: String,
+        host: URL?
+    ) -> LocalRepoStatus? {
+        guard let indexed = index[key] else { return nil }
+
+        let matches = indexed.filter { Self.matchesHost($0, host: host) }
+        guard matches.isEmpty == false else { return nil }
 
         return matches.reduce(matches[0]) { current, candidate in
             Self.preferredStatus(current, candidate)
         }
+    }
+
+    private static func matchesHost(_ status: LocalRepoStatus, host: URL?) -> Bool {
+        guard let host else { return true }
+        guard let remoteHost = status.remoteHost else { return true }
+
+        return remoteHost == Self.normalizedHost(host)
     }
 
     private static func preferredStatus(_ lhs: LocalRepoStatus, _ rhs: LocalRepoStatus) -> LocalRepoStatus {
@@ -304,5 +346,18 @@ public struct LocalRepoIndex: Equatable, Sendable {
             return rhs
         }
         return lhs.path.path <= rhs.path.path ? lhs : rhs
+    }
+
+    private static func normalizedHost(_ host: URL) -> String {
+        Account.hostAuthority(for: host)
+    }
+
+    private static func normalizedHost(_ host: String) -> String {
+        let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard let url = URL(string: trimmed.contains("://") ? trimmed : "https://\(trimmed)") else {
+            return trimmed
+        }
+
+        return Account.hostAuthority(for: url)
     }
 }

--- a/Sources/RepoBarCore/LocalProjects/LocalRepoStatus.swift
+++ b/Sources/RepoBarCore/LocalProjects/LocalRepoStatus.swift
@@ -99,6 +99,12 @@ public struct LocalRepoStatus: Equatable, Sendable {
         )
     }
 
+    public func matches(host: URL) -> Bool {
+        guard let remoteHost else { return true }
+
+        return remoteHost == Account.hostAuthority(for: host)
+    }
+
     private static func normalizedHost(_ host: String) -> String {
         let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard let url = URL(string: trimmed.contains("://") ? trimmed : "https://\(trimmed)") else {
@@ -328,9 +334,8 @@ public struct LocalRepoIndex: Equatable, Sendable {
 
     private static func matchesHost(_ status: LocalRepoStatus, host: URL?) -> Bool {
         guard let host else { return true }
-        guard let remoteHost = status.remoteHost else { return true }
 
-        return remoteHost == Self.normalizedHost(host)
+        return status.matches(host: host)
     }
 
     private static func preferredStatus(_ lhs: LocalRepoStatus, _ rhs: LocalRepoStatus) -> LocalRepoStatus {

--- a/Sources/RepoBarCore/Models/AccountScopedIdentity.swift
+++ b/Sources/RepoBarCore/Models/AccountScopedIdentity.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Identifies the account that supplied a GitHub-backed value.
+public struct AccountSource: Codable, Equatable, Hashable, Sendable {
+    public let accountID: String
+
+    public init(accountID: String) {
+        self.accountID = accountID
+    }
+
+    public init(account: Account) {
+        self.init(accountID: account.id)
+    }
+}
+
+/// Collision-safe identity for a repository returned through a specific account.
+public struct AccountScopedRepositoryIdentity: Codable, Equatable, Hashable, Sendable {
+    public let source: AccountSource
+    public let repositoryID: String
+
+    public init(source: AccountSource, repositoryID: String) {
+        self.source = source
+        self.repositoryID = repositoryID
+    }
+
+    public init(accountID: String, repositoryID: String) {
+        self.init(source: AccountSource(accountID: accountID), repositoryID: repositoryID)
+    }
+}
+
+/// Collision-safe identity for account-scoped references that have a canonical URL.
+public struct AccountScopedURLIdentity: Codable, Equatable, Hashable, Sendable {
+    public let source: AccountSource
+    public let url: URL
+
+    public init(source: AccountSource, url: URL) {
+        self.source = source
+        self.url = url
+    }
+
+    public init(accountID: String, url: URL) {
+        self.init(source: AccountSource(accountID: accountID), url: url)
+    }
+}
+
+/// Collision-safe identity for notification and attention events.
+public struct AccountScopedEventIdentity: Codable, Equatable, Hashable, Sendable {
+    public let source: AccountSource
+    public let namespace: String
+    public let eventID: String
+
+    public init(source: AccountSource, namespace: String, eventID: String) {
+        self.source = source
+        self.namespace = namespace
+        self.eventID = eventID
+    }
+
+    public init(accountID: String, namespace: String, eventID: String) {
+        self.init(
+            source: AccountSource(accountID: accountID),
+            namespace: namespace,
+            eventID: eventID
+        )
+    }
+}
+
+/// Cache key that cannot collide across account-specific stores or request routes.
+public struct AccountScopedCacheKey: Codable, Equatable, Hashable, Sendable {
+    public let source: AccountSource
+    public let key: String
+
+    public init(source: AccountSource, key: String) {
+        self.source = source
+        self.key = key
+    }
+
+    public init(accountID: String, key: String) {
+        self.init(source: AccountSource(accountID: accountID), key: key)
+    }
+}

--- a/Sources/RepoBarCore/Models/AccountScopedIdentity.swift
+++ b/Sources/RepoBarCore/Models/AccountScopedIdentity.swift
@@ -77,4 +77,8 @@ public struct AccountScopedCacheKey: Codable, Equatable, Hashable, Sendable {
     public init(accountID: String, key: String) {
         self.init(source: AccountSource(accountID: accountID), key: key)
     }
+
+    public var accountID: String {
+        self.source.accountID
+    }
 }

--- a/Sources/RepoBarCore/Settings/AccountScopedRepositoryLists.swift
+++ b/Sources/RepoBarCore/Settings/AccountScopedRepositoryLists.swift
@@ -4,8 +4,6 @@ import Foundation
 ///
 /// Entries are stored as `owner/name` to mirror the legacy single-account
 /// `RepoListSettings.pinnedRepositories` / `hiddenRepositories` format.
-/// Legacy values continue to work via `merged(with:legacyAccountID:)` and
-/// `legacyPinned(activeAccountID:)` helpers.
 public struct AccountScopedRepositoryLists: Equatable, Codable, Sendable {
     public var pinnedByAccount: [String: [String]]
     public var hiddenByAccount: [String: [String]]
@@ -30,39 +28,39 @@ public struct AccountScopedRepositoryLists: Equatable, Codable, Sendable {
         self.hiddenByAccount[accountID] ?? []
     }
 
+    public func hasPinnedEntry(for accountID: String) -> Bool {
+        self.pinnedByAccount[accountID] != nil
+    }
+
+    public func hasHiddenEntry(for accountID: String) -> Bool {
+        self.hiddenByAccount[accountID] != nil
+    }
+
     public mutating func setPinned(_ items: [String], for accountID: String) {
-        let cleaned = Self.normalize(items)
-        if cleaned.isEmpty {
-            self.pinnedByAccount.removeValue(forKey: accountID)
-        } else {
-            self.pinnedByAccount[accountID] = cleaned
-        }
+        self.pinnedByAccount[accountID] = Self.normalize(items)
     }
 
     public mutating func setHidden(_ items: [String], for accountID: String) {
-        let cleaned = Self.normalize(items)
-        if cleaned.isEmpty {
-            self.hiddenByAccount.removeValue(forKey: accountID)
-        } else {
-            self.hiddenByAccount[accountID] = cleaned
-        }
+        self.hiddenByAccount[accountID] = Self.normalize(items)
     }
 
-    /// Returns pinned items for `accountID`, falling back to legacy single-list
-    /// entries when no per-account entry exists. Useful while migrating UI to
-    /// multi-account without breaking single-account users.
     public func pinned(for accountID: String, legacy: [String]) -> [String] {
-        if let perAccount = self.pinnedByAccount[accountID], perAccount.isEmpty == false {
+        if let perAccount = self.pinnedByAccount[accountID] {
             return perAccount
         }
         return legacy
     }
 
     public func hidden(for accountID: String, legacy: [String]) -> [String] {
-        if let perAccount = self.hiddenByAccount[accountID], perAccount.isEmpty == false {
+        if let perAccount = self.hiddenByAccount[accountID] {
             return perAccount
         }
         return legacy
+    }
+
+    public mutating func remove(accountID: String) {
+        self.pinnedByAccount.removeValue(forKey: accountID)
+        self.hiddenByAccount.removeValue(forKey: accountID)
     }
 
     private static func normalize(_ items: [String]) -> [String] {

--- a/Sources/RepoBarCore/Settings/AttentionRule.swift
+++ b/Sources/RepoBarCore/Settings/AttentionRule.swift
@@ -92,6 +92,10 @@ public struct AttentionRule: Codable, Equatable, Hashable, Identifiable, Sendabl
     public var itemStates: [AttentionItemState]
     public var priority: AttentionPriority
 
+    public var isEffectivelyEnabled: Bool {
+        self.enabled && self.category.isKnown
+    }
+
     public init(
         id: AttentionRuleID,
         enabled: Bool = true,
@@ -127,8 +131,7 @@ public struct AttentionRule: Codable, Equatable, Hashable, Identifiable, Sendabl
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.id = try container.decode(AttentionRuleID.self, forKey: .id)
         self.category = try container.decode(AttentionRuleCategory.self, forKey: .category)
-        let decodedEnabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
-        self.enabled = self.category.isKnown ? decodedEnabled : false
+        self.enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
         self.accountSelection = try container.decodeIfPresent(
             AccountSelection.self,
             forKey: .accountSelection

--- a/Sources/RepoBarCore/Settings/AttentionRule.swift
+++ b/Sources/RepoBarCore/Settings/AttentionRule.swift
@@ -1,0 +1,227 @@
+import Foundation
+
+public struct AttentionRuleID: RawRepresentable, Codable, Equatable, Hashable, Sendable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        try self.init(rawValue: container.decode(String.self))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.rawValue)
+    }
+}
+
+/// Extensible category value. Unknown raw values survive decoding so a newer rule
+/// does not invalidate the complete settings payload.
+public struct AttentionRuleCategory: RawRepresentable, Codable, Equatable, Hashable, Sendable {
+    public static let reviewRequests = Self(rawValue: "reviewRequests")
+    public static let assignedIssues = Self(rawValue: "assignedIssues")
+    public static let assignedPullRequests = Self(rawValue: "assignedPullRequests")
+    public static let mentions = Self(rawValue: "mentions")
+    public static let subscribedUpdates = Self(rawValue: "subscribedUpdates")
+    public static let authoredItems = Self(rawValue: "authoredItems")
+    public static let failedWorkflows = Self(rawValue: "failedWorkflows")
+    public static let runnerHealth = Self(rawValue: "runnerHealth")
+    public static let queuePressure = Self(rawValue: "queuePressure")
+    public static let criticalAPIHealth = Self(rawValue: "criticalAPIHealth")
+
+    public static let knownCategories: Set<Self> = [
+        .reviewRequests,
+        .assignedIssues,
+        .assignedPullRequests,
+        .mentions,
+        .subscribedUpdates,
+        .authoredItems,
+        .failedWorkflows,
+        .runnerHealth,
+        .queuePressure,
+        .criticalAPIHealth
+    ]
+
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public var isKnown: Bool {
+        Self.knownCategories.contains(self)
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        try self.init(rawValue: container.decode(String.self))
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.rawValue)
+    }
+}
+
+public enum AttentionItemState: String, Codable, Equatable, Hashable, Sendable {
+    case open
+    case closed
+    case merged
+    case pending
+    case failing
+    case unhealthy
+}
+
+public enum AttentionPriority: String, Codable, Equatable, Hashable, Sendable {
+    case low
+    case normal
+    case high
+    case critical
+}
+
+public struct AttentionRule: Codable, Equatable, Hashable, Identifiable, Sendable {
+    public let id: AttentionRuleID
+    public var enabled: Bool
+    public var category: AttentionRuleCategory
+    public var accountSelection: AccountSelection
+    public var ownerFilters: [String]
+    public var repositoryFilters: [String]
+    public var itemStates: [AttentionItemState]
+    public var priority: AttentionPriority
+
+    public init(
+        id: AttentionRuleID,
+        enabled: Bool = true,
+        category: AttentionRuleCategory,
+        accountSelection: AccountSelection = .all,
+        ownerFilters: [String] = [],
+        repositoryFilters: [String] = [],
+        itemStates: [AttentionItemState] = [],
+        priority: AttentionPriority = .normal
+    ) {
+        self.id = id
+        self.enabled = enabled
+        self.category = category
+        self.accountSelection = accountSelection
+        self.ownerFilters = ownerFilters
+        self.repositoryFilters = repositoryFilters
+        self.itemStates = itemStates
+        self.priority = priority
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case enabled
+        case category
+        case accountSelection
+        case ownerFilters
+        case repositoryFilters
+        case itemStates
+        case priority
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(AttentionRuleID.self, forKey: .id)
+        self.category = try container.decode(AttentionRuleCategory.self, forKey: .category)
+        let decodedEnabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
+        self.enabled = self.category.isKnown ? decodedEnabled : false
+        self.accountSelection = try container.decodeIfPresent(
+            AccountSelection.self,
+            forKey: .accountSelection
+        ) ?? .all
+        self.ownerFilters = try container.decodeIfPresent([String].self, forKey: .ownerFilters) ?? []
+        self.repositoryFilters = try container.decodeIfPresent(
+            [String].self,
+            forKey: .repositoryFilters
+        ) ?? []
+        self.itemStates = try container.decodeIfPresent([AttentionItemState].self, forKey: .itemStates) ?? []
+        self.priority = try container.decodeIfPresent(AttentionPriority.self, forKey: .priority) ?? .normal
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.id, forKey: .id)
+        try container.encode(self.enabled, forKey: .enabled)
+        try container.encode(self.category, forKey: .category)
+        if case .all = self.accountSelection {
+            // Default account inclusion is represented by omission.
+        } else {
+            try container.encode(self.accountSelection, forKey: .accountSelection)
+        }
+        if self.ownerFilters.isEmpty == false {
+            try container.encode(self.ownerFilters, forKey: .ownerFilters)
+        }
+        if self.repositoryFilters.isEmpty == false {
+            try container.encode(self.repositoryFilters, forKey: .repositoryFilters)
+        }
+        if self.itemStates.isEmpty == false {
+            try container.encode(self.itemStates, forKey: .itemStates)
+        }
+        if self.priority != .normal {
+            try container.encode(self.priority, forKey: .priority)
+        }
+    }
+}
+
+public enum AttentionRulePresets {
+    public static func conservativeDefault(
+        pinnedRepositories: [String],
+        accountSelection: AccountSelection = .all
+    ) -> [AttentionRule] {
+        let repositories = self.normalizeRepositories(pinnedRepositories)
+        guard repositories.isEmpty == false else { return [] }
+
+        return [
+            AttentionRule(
+                id: AttentionRuleID(rawValue: "default.review-requests"),
+                category: .reviewRequests,
+                accountSelection: accountSelection,
+                repositoryFilters: repositories,
+                priority: .high
+            ),
+            AttentionRule(
+                id: AttentionRuleID(rawValue: "default.assigned-issues"),
+                category: .assignedIssues,
+                accountSelection: accountSelection,
+                repositoryFilters: repositories,
+                itemStates: [.open],
+                priority: .high
+            ),
+            AttentionRule(
+                id: AttentionRuleID(rawValue: "default.assigned-pull-requests"),
+                category: .assignedPullRequests,
+                accountSelection: accountSelection,
+                repositoryFilters: repositories,
+                itemStates: [.open],
+                priority: .high
+            ),
+            AttentionRule(
+                id: AttentionRuleID(rawValue: "default.failed-workflows"),
+                category: .failedWorkflows,
+                accountSelection: accountSelection,
+                repositoryFilters: repositories,
+                itemStates: [.failing],
+                priority: .critical
+            )
+        ]
+    }
+
+    private static func normalizeRepositories(_ repositories: [String]) -> [String] {
+        var seen: Set<String> = []
+        return repositories
+            .compactMap { repository -> String? in
+                let trimmed = repository.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard trimmed.isEmpty == false else { return nil }
+
+                let normalized = trimmed.lowercased()
+                guard seen.insert(normalized).inserted else { return nil }
+
+                return normalized
+            }
+            .sorted()
+    }
+}

--- a/Sources/RepoBarCore/Settings/UserSettings.swift
+++ b/Sources/RepoBarCore/Settings/UserSettings.swift
@@ -198,6 +198,82 @@ public struct UserSettings: Equatable, Codable {
             return ids.filter { selected.contains($0) }
         }
     }
+
+    public func pinnedRepositories(for accountID: String) -> [String] {
+        if self.accountRepoLists.hasPinnedEntry(for: accountID) {
+            return self.accountRepoLists.pinned(for: accountID)
+        }
+        guard self.resolvedActiveAccount()?.id == accountID else { return [] }
+
+        return self.repoList.pinnedRepositories
+    }
+
+    public func hiddenRepositories(for accountID: String) -> [String] {
+        if self.accountRepoLists.hasHiddenEntry(for: accountID) {
+            return self.accountRepoLists.hidden(for: accountID)
+        }
+        guard self.resolvedActiveAccount()?.id == accountID else { return [] }
+
+        return self.repoList.hiddenRepositories
+    }
+
+    public mutating func migrateLegacyRepositoryListsToActiveAccountIfNeeded() -> Bool {
+        guard let accountID = self.resolvedActiveAccount()?.id else { return false }
+
+        var changed = false
+        if self.accountRepoLists.hasPinnedEntry(for: accountID) == false {
+            self.accountRepoLists.setPinned(self.repoList.pinnedRepositories, for: accountID)
+            changed = true
+        }
+        if self.accountRepoLists.hasHiddenEntry(for: accountID) == false {
+            self.accountRepoLists.setHidden(self.repoList.hiddenRepositories, for: accountID)
+            changed = true
+        }
+        return changed
+    }
+
+    public mutating func prepareRepositoryListsForActiveAccountChange(to accountID: String) {
+        _ = self.migrateLegacyRepositoryListsToActiveAccountIfNeeded()
+        if self.accountRepoLists.hasPinnedEntry(for: accountID) == false {
+            self.accountRepoLists.setPinned([], for: accountID)
+        }
+        if self.accountRepoLists.hasHiddenEntry(for: accountID) == false {
+            self.accountRepoLists.setHidden([], for: accountID)
+        }
+        self.activeAccountID = accountID
+        self.mirrorRepositoryListsToLegacy(for: accountID)
+    }
+
+    public mutating func setPinnedRepositories(_ repositories: [String], for accountID: String) {
+        let isActive = self.resolvedActiveAccount()?.id == accountID
+        if isActive {
+            _ = self.migrateLegacyRepositoryListsToActiveAccountIfNeeded()
+        }
+        self.accountRepoLists.setPinned(repositories, for: accountID)
+        if isActive {
+            self.repoList.pinnedRepositories = self.accountRepoLists.pinned(for: accountID)
+        }
+    }
+
+    public mutating func setHiddenRepositories(_ repositories: [String], for accountID: String) {
+        let isActive = self.resolvedActiveAccount()?.id == accountID
+        if isActive {
+            _ = self.migrateLegacyRepositoryListsToActiveAccountIfNeeded()
+        }
+        self.accountRepoLists.setHidden(repositories, for: accountID)
+        if isActive {
+            self.repoList.hiddenRepositories = self.accountRepoLists.hidden(for: accountID)
+        }
+    }
+
+    public mutating func removeRepositoryLists(for accountID: String) {
+        self.accountRepoLists.remove(accountID: accountID)
+    }
+
+    public mutating func mirrorRepositoryListsToLegacy(for accountID: String) {
+        self.repoList.pinnedRepositories = self.accountRepoLists.pinned(for: accountID)
+        self.repoList.hiddenRepositories = self.accountRepoLists.hidden(for: accountID)
+    }
 }
 
 public struct ActionsSettings: Equatable, Codable {

--- a/Sources/RepoBarCore/Settings/UserSettings.swift
+++ b/Sources/RepoBarCore/Settings/UserSettings.swift
@@ -29,6 +29,8 @@ public struct UserSettings: Equatable, Codable {
     public var activeAccountID: String?
     public var accountSelection: AccountSelection = .all
     public var accountRepoLists: AccountScopedRepositoryLists = .init()
+    public var consolidateAccounts = false
+    public var attentionRules: [AttentionRule] = []
 
     public init() {}
 
@@ -60,6 +62,8 @@ public struct UserSettings: Equatable, Codable {
         case activeAccountID
         case accountSelection
         case accountRepoLists
+        case consolidateAccounts
+        case attentionRules
     }
 
     public init(from decoder: Decoder) throws {
@@ -112,6 +116,14 @@ public struct UserSettings: Equatable, Codable {
             AccountScopedRepositoryLists.self,
             forKey: .accountRepoLists
         ) ?? AccountScopedRepositoryLists()
+        self.consolidateAccounts = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .consolidateAccounts
+        ) ?? false
+        self.attentionRules = try container.decodeIfPresent(
+            [AttentionRule].self,
+            forKey: .attentionRules
+        ) ?? []
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -152,6 +164,12 @@ public struct UserSettings: Equatable, Codable {
         }
         if self.accountRepoLists.isEmpty == false {
             try container.encode(self.accountRepoLists, forKey: .accountRepoLists)
+        }
+        if self.consolidateAccounts {
+            try container.encode(true, forKey: .consolidateAccounts)
+        }
+        if self.attentionRules.isEmpty == false {
+            try container.encode(self.attentionRules, forKey: .attentionRules)
         }
     }
 
@@ -314,6 +332,7 @@ public struct AISummarySettings: Equatable, Codable, Sendable {
 
     public var enabled = false
     public var model = defaultModel
+    public var allowNonActiveAccountContent = false
 
     public init() {}
 
@@ -327,6 +346,7 @@ public struct AISummarySettings: Equatable, Codable, Sendable {
     enum CodingKeys: String, CodingKey {
         case enabled
         case model
+        case allowNonActiveAccountContent
     }
 
     public init(from decoder: Decoder) throws {
@@ -334,6 +354,19 @@ public struct AISummarySettings: Equatable, Codable, Sendable {
         self.enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
         let decodedModel = try container.decodeIfPresent(String.self, forKey: .model) ?? Self.defaultModel
         self.model = Self.normalizedModel(decodedModel)
+        self.allowNonActiveAccountContent = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .allowNonActiveAccountContent
+        ) ?? false
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.enabled, forKey: .enabled)
+        try container.encode(self.model, forKey: .model)
+        if self.allowNonActiveAccountContent {
+            try container.encode(true, forKey: .allowNonActiveAccountContent)
+        }
     }
 }
 

--- a/Sources/RepoBarCore/Settings/UserSettings.swift
+++ b/Sources/RepoBarCore/Settings/UserSettings.swift
@@ -199,6 +199,10 @@ public struct UserSettings: Equatable, Codable {
         }
     }
 
+    public var resolvedRepositoryHost: URL {
+        self.resolvedActiveAccount()?.host ?? self.enterpriseHost ?? self.githubHost
+    }
+
     public func pinnedRepositories(for accountID: String) -> [String] {
         if self.accountRepoLists.hasPinnedEntry(for: accountID) {
             return self.accountRepoLists.pinned(for: accountID)

--- a/Sources/RepoBarCore/Settings/UserSettings.swift
+++ b/Sources/RepoBarCore/Settings/UserSettings.swift
@@ -233,7 +233,18 @@ public struct UserSettings: Equatable, Codable {
     }
 
     public mutating func prepareRepositoryListsForActiveAccountChange(to accountID: String) {
+        self.prepareRepositoryListsForActiveAccountChange(to: Optional(accountID))
+    }
+
+    public mutating func prepareRepositoryListsForActiveAccountChange(to accountID: String?) {
         _ = self.migrateLegacyRepositoryListsToActiveAccountIfNeeded()
+        guard let accountID else {
+            self.activeAccountID = nil
+            self.repoList.pinnedRepositories = []
+            self.repoList.hiddenRepositories = []
+            return
+        }
+
         if self.accountRepoLists.hasPinnedEntry(for: accountID) == false {
             self.accountRepoLists.setPinned([], for: accountID)
         }

--- a/Sources/RepoBarCore/Support/RepoBarCacheDatabase.swift
+++ b/Sources/RepoBarCore/Support/RepoBarCacheDatabase.swift
@@ -84,7 +84,15 @@ public enum RepoBarPersistentCache {
     }
 
     public static func summary(limit: Int = 10, fileManager: FileManager = .default) throws -> RepoBarCacheSummary {
-        guard let url = self.standardDatabaseURL(fileManager: fileManager) else {
+        try self.summary(accountID: nil, limit: limit, fileManager: fileManager)
+    }
+
+    public static func summary(
+        accountID: String?,
+        limit: Int = 10,
+        fileManager: FileManager = .default
+    ) throws -> RepoBarCacheSummary {
+        guard let url = self.databaseURL(accountID: accountID, fileManager: fileManager) else {
             throw RepoBarCacheError.missingApplicationSupportDirectory
         }
 

--- a/Sources/repobarcli/AccountsCommands.swift
+++ b/Sources/repobarcli/AccountsCommands.swift
@@ -102,7 +102,7 @@ struct AccountsUseCommand: CommanderRunnableCommand {
         var settings = store.load()
         let account = try AccountResolver.resolve(self.target, settings: settings)
         try mirrorAccountCredentialsToLegacy(account)
-        settings.activeAccountID = account.id
+        settings.prepareRepositoryListsForActiveAccountChange(to: account.id)
         mirrorActiveAccountIntoSettings(account, settings: &settings)
         store.save(settings)
         print("Active account set to \(account.id).")
@@ -132,13 +132,14 @@ struct AccountsRemoveCommand: CommanderRunnableCommand {
         var settings = store.load()
         let account = try AccountResolver.resolve(self.target, settings: settings)
         TokenStore.shared.clear(accountID: account.id)
-        settings.accounts.removeAll(where: { $0.id == account.id })
-        if settings.activeAccountID == account.id {
-            settings.activeAccountID = settings.accounts.first?.id
+        let wasActive = settings.resolvedActiveAccount()?.id == account.id
+        if wasActive {
+            let nextAccountID = settings.accounts.first(where: { $0.id != account.id })?.id
+            settings.prepareRepositoryListsForActiveAccountChange(to: nextAccountID)
         }
+        settings.accounts.removeAll(where: { $0.id == account.id })
+        settings.removeRepositoryLists(for: account.id)
         mirrorResolvedActiveAccount(settings: &settings)
-        settings.accountRepoLists.pinnedByAccount.removeValue(forKey: account.id)
-        settings.accountRepoLists.hiddenByAccount.removeValue(forKey: account.id)
         store.save(settings)
         print("Removed account \(account.id).")
     }

--- a/Sources/repobarcli/CLIContext.swift
+++ b/Sources/repobarcli/CLIContext.swift
@@ -84,9 +84,13 @@ func mirrorActiveAccountIntoSettings(_ account: Account, settings: inout UserSet
 func mirrorResolvedActiveAccount(settings: inout UserSettings) {
     guard let active = settings.resolvedActiveAccount() else {
         TokenStore.shared.clear()
+        settings.repoList.pinnedRepositories = []
+        settings.repoList.hiddenRepositories = []
         return
     }
 
+    _ = settings.migrateLegacyRepositoryListsToActiveAccountIfNeeded()
+    settings.mirrorRepositoryListsToLegacy(for: active.id)
     mirrorActiveAccountIntoSettings(active, settings: &settings)
     _ = TokenStore.shared.mirrorAccountCredentialsToLegacy(
         accountID: active.id,

--- a/Sources/repobarcli/CLIContext.swift
+++ b/Sources/repobarcli/CLIContext.swift
@@ -81,6 +81,16 @@ func mirrorActiveAccountIntoSettings(_ account: Account, settings: inout UserSet
     settings.loopbackPort = account.loopbackPort
 }
 
+func activateCLIAccount(_ account: Account, settings: inout UserSettings) {
+    _ = settings.migrateLegacyRepositoryListsToActiveAccountIfNeeded()
+    if let index = settings.accounts.firstIndex(where: { $0.id == account.id }) {
+        settings.accounts[index] = account
+    } else {
+        settings.accounts.append(account)
+    }
+    settings.prepareRepositoryListsForActiveAccountChange(to: account.id)
+}
+
 func mirrorResolvedActiveAccount(settings: inout UserSettings) {
     guard let active = settings.resolvedActiveAccount() else {
         TokenStore.shared.clear()

--- a/Sources/repobarcli/Commands.swift
+++ b/Sources/repobarcli/Commands.swift
@@ -457,7 +457,7 @@ struct LoginCommand: CommanderRunnableCommand {
         } else {
             settings.accounts.append(account)
         }
-        settings.activeAccountID = account.id
+        settings.prepareRepositoryListsForActiveAccountChange(to: account.id)
         store.save(settings)
 
         print("Login succeeded; tokens stored for \(account.id).")
@@ -497,8 +497,11 @@ struct LogoutCommand: CommanderRunnableCommand {
             for accountID in scopedAccountIDs {
                 TokenStore.shared.clear(accountID: accountID)
             }
+            settings.prepareRepositoryListsForActiveAccountChange(to: nil)
+            for accountID in settings.accounts.map(\.id) {
+                settings.removeRepositoryLists(for: accountID)
+            }
             settings.accounts = []
-            settings.activeAccountID = nil
             store.save(settings)
             print("Logged out of all accounts.")
             return
@@ -512,10 +515,13 @@ struct LogoutCommand: CommanderRunnableCommand {
 
         let resolved = try AccountResolver.resolve(self.account, settings: settings)
         TokenStore.shared.clear(accountID: resolved.id)
-        settings.accounts.removeAll(where: { $0.id == resolved.id })
-        if settings.activeAccountID == resolved.id {
-            settings.activeAccountID = settings.accounts.first?.id
+        let wasActive = settings.resolvedActiveAccount()?.id == resolved.id
+        if wasActive {
+            let nextAccountID = settings.accounts.first(where: { $0.id != resolved.id })?.id
+            settings.prepareRepositoryListsForActiveAccountChange(to: nextAccountID)
         }
+        settings.accounts.removeAll(where: { $0.id == resolved.id })
+        settings.removeRepositoryLists(for: resolved.id)
         mirrorResolvedActiveAccount(settings: &settings)
         store.save(settings)
         print("Logged out of \(resolved.id).")
@@ -622,7 +628,7 @@ struct ImportGHTokenCommand: CommanderRunnableCommand {
         } else {
             settings.accounts.append(account)
         }
-        settings.activeAccountID = account.id
+        settings.prepareRepositoryListsForActiveAccountChange(to: account.id)
         store.save(settings)
 
         print("Successfully imported gh CLI token for \(account.id).")

--- a/Sources/repobarcli/Commands.swift
+++ b/Sources/repobarcli/Commands.swift
@@ -452,12 +452,7 @@ struct LoginCommand: CommanderRunnableCommand {
         } else {
             settings.enterpriseHost = normalizedHost
         }
-        if let index = settings.accounts.firstIndex(where: { $0.id == account.id }) {
-            settings.accounts[index] = account
-        } else {
-            settings.accounts.append(account)
-        }
-        settings.prepareRepositoryListsForActiveAccountChange(to: account.id)
+        activateCLIAccount(account, settings: &settings)
         store.save(settings)
 
         print("Login succeeded; tokens stored for \(account.id).")
@@ -623,12 +618,7 @@ struct ImportGHTokenCommand: CommanderRunnableCommand {
         } else {
             settings.enterpriseHost = normalizedHost
         }
-        if let index = settings.accounts.firstIndex(where: { $0.id == account.id }) {
-            settings.accounts[index] = account
-        } else {
-            settings.accounts.append(account)
-        }
-        settings.prepareRepositoryListsForActiveAccountChange(to: account.id)
+        activateCLIAccount(account, settings: &settings)
         store.save(settings)
 
         print("Successfully imported gh CLI token for \(account.id).")

--- a/Sources/repobarcli/SettingsCommands.swift
+++ b/Sources/repobarcli/SettingsCommands.swift
@@ -30,10 +30,7 @@ struct PinCommand: CommanderRunnableCommand {
         let store = cliSettingsStore()
         var settings = store.load()
 
-        settings.repoList.hiddenRepositories.removeAll { $0.equalsCaseInsensitive(normalized) }
-        if settings.repoList.pinnedRepositories.contains(where: { $0.equalsCaseInsensitive(normalized) }) == false {
-            settings.repoList.pinnedRepositories.append(normalized)
-        }
+        applyRepoListMutation(.pin, repository: normalized, settings: &settings)
         store.save(settings)
 
         try renderRepoListUpdate(
@@ -73,7 +70,7 @@ struct UnpinCommand: CommanderRunnableCommand {
         let store = cliSettingsStore()
         var settings = store.load()
 
-        settings.repoList.pinnedRepositories.removeAll { $0.equalsCaseInsensitive(normalized) }
+        applyRepoListMutation(.unpin, repository: normalized, settings: &settings)
         store.save(settings)
 
         try renderRepoListUpdate(
@@ -113,10 +110,7 @@ struct HideCommand: CommanderRunnableCommand {
         let store = cliSettingsStore()
         var settings = store.load()
 
-        settings.repoList.pinnedRepositories.removeAll { $0.equalsCaseInsensitive(normalized) }
-        if settings.repoList.hiddenRepositories.contains(where: { $0.equalsCaseInsensitive(normalized) }) == false {
-            settings.repoList.hiddenRepositories.append(normalized)
-        }
+        applyRepoListMutation(.hide, repository: normalized, settings: &settings)
         store.save(settings)
 
         try renderRepoListUpdate(
@@ -156,7 +150,7 @@ struct ShowCommand: CommanderRunnableCommand {
         let store = cliSettingsStore()
         var settings = store.load()
 
-        settings.repoList.hiddenRepositories.removeAll { $0.equalsCaseInsensitive(normalized) }
+        applyRepoListMutation(.show, repository: normalized, settings: &settings)
         store.save(settings)
 
         try renderRepoListUpdate(

--- a/Sources/repobarcli/SettingsSupport.swift
+++ b/Sources/repobarcli/SettingsSupport.swift
@@ -464,6 +464,66 @@ func normalizeRepoFullName(_ raw: String) throws -> String {
     try parseRepoName(raw).fullName
 }
 
+enum RepoListMutation {
+    case pin
+    case unpin
+    case hide
+    case show
+}
+
+func applyRepoListMutation(
+    _ mutation: RepoListMutation,
+    repository fullName: String,
+    settings: inout UserSettings
+) {
+    guard let accountID = settings.resolvedActiveAccount()?.id else {
+        applyLegacyRepoListMutation(mutation, repository: fullName, settings: &settings)
+        return
+    }
+
+    var pinned = settings.pinnedRepositories(for: accountID)
+    var hidden = settings.hiddenRepositories(for: accountID)
+    applyRepoListMutation(mutation, repository: fullName, pinned: &pinned, hidden: &hidden)
+    settings.setPinnedRepositories(pinned, for: accountID)
+    settings.setHiddenRepositories(hidden, for: accountID)
+}
+
+private func applyLegacyRepoListMutation(
+    _ mutation: RepoListMutation,
+    repository fullName: String,
+    settings: inout UserSettings
+) {
+    var pinned = settings.repoList.pinnedRepositories
+    var hidden = settings.repoList.hiddenRepositories
+    applyRepoListMutation(mutation, repository: fullName, pinned: &pinned, hidden: &hidden)
+    settings.repoList.pinnedRepositories = pinned
+    settings.repoList.hiddenRepositories = hidden
+}
+
+private func applyRepoListMutation(
+    _ mutation: RepoListMutation,
+    repository fullName: String,
+    pinned: inout [String],
+    hidden: inout [String]
+) {
+    switch mutation {
+    case .pin:
+        hidden.removeAll { $0.equalsCaseInsensitive(fullName) }
+        if pinned.contains(where: { $0.equalsCaseInsensitive(fullName) }) == false {
+            pinned.append(fullName)
+        }
+    case .unpin:
+        pinned.removeAll { $0.equalsCaseInsensitive(fullName) }
+    case .hide:
+        pinned.removeAll { $0.equalsCaseInsensitive(fullName) }
+        if hidden.contains(where: { $0.equalsCaseInsensitive(fullName) }) == false {
+            hidden.append(fullName)
+        }
+    case .show:
+        hidden.removeAll { $0.equalsCaseInsensitive(fullName) }
+    }
+}
+
 func renderRepoListUpdate(action: String, repoName: String, settings: UserSettings, output: OutputOptions) throws {
     if output.jsonOutput {
         let payload = RepoListOutput(

--- a/Tests/RepoBarTests/AccountManagerTests.swift
+++ b/Tests/RepoBarTests/AccountManagerTests.swift
@@ -79,6 +79,26 @@ struct AccountManagerTests {
         #expect(try await manager.currentAccessToken(accountID: account.id) == "pat-token")
     }
 
+    @Test
+    func `explicit client resolver returns scoped client and throws for unknown account`() async throws {
+        let (store, account) = try Self.makeStoreAndAccount(authMethod: .pat)
+        defer { store.clear(accountID: account.id) }
+        try store.savePAT("pat-token", accountID: account.id)
+        let manager = AccountManager(tokenStore: store)
+        await manager.bootstrap(from: Self.settings(account: account))
+
+        let resolved = try manager.resolveClient(for: account.id)
+        let expected = try #require(manager.client(for: account.id))
+        #expect(resolved === expected)
+
+        do {
+            _ = try manager.resolveClient(for: "github.com#missing")
+            Issue.record("Expected unknown account error")
+        } catch let AccountManagerError.unknownAccount(accountID) {
+            #expect(accountID == "github.com#missing")
+        }
+    }
+
     private static func makeStoreAndAccount(authMethod: AuthMethod) throws -> (TokenStore, Account) {
         let service = "com.steipete.repobar.account-manager-tests.\(UUID().uuidString)"
         let store = TokenStore(service: service)

--- a/Tests/RepoBarTests/ChangelogMenuCoordinatorTests.swift
+++ b/Tests/RepoBarTests/ChangelogMenuCoordinatorTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+@testable import RepoBar
+import Testing
+
+struct ChangelogMenuCoordinatorTests {
+    @MainActor
+    @Test
+    func `removed account changelog request cannot repopulate cache after readd`() async {
+        let gate = ChangelogResponseGate()
+        let appState = AppState()
+        let manager = StatusBarMenuManager(appState: appState)
+        let builder = StatusBarMenuBuilder(appState: appState, target: manager)
+        let coordinator = ChangelogMenuCoordinator(
+            appState: appState,
+            menuBuilder: builder,
+            menuItemFactory: MenuItemViewFactory(),
+            fetchOverride: { _, _, _ in
+                await gate.fetch()
+            }
+        )
+
+        let first = Task { @MainActor in
+            await coordinator.loadChangelogForTesting(accountID: "alice", fullName: "owner/repo")
+        }
+        await gate.waitUntilFirstRequestStarts()
+        coordinator.removeCachedState(accountID: "alice")
+        await gate.releaseFirstRequest()
+
+        #expect(await first.value == false)
+        #expect(coordinator.hasCachedStateForTesting(accountID: "alice", fullName: "owner/repo") == false)
+
+        #expect(await coordinator.loadChangelogForTesting(accountID: "alice", fullName: "owner/repo"))
+        #expect(coordinator.hasCachedStateForTesting(accountID: "alice", fullName: "owner/repo"))
+    }
+}
+
+private actor ChangelogResponseGate {
+    private var requestCount = 0
+    private var firstRequestContinuation: CheckedContinuation<Void, Never>?
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func fetch() async -> ChangelogFetchResult {
+        self.requestCount += 1
+        if self.requestCount == 1 {
+            let waiters = self.startWaiters
+            self.startWaiters = []
+            waiters.forEach { $0.resume() }
+            await withCheckedContinuation { continuation in
+                self.firstRequestContinuation = continuation
+            }
+        }
+        return ChangelogFetchResult(result: .missing, parsed: nil)
+    }
+
+    func waitUntilFirstRequestStarts() async {
+        guard self.requestCount == 0 else { return }
+
+        await withCheckedContinuation { continuation in
+            self.startWaiters.append(continuation)
+        }
+    }
+
+    func releaseFirstRequest() {
+        self.firstRequestContinuation?.resume()
+        self.firstRequestContinuation = nil
+    }
+}

--- a/Tests/RepoBarTests/LocalProjectsServiceTests.swift
+++ b/Tests/RepoBarTests/LocalProjectsServiceTests.swift
@@ -54,11 +54,14 @@ struct LocalProjectsServiceTests {
         let repoA = root.appendingPathComponent("repo-a", isDirectory: true)
         let nested = root.appendingPathComponent("group", isDirectory: true)
         let repoB = nested.appendingPathComponent("repo-b", isDirectory: true)
+        let repoC = root.appendingPathComponent("repo-c", isDirectory: true)
         try FileManager.default.createDirectory(at: repoA, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: repoB, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: repoC, withIntermediateDirectories: true)
 
         try initializeRepo(at: repoA, origin: "git@github.com:foo/repo-a.git")
         try initializeRepo(at: repoB, origin: "https://github.com/foo/repo-b.git")
+        try initializeRepo(at: repoC, origin: "https://ghe.example.com:8443/foo/repo-c.git")
 
         let snapshot = await LocalProjectsService().snapshot(
             rootPath: root.path,
@@ -67,12 +70,16 @@ struct LocalProjectsServiceTests {
             concurrencyLimit: 1
         )
 
-        #expect(snapshot.statuses.count == 2)
+        #expect(snapshot.statuses.count == 3)
         let names = Set(snapshot.statuses.map(\.displayName))
         #expect(names.contains("foo/repo-a"))
         #expect(names.contains("foo/repo-b"))
+        #expect(names.contains("foo/repo-c"))
         let repoAStatus = snapshot.statuses.first(where: { $0.name == "repo-a" })
         #expect(repoAStatus?.branch == "main")
+        #expect(repoAStatus?.remoteHost == "github.com")
+        #expect(snapshot.statuses.first(where: { $0.name == "repo-b" })?.remoteHost == "github.com")
+        #expect(snapshot.statuses.first(where: { $0.name == "repo-c" })?.remoteHost == "ghe.example.com:8443")
     }
 
     @Test

--- a/Tests/RepoBarTests/LocalProjectsServiceTests.swift
+++ b/Tests/RepoBarTests/LocalProjectsServiceTests.swift
@@ -206,6 +206,51 @@ struct LocalProjectsServiceTests {
     }
 
     @Test
+    func `local repo index rejects same owner and name on a different host`() throws {
+        let status = LocalRepoStatus(
+            path: URL(fileURLWithPath: "/tmp/RepoBar"),
+            name: "RepoBar",
+            fullName: "steipete/RepoBar",
+            remoteHost: "github.com",
+            branch: "main",
+            isClean: true,
+            aheadCount: 0,
+            behindCount: 0,
+            syncState: .synced
+        )
+        let index = LocalRepoIndex(statuses: [status])
+        let repo = makeRepository(name: "RepoBar", owner: "steipete")
+        let github = try #require(URL(string: "https://github.com"))
+        let enterprise = try #require(URL(string: "https://ghe.example.com"))
+
+        #expect(index.status(for: repo, host: github)?.path == status.path)
+        #expect(index.status(for: repo, host: enterprise) == nil)
+    }
+
+    @Test
+    func `same host account rows may share a local checkout`() throws {
+        let status = LocalRepoStatus(
+            path: URL(fileURLWithPath: "/tmp/RepoBar"),
+            name: "RepoBar",
+            fullName: "steipete/RepoBar",
+            remoteHost: "github.com",
+            branch: "main",
+            isClean: true,
+            aheadCount: 0,
+            behindCount: 0,
+            syncState: .synced
+        )
+        let index = LocalRepoIndex(statuses: [status])
+        let host = try #require(URL(string: "https://github.com"))
+
+        let firstAccountMatch = index.status(forFullName: "steipete/RepoBar", host: host)
+        let secondAccountMatch = index.status(forFullName: "steipete/RepoBar", host: host)
+
+        #expect(firstAccountMatch?.path == status.path)
+        #expect(secondAccountMatch?.path == status.path)
+    }
+
+    @Test
     func `local repo index prefers higher hierarchy for duplicate full names`() {
         let worktree = LocalRepoStatus(
             path: URL(fileURLWithPath: "/tmp/Repo/.work/feature"),

--- a/Tests/RepoBarTests/MenuSignatureTests.swift
+++ b/Tests/RepoBarTests/MenuSignatureTests.swift
@@ -45,6 +45,11 @@ struct MenuSignatureTests {
         let manager = StatusBarMenuManager(appState: appState)
         let builder = StatusBarMenuBuilder(appState: appState, target: manager)
         let repository = Self.repository(id: "remote-node", owner: "owner", name: "Repo")
+        let enterpriseAccount = try Account(
+            username: "alice",
+            host: #require(URL(string: "https://ghe.example.com:8443")),
+            authMethod: .oauth
+        )
         let localStatus = LocalRepoStatus(
             path: URL(fileURLWithPath: "/tmp/Repo"),
             name: "Repo",
@@ -60,7 +65,8 @@ struct MenuSignatureTests {
         appState.session.menuDisplayIndex = [
             repository.fullName.lowercased(): RepositoryDisplayModel(repo: repository)
         ]
-        appState.session.settings.githubHost = try #require(URL(string: "https://ghe.example.com"))
+        appState.session.settings.accounts = [enterpriseAccount]
+        appState.session.settings.activeAccountID = enterpriseAccount.id
 
         let models = builder.localScopeViewModels(
             session: appState.session,
@@ -71,6 +77,47 @@ struct MenuSignatureTests {
         #expect(models.count == 1)
         #expect(models.first?.id == "local:/tmp/Repo")
         #expect(models.first?.localStatus?.remoteHost == "github.com")
+    }
+
+    @MainActor
+    @Test
+    func `local scope substitutes remote model for active Enterprise host with custom port`() throws {
+        let appState = AppState()
+        let manager = StatusBarMenuManager(appState: appState)
+        let builder = StatusBarMenuBuilder(appState: appState, target: manager)
+        let repository = Self.repository(id: "remote-node", owner: "owner", name: "Repo")
+        let enterpriseAccount = try Account(
+            username: "alice",
+            host: #require(URL(string: "https://ghe.example.com:8443")),
+            authMethod: .oauth
+        )
+        let localStatus = LocalRepoStatus(
+            path: URL(fileURLWithPath: "/tmp/Repo"),
+            name: "Repo",
+            fullName: "owner/Repo",
+            remoteHost: "ghe.example.com:8443",
+            branch: "main",
+            isClean: true,
+            aheadCount: 0,
+            behindCount: 0,
+            syncState: .synced
+        )
+        appState.session.localRepoIndex = LocalRepoIndex(statuses: [localStatus])
+        appState.session.menuDisplayIndex = [
+            repository.fullName.lowercased(): RepositoryDisplayModel(repo: repository, localStatus: localStatus)
+        ]
+        appState.session.settings.accounts = [enterpriseAccount]
+        appState.session.settings.activeAccountID = enterpriseAccount.id
+
+        let models = builder.localScopeViewModels(
+            session: appState.session,
+            settings: appState.session.settings,
+            now: Date()
+        )
+
+        #expect(models.count == 1)
+        #expect(models.first?.id == repository.id)
+        #expect(models.first?.localStatus?.remoteHost == "ghe.example.com:8443")
     }
 
     @Test

--- a/Tests/RepoBarTests/MenuSignatureTests.swift
+++ b/Tests/RepoBarTests/MenuSignatureTests.swift
@@ -38,6 +38,41 @@ struct MenuSignatureTests {
         #expect(builder.repoSubmenusByFullName[idKey] == nil)
     }
 
+    @MainActor
+    @Test
+    func `local scope does not substitute remote model from another host`() throws {
+        let appState = AppState()
+        let manager = StatusBarMenuManager(appState: appState)
+        let builder = StatusBarMenuBuilder(appState: appState, target: manager)
+        let repository = Self.repository(id: "remote-node", owner: "owner", name: "Repo")
+        let localStatus = LocalRepoStatus(
+            path: URL(fileURLWithPath: "/tmp/Repo"),
+            name: "Repo",
+            fullName: "owner/Repo",
+            remoteHost: "github.com",
+            branch: "main",
+            isClean: true,
+            aheadCount: 0,
+            behindCount: 0,
+            syncState: .synced
+        )
+        appState.session.localRepoIndex = LocalRepoIndex(statuses: [localStatus])
+        appState.session.menuDisplayIndex = [
+            repository.fullName.lowercased(): RepositoryDisplayModel(repo: repository)
+        ]
+        appState.session.settings.githubHost = try #require(URL(string: "https://ghe.example.com"))
+
+        let models = builder.localScopeViewModels(
+            session: appState.session,
+            settings: appState.session.settings,
+            now: Date()
+        )
+
+        #expect(models.count == 1)
+        #expect(models.first?.id == "local:/tmp/Repo")
+        #expect(models.first?.localStatus?.remoteHost == "github.com")
+    }
+
     @Test
     func `repo submenu signature changes with repo counts`() {
         let now = Date(timeIntervalSinceReferenceDate: 1_000_000)
@@ -224,6 +259,24 @@ struct MenuSignatureTests {
                 )
             ],
             rateLimits: []
+        )
+    }
+
+    private static func repository(id: String, owner: String, name: String) -> Repository {
+        Repository(
+            id: id,
+            name: name,
+            owner: owner,
+            sortOrder: nil,
+            error: nil,
+            rateLimitedUntil: nil,
+            ciStatus: .unknown,
+            openIssues: 0,
+            openPulls: 0,
+            latestRelease: nil,
+            latestActivity: nil,
+            traffic: nil,
+            heatmap: []
         )
     }
 }

--- a/Tests/RepoBarTests/MenuSignatureTests.swift
+++ b/Tests/RepoBarTests/MenuSignatureTests.swift
@@ -31,9 +31,11 @@ struct MenuSignatureTests {
             isPinned: false
         )
 
+        let fullNameKey = AccountScopedCacheKey(accountID: "legacy", key: "owner/Repo")
+        let idKey = AccountScopedCacheKey(accountID: "legacy", key: repo.id)
         #expect(builder.repoFullName(for: submenu) == "owner/Repo")
-        #expect(builder.repoSubmenusByFullName["owner/Repo"]?.menu === submenu)
-        #expect(builder.repoSubmenusByFullName[repo.id] == nil)
+        #expect(builder.repoSubmenusByFullName[fullNameKey]?.menu === submenu)
+        #expect(builder.repoSubmenusByFullName[idKey] == nil)
     }
 
     @Test

--- a/Tests/RepoBarTests/MultiAccountContractTests.swift
+++ b/Tests/RepoBarTests/MultiAccountContractTests.swift
@@ -86,15 +86,22 @@ struct AttentionRuleContractTests {
 
         #expect(rule.category.rawValue == "futureCategory")
         #expect(rule.category.isKnown == false)
-        #expect(rule.enabled == false)
+        #expect(rule.enabled)
+        #expect(rule.isEffectivelyEnabled == false)
         #expect(rule.repositoryFilters == ["example/repo"])
+
+        let encoded = try JSONEncoder().encode(settings)
+        let encodedObject = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        let encodedRules = try #require(encodedObject["attentionRules"] as? [[String: Any]])
+        #expect(encodedRules.first?["enabled"] as? Bool == true)
 
         let roundTrip = try JSONDecoder().decode(
             UserSettings.self,
-            from: JSONEncoder().encode(settings)
+            from: encoded
         )
         #expect(roundTrip.attentionRules.first?.category.rawValue == "futureCategory")
-        #expect(roundTrip.attentionRules.first?.enabled == false)
+        #expect(roundTrip.attentionRules.first?.enabled == true)
+        #expect(roundTrip.attentionRules.first?.isEffectivelyEnabled == false)
     }
 
     @Test

--- a/Tests/RepoBarTests/MultiAccountContractTests.swift
+++ b/Tests/RepoBarTests/MultiAccountContractTests.swift
@@ -1,0 +1,231 @@
+import Foundation
+@testable import RepoBarCore
+import Testing
+
+struct MultiAccountSettingsContractTests {
+    @Test
+    func `legacy settings decode with consolidated features disabled`() throws {
+        let legacyJSON = """
+        {
+            "githubHost": "https://github.com",
+            "aiSummaries": {
+                "enabled": true,
+                "model": "gpt-5.5"
+            }
+        }
+        """
+
+        let settings = try JSONDecoder().decode(
+            UserSettings.self,
+            from: #require(legacyJSON.data(using: .utf8))
+        )
+
+        #expect(settings.consolidateAccounts == false)
+        #expect(settings.aiSummaries.allowNonActiveAccountContent == false)
+        #expect(settings.attentionRules.isEmpty)
+    }
+
+    @Test
+    func `new settings round trip without changing account selection`() throws {
+        var settings = UserSettings()
+        settings.consolidateAccounts = true
+        settings.accountSelection = .only(["github.com#alice"])
+        settings.aiSummaries.allowNonActiveAccountContent = true
+        settings.attentionRules = [
+            AttentionRule(
+                id: AttentionRuleID(rawValue: "custom.review"),
+                category: .reviewRequests,
+                accountSelection: .only(["github.com#alice"]),
+                ownerFilters: ["example"],
+                repositoryFilters: ["example/repo"],
+                itemStates: [.open],
+                priority: .high
+            )
+        ]
+
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(UserSettings.self, from: data)
+
+        #expect(decoded == settings)
+        #expect(decoded.accountSelection == .only(["github.com#alice"]))
+    }
+
+    @Test
+    func `default settings omit new contracts`() throws {
+        let data = try JSONEncoder().encode(UserSettings())
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let aiSummaries = try #require(object["aiSummaries"] as? [String: Any])
+
+        #expect(object["consolidateAccounts"] == nil)
+        #expect(object["attentionRules"] == nil)
+        #expect(aiSummaries["allowNonActiveAccountContent"] == nil)
+    }
+}
+
+struct AttentionRuleContractTests {
+    @Test
+    func `unknown category is preserved and safely disabled`() throws {
+        let json = """
+        {
+            "attentionRules": [
+                {
+                    "id": "future.rule",
+                    "enabled": true,
+                    "category": "futureCategory",
+                    "repositoryFilters": ["example/repo"]
+                }
+            ]
+        }
+        """
+
+        let settings = try JSONDecoder().decode(
+            UserSettings.self,
+            from: #require(json.data(using: .utf8))
+        )
+        let rule = try #require(settings.attentionRules.first)
+
+        #expect(rule.category.rawValue == "futureCategory")
+        #expect(rule.category.isKnown == false)
+        #expect(rule.enabled == false)
+        #expect(rule.repositoryFilters == ["example/repo"])
+
+        let roundTrip = try JSONDecoder().decode(
+            UserSettings.self,
+            from: JSONEncoder().encode(settings)
+        )
+        #expect(roundTrip.attentionRules.first?.category.rawValue == "futureCategory")
+        #expect(roundTrip.attentionRules.first?.enabled == false)
+    }
+
+    @Test
+    func `missing optional rule fields use compatibility defaults`() throws {
+        let json = """
+        {
+            "id": "minimal.rule",
+            "category": "mentions"
+        }
+        """
+
+        let rule = try JSONDecoder().decode(
+            AttentionRule.self,
+            from: #require(json.data(using: .utf8))
+        )
+
+        #expect(rule.enabled)
+        #expect(rule.accountSelection == .all)
+        #expect(rule.ownerFilters.isEmpty)
+        #expect(rule.repositoryFilters.isEmpty)
+        #expect(rule.itemStates.isEmpty)
+        #expect(rule.priority == .normal)
+
+        let encoded = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(rule)) as? [String: Any]
+        )
+        #expect(encoded["accountSelection"] == nil)
+        #expect(encoded["ownerFilters"] == nil)
+        #expect(encoded["repositoryFilters"] == nil)
+        #expect(encoded["itemStates"] == nil)
+        #expect(encoded["priority"] == nil)
+    }
+
+    @Test
+    func `first version categories are complete and stable`() {
+        #expect(AttentionRuleCategory.knownCategories == [
+            .reviewRequests,
+            .assignedIssues,
+            .assignedPullRequests,
+            .mentions,
+            .subscribedUpdates,
+            .authoredItems,
+            .failedWorkflows,
+            .runnerHealth,
+            .queuePressure,
+            .criticalAPIHealth
+        ])
+    }
+
+    @Test
+    func `conservative preset is deterministic and pinned only`() {
+        let selection = AccountSelection.only(["github.com#alice"])
+        let first = AttentionRulePresets.conservativeDefault(
+            pinnedRepositories: [" Example/Zeta ", "example/alpha", "EXAMPLE/ZETA", ""],
+            accountSelection: selection
+        )
+        let second = AttentionRulePresets.conservativeDefault(
+            pinnedRepositories: ["example/alpha", "example/zeta"],
+            accountSelection: selection
+        )
+
+        #expect(first == second)
+        #expect(first.map(\.id.rawValue) == [
+            "default.review-requests",
+            "default.assigned-issues",
+            "default.assigned-pull-requests",
+            "default.failed-workflows"
+        ])
+        #expect(first.map(\.category) == [
+            .reviewRequests,
+            .assignedIssues,
+            .assignedPullRequests,
+            .failedWorkflows
+        ])
+        for rule in first {
+            #expect(rule.enabled)
+        }
+        #expect(first.allSatisfy { $0.accountSelection == selection })
+        #expect(first.allSatisfy { $0.repositoryFilters == ["example/alpha", "example/zeta"] })
+        #expect(AttentionRulePresets.conservativeDefault(pinnedRepositories: []).isEmpty)
+    }
+}
+
+struct AccountScopedIdentityTests {
+    @Test
+    func `same repository is distinct across account sources`() {
+        let personal = AccountScopedRepositoryIdentity(
+            accountID: "github.com#alice",
+            repositoryID: "R_123"
+        )
+        let work = AccountScopedRepositoryIdentity(
+            accountID: "github.com#alice-work",
+            repositoryID: "R_123"
+        )
+
+        #expect(personal != work)
+        #expect(Set([personal, work]).count == 2)
+    }
+
+    @Test
+    func `same URL is distinct across account sources and codable`() throws {
+        let url = try #require(URL(string: "https://github.com/example/repo/pull/1"))
+        let personal = AccountScopedURLIdentity(accountID: "github.com#alice", url: url)
+        let work = AccountScopedURLIdentity(accountID: "github.com#alice-work", url: url)
+
+        #expect(personal != work)
+        #expect(Set([personal, work]).count == 2)
+
+        let decoded = try JSONDecoder().decode(
+            AccountScopedURLIdentity.self,
+            from: JSONEncoder().encode(personal)
+        )
+        #expect(decoded == personal)
+    }
+
+    @Test
+    func `event and cache identities include account source`() {
+        let personalEvent = AccountScopedEventIdentity(
+            accountID: "github.com#alice",
+            namespace: "pull-request",
+            eventID: "42"
+        )
+        let workEvent = AccountScopedEventIdentity(
+            accountID: "github.com#alice-work",
+            namespace: "pull-request",
+            eventID: "42"
+        )
+        let personalCache = AccountScopedCacheKey(accountID: "github.com#alice", key: "repos")
+        let workCache = AccountScopedCacheKey(accountID: "github.com#alice-work", key: "repos")
+
+        #expect(personalEvent != workEvent)
+        #expect(personalCache != workCache)
+    }
+}

--- a/Tests/RepoBarTests/MultiAccountRepositoryRefreshTests.swift
+++ b/Tests/RepoBarTests/MultiAccountRepositoryRefreshTests.swift
@@ -1,0 +1,558 @@
+import Foundation
+@testable import RepoBar
+@testable import RepoBarCore
+import Testing
+
+@MainActor
+struct MultiAccountRepositoryRefreshTests {
+    @Test
+    func `consolidation off refreshes active account only`() async throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob")
+        let aliceTransport = AccountRepositoryTransport(repositories: [.init(id: 1, owner: "alice", name: "one")])
+        let bobTransport = AccountRepositoryTransport(repositories: [.init(id: 2, owner: "bob", name: "two")])
+        let environment = try await Self.environment(
+            accounts: [alice, bob],
+            activeAccountID: alice.id,
+            consolidateAccounts: false,
+            selectedAccountIDs: [alice.id, bob.id],
+            transports: [alice.id: aliceTransport, bob.id: bobTransport]
+        )
+        defer { environment.cleanup() }
+
+        _ = await environment.app.refreshAccountRepositorySnapshots(now: Date(timeIntervalSince1970: 100))
+
+        #expect(await aliceTransport.requestCount == 1)
+        #expect(await bobTransport.requestCount == 0)
+        #expect(environment.app.session.accountSessions.map(\.id) == [alice.id])
+        #expect(environment.app.session.repositories.map(\.fullName) == ["alice/one"])
+    }
+
+    @Test
+    func `consolidation on isolates same host accounts and preserves overlapping repositories`() async throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob")
+        let shared = AccountRepositoryFixture(id: 42, owner: "example", name: "shared")
+        let aliceTransport = AccountRepositoryTransport(repositories: [shared])
+        let bobTransport = AccountRepositoryTransport(repositories: [shared])
+        let environment = try await Self.environment(
+            accounts: [alice, bob],
+            activeAccountID: alice.id,
+            consolidateAccounts: true,
+            selectedAccountIDs: [alice.id, bob.id],
+            transports: [alice.id: aliceTransport, bob.id: bobTransport]
+        )
+        defer { environment.cleanup() }
+
+        _ = await environment.app.refreshAccountRepositorySnapshots(now: Date(timeIntervalSince1970: 200))
+
+        #expect(await aliceTransport.requestCount == 1)
+        #expect(await bobTransport.requestCount == 1)
+        #expect(await aliceTransport.requestedPaths == ["/user/repos"])
+        #expect(await bobTransport.requestedPaths == ["/user/repos"])
+        #expect(environment.app.session.accountSessions.map(\.id) == [alice.id, bob.id])
+        #expect(environment.app.session.aggregatedRepositories.count == 2)
+        #expect(Set(environment.app.session.aggregatedRepositories.map(\.id)).count == 2)
+        #expect(environment.app.session.repositories.count == 1)
+    }
+
+    @Test
+    func `consolidation on refreshes only included credentialed current accounts`() async throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob")
+        let credentialless = try Self.account("credentialless")
+        let removed = try Self.account("removed")
+        let aliceTransport = AccountRepositoryTransport(repositories: [.init(id: 1, owner: "alice", name: "one")])
+        let bobTransport = AccountRepositoryTransport(repositories: [.init(id: 2, owner: "bob", name: "two")])
+        let credentiallessTransport = AccountRepositoryTransport(
+            repositories: [.init(id: 3, owner: "credentialless", name: "three")]
+        )
+        let removedTransport = AccountRepositoryTransport(repositories: [.init(id: 4, owner: "removed", name: "four")])
+        let environment = try await Self.environment(
+            accounts: [alice, bob, credentialless, removed],
+            activeAccountID: alice.id,
+            consolidateAccounts: true,
+            selectedAccountIDs: [alice.id, credentialless.id, removed.id, "github.com#unknown"],
+            credentialedAccountIDs: [alice.id, bob.id, removed.id],
+            transports: [
+                alice.id: aliceTransport,
+                bob.id: bobTransport,
+                credentialless.id: credentiallessTransport,
+                removed.id: removedTransport
+            ]
+        )
+        defer { environment.cleanup() }
+        await environment.app.accountManager.remove(accountID: removed.id)
+
+        _ = await environment.app.refreshAccountRepositorySnapshots(now: Date(timeIntervalSince1970: 300))
+
+        #expect(await aliceTransport.requestCount == 1)
+        #expect(await bobTransport.requestCount == 0)
+        #expect(await credentiallessTransport.requestCount == 0)
+        #expect(await removedTransport.requestCount == 0)
+        #expect(environment.app.session.accountSessions.map(\.id) == [alice.id])
+        #expect(environment.app.session.aggregatedRepositories.map(\.accountID) == [alice.id])
+    }
+
+    @Test
+    func `partial failure retains last good account state while healthy account advances`() async throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob")
+        let aliceTransport = AccountRepositoryTransport(repositories: [.init(id: 1, owner: "alice", name: "old")])
+        let bobTransport = AccountRepositoryTransport(repositories: [.init(id: 2, owner: "bob", name: "old")])
+        let environment = try await Self.environment(
+            accounts: [alice, bob],
+            activeAccountID: alice.id,
+            consolidateAccounts: true,
+            selectedAccountIDs: [alice.id, bob.id],
+            transports: [alice.id: aliceTransport, bob.id: bobTransport]
+        )
+        defer { environment.cleanup() }
+        let firstDate = Date(timeIntervalSince1970: 400)
+        _ = await environment.app.refreshAccountRepositorySnapshots(now: firstDate)
+
+        await aliceTransport.setFailure(statusCode: 500)
+        await bobTransport.setRepositories([.init(id: 3, owner: "bob", name: "new")])
+        _ = await environment.app.refreshAccountRepositorySnapshots(now: Date(timeIntervalSince1970: 500))
+
+        let aliceSession = try #require(environment.app.session.accountSessions.first(where: { $0.id == alice.id }))
+        let bobSession = try #require(environment.app.session.accountSessions.first(where: { $0.id == bob.id }))
+        #expect(aliceSession.repositories.map(\.fullName) == ["alice/old"])
+        #expect(aliceSession.lastSuccessfulRefreshAt == firstDate)
+        #expect(aliceSession.isStale)
+        #expect(aliceSession.lastError != nil)
+        #expect(bobSession.repositories.map(\.fullName) == ["bob/new"])
+        #expect(bobSession.lastSuccessfulRefreshAt == Date(timeIntervalSince1970: 500))
+        #expect(bobSession.isStale == false)
+        #expect(environment.app.session.aggregatedRepositories.count == 2)
+    }
+
+    @Test
+    func `older generation cannot overwrite a newer refresh`() async throws {
+        let alice = try Self.account("alice")
+        let transport = AccountRepositoryTransport(repositories: [])
+        let loader = SequencedAccountRepositoryLoader(
+            responses: [
+                .init(delay: .milliseconds(200), repository: Self.repository(id: "old", owner: "alice", name: "old")),
+                .init(delay: .zero, repository: Self.repository(id: "new", owner: "alice", name: "new"))
+            ]
+        )
+        let environment = try await Self.environment(
+            accounts: [alice],
+            activeAccountID: alice.id,
+            consolidateAccounts: false,
+            selectedAccountIDs: [alice.id],
+            transports: [alice.id: transport],
+            loader: loader
+        )
+        defer { environment.cleanup() }
+
+        let first = Task { @MainActor in
+            await environment.app.refreshAccountRepositorySnapshots(now: Date(timeIntervalSince1970: 600))
+        }
+        while await loader.snapshotRequestCount == 0 {
+            await Task.yield()
+        }
+        let second = await environment.app.refreshAccountRepositorySnapshots(now: Date(timeIntervalSince1970: 700))
+        let firstOutcome = await first.value
+
+        #expect(second.published)
+        #expect(firstOutcome.published == false)
+        #expect(environment.app.session.repositories.map(\.fullName) == ["alice/new"])
+    }
+
+    @Test
+    func `cancelled refresh cannot overwrite last good state`() async throws {
+        let alice = try Self.account("alice")
+        let transport = AccountRepositoryTransport(repositories: [])
+        let loader = SequencedAccountRepositoryLoader(
+            responses: [
+                .init(delay: .zero, repository: Self.repository(id: "good", owner: "alice", name: "good")),
+                .init(delay: .seconds(1), repository: Self.repository(id: "late", owner: "alice", name: "late"))
+            ]
+        )
+        let environment = try await Self.environment(
+            accounts: [alice],
+            activeAccountID: alice.id,
+            consolidateAccounts: false,
+            selectedAccountIDs: [alice.id],
+            transports: [alice.id: transport],
+            loader: loader
+        )
+        defer { environment.cleanup() }
+        _ = await environment.app.refreshAccountRepositorySnapshots(now: Date(timeIntervalSince1970: 710))
+
+        let cancelled = Task { @MainActor in
+            await environment.app.refreshAccountRepositorySnapshots(now: Date(timeIntervalSince1970: 720))
+        }
+        while await loader.snapshotRequestCount < 2 {
+            await Task.yield()
+        }
+        cancelled.cancel()
+        let outcome = await cancelled.value
+
+        #expect(outcome.published == false)
+        #expect(environment.app.session.repositories.map(\.fullName) == ["alice/good"])
+    }
+
+    @Test
+    func `hydrated snapshot cannot cross an active account switch`() async throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob")
+        let aliceTransport = AccountRepositoryTransport(repositories: [.init(id: 1, owner: "alice", name: "one")])
+        let bobTransport = AccountRepositoryTransport(repositories: [.init(id: 2, owner: "bob", name: "two")])
+        let environment = try await Self.environment(
+            accounts: [alice, bob],
+            activeAccountID: alice.id,
+            consolidateAccounts: true,
+            selectedAccountIDs: [alice.id, bob.id],
+            transports: [alice.id: aliceTransport, bob.id: bobTransport]
+        )
+        defer { environment.cleanup() }
+        let outcome = await environment.app.refreshAccountRepositorySnapshots(now: Date(timeIntervalSince1970: 730))
+        let aliceHydrated = Self.repository(id: "alice-hydrated", owner: "alice", name: "hydrated")
+        let bobBefore = try #require(
+            environment.app.session.accountSessions.first(where: { $0.id == bob.id })?.repositories
+        )
+
+        environment.app.session.activeAccountID = bob.id
+        let published = environment.app.publishHydratedActiveRepositorySnapshot(
+            accessibleRepositories: [aliceHydrated],
+            repositories: [aliceHydrated],
+            accountID: alice.id,
+            generation: outcome.generation,
+            now: Date(timeIntervalSince1970: 740)
+        )
+
+        #expect(published == false)
+        #expect(environment.app.session.accountSessions.first(where: { $0.id == bob.id })?.repositories == bobBefore)
+    }
+
+    @Test
+    func `non active authentication failure remains account local`() async throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob")
+        let aliceTransport = AccountRepositoryTransport(repositories: [.init(id: 1, owner: "alice", name: "one")])
+        let bobTransport = AccountRepositoryTransport(repositories: [.init(id: 2, owner: "bob", name: "two")])
+        let environment = try await Self.environment(
+            accounts: [alice, bob],
+            activeAccountID: alice.id,
+            consolidateAccounts: true,
+            selectedAccountIDs: [alice.id, bob.id],
+            transports: [alice.id: aliceTransport, bob.id: bobTransport]
+        )
+        defer { environment.cleanup() }
+        await bobTransport.setFailure(statusCode: 401)
+
+        _ = await environment.app.refreshAccountRepositorySnapshots(now: Date(timeIntervalSince1970: 750))
+
+        let aliceSession = try #require(environment.app.session.accountSessions.first(where: { $0.id == alice.id }))
+        let bobSession = try #require(environment.app.session.accountSessions.first(where: { $0.id == bob.id }))
+        #expect(aliceSession.state.isLoggedIn)
+        #expect(bobSession.state == .loggedOut)
+        #expect(try environment.tokenStore.loadPAT(accountID: alice.id) != nil)
+        #expect(try environment.tokenStore.loadPAT(accountID: bob.id) != nil)
+    }
+
+    @Test
+    func `consolidated active failure remains visible after full refresh`() async throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob")
+        let aliceTransport = AccountRepositoryTransport(repositories: [])
+        let bobTransport = AccountRepositoryTransport(repositories: [.init(id: 2, owner: "bob", name: "two")])
+        let environment = try await Self.environment(
+            accounts: [alice, bob],
+            activeAccountID: alice.id,
+            consolidateAccounts: true,
+            selectedAccountIDs: [alice.id, bob.id],
+            transports: [alice.id: aliceTransport, bob.id: bobTransport]
+        )
+        defer { environment.cleanup() }
+        await aliceTransport.setFailure(statusCode: 500)
+
+        await environment.app.refresh()
+
+        let aliceSession = try #require(environment.app.session.accountSessions.first(where: { $0.id == alice.id }))
+        let bobSession = try #require(environment.app.session.accountSessions.first(where: { $0.id == bob.id }))
+        #expect(aliceSession.isStale)
+        #expect(aliceSession.lastError != nil)
+        #expect(environment.app.session.lastError == aliceSession.lastError)
+        #expect(bobSession.repositories.map(\.fullName) == ["bob/two"])
+    }
+
+    @Test
+    func `account caches hydrate independently before failed live requests`() async throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob")
+        let aliceTransport = AccountRepositoryTransport(repositories: [.init(id: 1, owner: "alice", name: "cached")])
+        let bobTransport = AccountRepositoryTransport(repositories: [.init(id: 2, owner: "bob", name: "cached")])
+        let first = try await Self.environment(
+            accounts: [alice, bob],
+            activeAccountID: alice.id,
+            consolidateAccounts: true,
+            selectedAccountIDs: [alice.id, bob.id],
+            transports: [alice.id: aliceTransport, bob.id: bobTransport]
+        )
+        _ = await first.app.refreshAccountRepositorySnapshots(now: Date(timeIntervalSince1970: 800))
+        #expect(first.caches[alice.id]?.count() == 1)
+        #expect(first.caches[bob.id]?.count() == 1)
+        let firstAliceClient = try #require(first.app.accountManager.client(for: alice.id))
+        let firstBobClient = try #require(first.app.accountManager.client(for: bob.id))
+        #expect(try await firstAliceClient.cachedRepositoryList(limit: nil).map(\.fullName) == ["alice/cached"])
+        #expect(try await firstBobClient.cachedRepositoryList(limit: nil).map(\.fullName) == ["bob/cached"])
+
+        await aliceTransport.setFailure(statusCode: 503)
+        await bobTransport.setFailure(statusCode: 503)
+        let second = try await Self.environment(
+            accounts: [alice, bob],
+            activeAccountID: alice.id,
+            consolidateAccounts: true,
+            selectedAccountIDs: [alice.id, bob.id],
+            transports: [alice.id: aliceTransport, bob.id: bobTransport],
+            cacheDirectories: first.cacheDirectories,
+            tokenStore: first.tokenStore
+        )
+        defer {
+            second.cleanup(removeCaches: false)
+            first.cleanup()
+        }
+
+        _ = await second.app.refreshAccountRepositorySnapshots(now: Date(timeIntervalSince1970: 900))
+
+        let sessions = Dictionary(uniqueKeysWithValues: second.app.session.accountSessions.map { ($0.id, $0) })
+        #expect(sessions[alice.id]?.repositories.map(\.fullName) == ["alice/cached"])
+        #expect(sessions[bob.id]?.repositories.map(\.fullName) == ["bob/cached"])
+        #expect(sessions[alice.id]?.isStale == true)
+        #expect(sessions[bob.id]?.isStale == true)
+        #expect(second.app.session.aggregatedRepositories.count == 2)
+    }
+
+    private static func account(_ username: String) throws -> Account {
+        try Account(
+            username: username,
+            host: #require(URL(string: "https://github.com")),
+            authMethod: .pat
+        )
+    }
+
+    private static func environment(
+        accounts: [Account],
+        activeAccountID: String,
+        consolidateAccounts: Bool,
+        selectedAccountIDs: Set<String>,
+        credentialedAccountIDs: Set<String>? = nil,
+        transports: [String: AccountRepositoryTransport],
+        loader: any AccountRepositorySnapshotLoading = AccountRepositorySnapshotLoader(),
+        cacheDirectories: [String: URL]? = nil,
+        tokenStore: TokenStore? = nil
+    ) async throws -> AccountRefreshTestEnvironment {
+        let store = tokenStore ?? TokenStore(service: "com.steipete.repobar.multi-account-refresh.\(UUID().uuidString)")
+        let credentialed = credentialedAccountIDs ?? Set(accounts.map(\.id))
+        for account in accounts where credentialed.contains(account.id) {
+            try store.savePAT("token-\(account.username)", accountID: account.id)
+        }
+
+        var directories = cacheDirectories ?? [:]
+        var clients: [String: GitHubClient] = [:]
+        var caches: [String: HTTPResponseDiskCache] = [:]
+        for account in accounts {
+            let directory: URL
+            if let existing = directories[account.id] {
+                directory = existing
+            } else {
+                directory = FileManager.default.temporaryDirectory
+                    .appending(path: "repobar-account-refresh-\(UUID().uuidString)", directoryHint: .isDirectory)
+                directories[account.id] = directory
+            }
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            let cache = try HTTPResponseDiskCache(path: directory.appending(path: "cache.sqlite").path)
+            caches[account.id] = cache
+            let transport = try #require(transports[account.id])
+            let dataLoader = HTTPDataLoader { request in
+                try await transport.data(for: request)
+            }
+            clients[account.id] = GitHubClient(
+                accountID: account.id,
+                archiveSettingsProvider: { GitHubArchiveSettings() },
+                dataLoader: dataLoader,
+                responseDiskCache: cache,
+                etagCache: ETagCache(persistentStore: cache)
+            )
+        }
+
+        var settings = UserSettings()
+        settings.accounts = accounts
+        settings.activeAccountID = activeAccountID
+        settings.consolidateAccounts = consolidateAccounts
+        settings.accountSelection = .only(selectedAccountIDs)
+        let defaultsName = "com.steipete.repobar.multi-account-refresh.defaults.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: defaultsName))
+        let manager = AccountManager(
+            tokenStore: store,
+            clientFactory: { account in
+                clients[account.id]!
+            }
+        )
+        let app = AppState(
+            settingsStore: SettingsStore(defaults: defaults),
+            accountManager: manager,
+            accountRepositorySnapshotLoader: loader
+        )
+        app.session.settings = settings
+        await app.bootstrapAccounts()
+        return AccountRefreshTestEnvironment(
+            app: app,
+            tokenStore: store,
+            accounts: accounts,
+            cacheDirectories: directories,
+            caches: caches,
+            defaultsName: defaultsName
+        )
+    }
+
+    private static func repository(id: String, owner: String, name: String) -> Repository {
+        Repository(
+            id: id,
+            name: name,
+            owner: owner,
+            sortOrder: nil,
+            error: nil,
+            rateLimitedUntil: nil,
+            ciStatus: .unknown,
+            ciRunCount: nil,
+            openIssues: 0,
+            openPulls: 0,
+            stars: 0,
+            forks: 0,
+            pushedAt: nil,
+            latestRelease: nil,
+            latestActivity: nil,
+            activityEvents: [],
+            traffic: nil,
+            heatmap: []
+        )
+    }
+}
+
+@MainActor
+private struct AccountRefreshTestEnvironment {
+    let app: AppState
+    let tokenStore: TokenStore
+    let accounts: [Account]
+    let cacheDirectories: [String: URL]
+    let caches: [String: HTTPResponseDiskCache]
+    let defaultsName: String
+
+    func cleanup(removeCaches: Bool = true) {
+        for account in self.accounts {
+            self.tokenStore.clear(accountID: account.id)
+        }
+        UserDefaults.standard.removePersistentDomain(forName: self.defaultsName)
+        if removeCaches {
+            for directory in self.cacheDirectories.values {
+                try? FileManager.default.removeItem(at: directory)
+            }
+        }
+    }
+}
+
+private struct AccountRepositoryFixture {
+    let id: Int
+    let owner: String
+    let name: String
+}
+
+private actor AccountRepositoryTransport {
+    private var repositories: [AccountRepositoryFixture]
+    private var statusCode = 200
+    private(set) var requests: [URLRequest] = []
+
+    init(repositories: [AccountRepositoryFixture]) {
+        self.repositories = repositories
+    }
+
+    var requestCount: Int {
+        self.requests.count
+    }
+
+    var requestedPaths: [String] {
+        self.requests.compactMap(\.url?.path)
+    }
+
+    func setRepositories(_ repositories: [AccountRepositoryFixture]) {
+        self.repositories = repositories
+        self.statusCode = 200
+    }
+
+    func setFailure(statusCode: Int) {
+        self.statusCode = statusCode
+    }
+
+    func data(for request: URLRequest) throws -> (Data, URLResponse) {
+        self.requests.append(request)
+        let data: Data
+        if self.statusCode == 200 {
+            let objects: [[String: Any]] = self.repositories.map { repo in
+                [
+                    "id": repo.id,
+                    "name": repo.name,
+                    "full_name": "\(repo.owner)/\(repo.name)",
+                    "description": NSNull(),
+                    "language": NSNull(),
+                    "topics": [],
+                    "fork": false,
+                    "archived": false,
+                    "has_discussions": true,
+                    "open_issues_count": 0,
+                    "stargazers_count": 0,
+                    "forks_count": 0,
+                    "pushed_at": NSNull(),
+                    "permissions": ["pull": true],
+                    "owner": ["login": repo.owner]
+                ]
+            }
+            data = try JSONSerialization.data(withJSONObject: objects)
+        } else {
+            data = Data(#"{"message":"injected failure"}"#.utf8)
+        }
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: self.statusCode,
+            httpVersion: nil,
+            headerFields: self.statusCode == 200 ? ["ETag": "\"refresh-test\""] : nil
+        )!
+        return (data, response)
+    }
+}
+
+private actor SequencedAccountRepositoryLoader: AccountRepositorySnapshotLoading {
+    struct Response {
+        let delay: Duration
+        let repository: Repository
+    }
+
+    private var responses: [Response]
+    private(set) var snapshotRequestCount = 0
+
+    init(responses: [Response]) {
+        self.responses = responses
+    }
+
+    func cachedSnapshot(for _: AccountRepositorySnapshotRequest) async throws -> AccountRepositorySnapshot? {
+        nil
+    }
+
+    func snapshot(for request: AccountRepositorySnapshotRequest) async throws -> AccountRepositorySnapshot {
+        self.snapshotRequestCount += 1
+        let response = self.responses.removeFirst()
+        try await Task.sleep(for: response.delay)
+        return AccountRepositorySnapshot(
+            account: request.account,
+            accessibleRepositories: [response.repository],
+            repositories: [response.repository],
+            capturedAt: request.now,
+            diagnostics: .empty,
+            cacheSummary: nil
+        )
+    }
+}

--- a/Tests/RepoBarTests/RecentListMenuTests.swift
+++ b/Tests/RepoBarTests/RecentListMenuTests.swift
@@ -1,6 +1,6 @@
 import AppKit
 @testable import RepoBar
-import RepoBarCore
+@testable import RepoBarCore
 import Testing
 
 struct RecentListMenuTests {
@@ -9,16 +9,19 @@ struct RecentListMenuTests {
     func `recent list cache evicts least recently used entry`() {
         let cache = RecentListCache<Int>(maxEntries: 2)
         let now = Date(timeIntervalSinceReferenceDate: 1000)
+        let one = AccountScopedCacheKey(accountID: "account", key: "one")
+        let two = AccountScopedCacheKey(accountID: "account", key: "two")
+        let three = AccountScopedCacheKey(accountID: "account", key: "three")
 
-        cache.store([1], for: "one", fetchedAt: now)
-        cache.store([2], for: "two", fetchedAt: now)
-        #expect(cache.stale(for: "one") == [1])
-        cache.store([3], for: "three", fetchedAt: now)
+        cache.store([1], for: one, fetchedAt: now)
+        cache.store([2], for: two, fetchedAt: now)
+        #expect(cache.stale(for: one) == [1])
+        cache.store([3], for: three, fetchedAt: now)
 
         #expect(cache.count() == 2)
-        #expect(cache.stale(for: "one") == [1])
-        #expect(cache.stale(for: "two") == nil)
-        #expect(cache.stale(for: "three") == [3])
+        #expect(cache.stale(for: one) == [1])
+        #expect(cache.stale(for: two) == nil)
+        #expect(cache.stale(for: three) == [3])
     }
 
     @MainActor
@@ -32,7 +35,7 @@ struct RecentListMenuTests {
         manager.setMainMenuForTesting(mainMenu)
         manager.registerRecentListMenu(
             submenu,
-            context: RepoRecentMenuContext(fullName: "owner/repo", kind: .issues)
+            context: RepoRecentMenuContext(accountID: "account", fullName: "owner/repo", kind: .issues)
         )
 
         manager.menuWillOpen(mainMenu)
@@ -51,7 +54,7 @@ struct RecentListMenuTests {
         manager.setMainMenuForTesting(mainMenu)
         manager.registerRecentListMenu(
             submenu,
-            context: RepoRecentMenuContext(fullName: "owner/repo", kind: .issues)
+            context: RepoRecentMenuContext(accountID: "account", fullName: "owner/repo", kind: .issues)
         )
 
         manager.menuFiltersChanged()
@@ -85,6 +88,61 @@ struct RecentListMenuTests {
 
         #expect(RecentListMenuCoordinator.rateLimitMessage(for: error)?.contains("GitHub rate limited; resets") == true)
         #expect(RecentListMenuCoordinator.rateLimitMessage(for: URLError(.timedOut)) == nil)
+    }
+
+    @MainActor
+    @Test
+    func `identical repository requests use account scoped clients caches and inflight tasks`() async throws {
+        let requestLog = RecentRequestLog()
+        let aliceClient = await Self.makeRecentListClient(
+            accountID: "alice",
+            branchName: "alice-branch",
+            requestLog: requestLog
+        )
+        let bobClient = await Self.makeRecentListClient(
+            accountID: "bob",
+            branchName: "bob-branch",
+            requestLog: requestLog
+        )
+        let clients = ["alice": aliceClient, "bob": bobClient]
+        let service = RecentMenuService(
+            clientResolver: { accountID in
+                guard let client = clients[accountID] else {
+                    throw AccountManagerError.unknownAccount(accountID)
+                }
+
+                return client
+            },
+            activeAccountID: { "alice" }
+        )
+        let alice = try service.cacheContext(accountID: "alice", fullName: "owner/repo")
+        let bob = try service.cacheContext(accountID: "bob", fullName: "owner/repo")
+
+        let aliceTask = Task { @MainActor in
+            try await service.load(accountID: "alice", fullName: "owner/repo", kind: .branches)
+        }
+        let bobTask = Task { @MainActor in
+            try await service.load(accountID: "bob", fullName: "owner/repo", kind: .branches)
+        }
+        let loaded = try await (aliceTask.value, bobTask.value)
+
+        guard case let .branches(aliceBranches) = loaded.0,
+              case let .branches(bobBranches) = loaded.1
+        else {
+            Issue.record("Expected branch results")
+            return
+        }
+
+        #expect(alice.key != bob.key)
+        #expect(aliceBranches.map(\.name) == ["alice-branch"])
+        #expect(bobBranches.map(\.name) == ["bob-branch"])
+        #expect(await requestLog.count(for: "alice") == 1)
+        #expect(await requestLog.count(for: "bob") == 1)
+
+        service.removeCachedState(accountID: "alice")
+        let descriptor = try #require(service.descriptor(for: .branches))
+        #expect(descriptor.stale(alice.key) == nil)
+        #expect(descriptor.stale(bob.key)?.count == 1)
     }
 
     @MainActor
@@ -138,5 +196,49 @@ struct RecentListMenuTests {
             createdAt: Date(timeIntervalSinceReferenceDate: TimeInterval(number)),
             updatedAt: Date(timeIntervalSinceReferenceDate: TimeInterval(number))
         )
+    }
+
+    private static func makeRecentListClient(
+        accountID: String,
+        branchName: String,
+        requestLog: RecentRequestLog
+    ) async -> GitHubClient {
+        let dataLoader = HTTPDataLoader { request in
+            await requestLog.record(accountID)
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let body = Data(
+                """
+                [{"name":"\(branchName)","commit":{"sha":"\(accountID)-sha"},"protected":false}]
+                """.utf8
+            )
+            return (body, response)
+        }
+        let client = GitHubClient(
+            accountID: accountID,
+            archiveSettingsProvider: { GitHubArchiveSettings() },
+            dataLoader: dataLoader,
+            responseDiskCache: nil
+        )
+        await client.setTokenProvider {
+            OAuthTokens(accessToken: "\(accountID)-token", refreshToken: "", expiresAt: nil)
+        }
+        return client
+    }
+}
+
+private actor RecentRequestLog {
+    private var counts: [String: Int] = [:]
+
+    func record(_ accountID: String) {
+        self.counts[accountID, default: 0] += 1
+    }
+
+    func count(for accountID: String) -> Int {
+        self.counts[accountID, default: 0]
     }
 }

--- a/Tests/RepoBarTests/RecentListMenuTests.swift
+++ b/Tests/RepoBarTests/RecentListMenuTests.swift
@@ -147,6 +147,39 @@ struct RecentListMenuTests {
 
     @MainActor
     @Test
+    func `coalesced repository requests both return the shared result`() async throws {
+        let gate = RecentResponseGate()
+        let client = await Self.makeRecentListClient(accountID: "alice", responseGate: gate)
+        let service = RecentMenuService(
+            clientResolver: { _ in client },
+            activeAccountID: { "alice" }
+        )
+
+        let first = Task { @MainActor in
+            try await service.load(accountID: "alice", fullName: "owner/repo", kind: .branches)
+        }
+        await gate.waitUntilFirstRequestStarts()
+        let second = Task { @MainActor in
+            try await service.load(accountID: "alice", fullName: "owner/repo", kind: .branches)
+        }
+        await Task.yield()
+        await gate.releaseFirstRequest()
+        let results = try await (first.value, second.value)
+
+        guard case let .branches(firstBranches) = results.0,
+              case let .branches(secondBranches) = results.1
+        else {
+            Issue.record("Expected branch results")
+            return
+        }
+
+        #expect(firstBranches.map(\.name) == ["old-branch"])
+        #expect(secondBranches.map(\.name) == ["old-branch"])
+        #expect(await gate.totalRequestCount() == 1)
+    }
+
+    @MainActor
+    @Test
     func `removed account recent request cannot repopulate cache after readd`() async throws {
         let gate = RecentResponseGate()
         let client = await Self.makeRecentListClient(accountID: "alice", responseGate: gate)
@@ -348,5 +381,9 @@ private actor RecentResponseGate {
     func releaseFirstRequest() {
         self.firstRequestContinuation?.resume()
         self.firstRequestContinuation = nil
+    }
+
+    func totalRequestCount() -> Int {
+        self.requestCount
     }
 }

--- a/Tests/RepoBarTests/RecentListMenuTests.swift
+++ b/Tests/RepoBarTests/RecentListMenuTests.swift
@@ -147,6 +147,49 @@ struct RecentListMenuTests {
 
     @MainActor
     @Test
+    func `removed account recent request cannot repopulate cache after readd`() async throws {
+        let gate = RecentResponseGate()
+        let client = await Self.makeRecentListClient(accountID: "alice", responseGate: gate)
+        let service = RecentMenuService(
+            clientResolver: { _ in client },
+            activeAccountID: { "alice" }
+        )
+        let key = service.cacheKey(accountID: "alice", fullName: "owner/repo")
+
+        let first = Task { @MainActor in
+            try await service.load(accountID: "alice", fullName: "owner/repo", kind: .branches)
+        }
+        await gate.waitUntilFirstRequestStarts()
+        service.removeCachedState(accountID: "alice")
+        await gate.releaseFirstRequest()
+
+        do {
+            _ = try await first.value
+            Issue.record("Expected removed-account request to be discarded")
+        } catch is CancellationError {
+            // Expected: the removed account generation no longer owns this completion.
+        }
+
+        let descriptor = try #require(service.descriptor(for: .branches))
+        #expect(descriptor.stale(key) == nil)
+
+        let second = try await service.load(accountID: "alice", fullName: "owner/repo", kind: .branches)
+        guard case let .branches(branches) = second else {
+            Issue.record("Expected branch results")
+            return
+        }
+
+        #expect(branches.map(\.name) == ["new-branch"])
+        guard case let .branches(cachedBranches) = descriptor.stale(key) else {
+            Issue.record("Expected cached branch results")
+            return
+        }
+
+        #expect(cachedBranches.map(\.name) == ["new-branch"])
+    }
+
+    @MainActor
+    @Test
     func `multi reference menu offers issue navigator action at end`() throws {
         let appState = AppState()
         let manager = StatusBarMenuManager(appState: appState)
@@ -229,6 +272,37 @@ struct RecentListMenuTests {
         }
         return client
     }
+
+    private static func makeRecentListClient(
+        accountID: String,
+        responseGate: RecentResponseGate
+    ) async -> GitHubClient {
+        let dataLoader = HTTPDataLoader { request in
+            let branchName = await responseGate.branchNameForRequest()
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            let body = Data(
+                """
+                [{"name":"\(branchName)","commit":{"sha":"\(branchName)-sha"},"protected":false}]
+                """.utf8
+            )
+            return (body, response)
+        }
+        let client = GitHubClient(
+            accountID: accountID,
+            archiveSettingsProvider: { GitHubArchiveSettings() },
+            dataLoader: dataLoader,
+            responseDiskCache: nil
+        )
+        await client.setTokenProvider {
+            OAuthTokens(accessToken: "\(accountID)-token", refreshToken: "", expiresAt: nil)
+        }
+        return client
+    }
 }
 
 private actor RecentRequestLog {
@@ -240,5 +314,39 @@ private actor RecentRequestLog {
 
     func count(for accountID: String) -> Int {
         self.counts[accountID, default: 0]
+    }
+}
+
+private actor RecentResponseGate {
+    private var requestCount = 0
+    private var firstRequestContinuation: CheckedContinuation<Void, Never>?
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func branchNameForRequest() async -> String {
+        self.requestCount += 1
+        let currentRequest = self.requestCount
+        if currentRequest == 1 {
+            let waiters = self.startWaiters
+            self.startWaiters = []
+            waiters.forEach { $0.resume() }
+            await withCheckedContinuation { continuation in
+                self.firstRequestContinuation = continuation
+            }
+            return "old-branch"
+        }
+        return "new-branch"
+    }
+
+    func waitUntilFirstRequestStarts() async {
+        guard self.requestCount == 0 else { return }
+
+        await withCheckedContinuation { continuation in
+            self.startWaiters.append(continuation)
+        }
+    }
+
+    func releaseFirstRequest() {
+        self.firstRequestContinuation?.resume()
+        self.firstRequestContinuation = nil
     }
 }

--- a/Tests/RepoBarTests/UserSettingsMultiAccountTests.swift
+++ b/Tests/RepoBarTests/UserSettingsMultiAccountTests.swift
@@ -103,4 +103,105 @@ struct UserSettingsMultiAccountTests {
         #expect(json.contains("\"accountSelection\"") == false)
         #expect(json.contains("\"accountRepoLists\"") == false)
     }
+
+    @Test
+    func `legacy repository lists belong only to active account`() throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob")
+        var settings = UserSettings()
+        settings.accounts = [alice, bob]
+        settings.activeAccountID = alice.id
+        settings.repoList.pinnedRepositories = ["owner/shared"]
+        settings.repoList.hiddenRepositories = ["owner/hidden"]
+
+        #expect(settings.pinnedRepositories(for: alice.id) == ["owner/shared"])
+        #expect(settings.hiddenRepositories(for: alice.id) == ["owner/hidden"])
+        #expect(settings.pinnedRepositories(for: bob.id).isEmpty)
+        #expect(settings.hiddenRepositories(for: bob.id).isEmpty)
+    }
+
+    @Test
+    func `deliberate empty account lists suppress legacy fallback`() throws {
+        let alice = try Self.account("alice")
+        var settings = UserSettings()
+        settings.accounts = [alice]
+        settings.activeAccountID = alice.id
+        settings.repoList.pinnedRepositories = ["owner/legacy"]
+        settings.repoList.hiddenRepositories = ["owner/legacy-hidden"]
+        settings.accountRepoLists.setPinned([], for: alice.id)
+        settings.accountRepoLists.setHidden([], for: alice.id)
+
+        #expect(settings.pinnedRepositories(for: alice.id).isEmpty)
+        #expect(settings.hiddenRepositories(for: alice.id).isEmpty)
+    }
+
+    @Test
+    func `active mutations mirror legacy lists while nonactive mutations do not`() throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob")
+        var settings = UserSettings()
+        settings.accounts = [alice, bob]
+        settings.activeAccountID = alice.id
+        settings.setPinnedRepositories(["owner/alice"], for: alice.id)
+        settings.setHiddenRepositories(["owner/alice-hidden"], for: alice.id)
+
+        #expect(settings.repoList.pinnedRepositories == ["owner/alice"])
+        #expect(settings.repoList.hiddenRepositories == ["owner/alice-hidden"])
+
+        settings.setPinnedRepositories(["owner/bob"], for: bob.id)
+        settings.setHiddenRepositories(["owner/bob-hidden"], for: bob.id)
+
+        #expect(settings.pinnedRepositories(for: bob.id) == ["owner/bob"])
+        #expect(settings.hiddenRepositories(for: bob.id) == ["owner/bob-hidden"])
+        #expect(settings.repoList.pinnedRepositories == ["owner/alice"])
+        #expect(settings.repoList.hiddenRepositories == ["owner/alice-hidden"])
+    }
+
+    @Test
+    func `switching active account does not copy previous legacy lists`() throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob")
+        var settings = UserSettings()
+        settings.accounts = [alice, bob]
+        settings.activeAccountID = alice.id
+        settings.repoList.pinnedRepositories = ["owner/alice"]
+        settings.repoList.hiddenRepositories = ["owner/alice-hidden"]
+
+        settings.prepareRepositoryListsForActiveAccountChange(to: bob.id)
+
+        #expect(settings.pinnedRepositories(for: alice.id) == ["owner/alice"])
+        #expect(settings.hiddenRepositories(for: alice.id) == ["owner/alice-hidden"])
+        #expect(settings.pinnedRepositories(for: bob.id).isEmpty)
+        #expect(settings.hiddenRepositories(for: bob.id).isEmpty)
+        #expect(settings.repoList.pinnedRepositories.isEmpty)
+        #expect(settings.repoList.hiddenRepositories.isEmpty)
+    }
+
+    @Test
+    func `removing one account leaves another repository preferences intact`() throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob")
+        var settings = UserSettings()
+        settings.accounts = [alice, bob]
+        settings.activeAccountID = bob.id
+        settings.setPinnedRepositories(["owner/alice"], for: alice.id)
+        settings.setPinnedRepositories(["owner/bob"], for: bob.id)
+        settings.setHiddenRepositories(["owner/bob-hidden"], for: bob.id)
+
+        settings.removeRepositoryLists(for: alice.id)
+
+        #expect(settings.accountRepoLists.hasPinnedEntry(for: alice.id) == false)
+        #expect(settings.pinnedRepositories(for: bob.id) == ["owner/bob"])
+        #expect(settings.hiddenRepositories(for: bob.id) == ["owner/bob-hidden"])
+        #expect(settings.repoList.pinnedRepositories == ["owner/bob"])
+        #expect(settings.repoList.hiddenRepositories == ["owner/bob-hidden"])
+    }
+
+    private static func account(_ username: String) throws -> Account {
+        try Account(
+            username: username,
+            host: #require(URL(string: "https://github.com")),
+            authMethod: .oauth
+        )
+    }
 }

--- a/Tests/RepoBarTests/VisibilityTests.swift
+++ b/Tests/RepoBarTests/VisibilityTests.swift
@@ -145,6 +145,39 @@ struct VisibilityTests {
         #expect(matchingFullNames.count == 1)
         #expect(keptIssues == 1)
     }
+
+    @MainActor
+    @Test
+    func `account scoped pin hide and reorder remain isolated`() async throws {
+        let defaultsName = "com.steipete.repobar.visibility.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: defaultsName))
+        defer { defaults.removePersistentDomain(forName: defaultsName) }
+        let appState = AppState(settingsStore: SettingsStore(defaults: defaults))
+        let alice = try Account(
+            username: "alice",
+            host: #require(URL(string: "https://github.com")),
+            authMethod: .oauth
+        )
+        let bob = try Account(
+            username: "bob",
+            host: #require(URL(string: "https://github.com")),
+            authMethod: .oauth
+        )
+        appState.session.settings.accounts = [alice, bob]
+        appState.session.settings.activeAccountID = alice.id
+
+        await appState.addPinned("owner/shared", accountID: alice.id)
+        await appState.addPinned("owner/other", accountID: alice.id)
+        await appState.hide("owner/shared", accountID: bob.id)
+        await appState.movePinned("owner/other", direction: -1, accountID: alice.id)
+
+        #expect(appState.session.settings.pinnedRepositories(for: alice.id) == ["owner/other", "owner/shared"])
+        #expect(appState.session.settings.hiddenRepositories(for: alice.id).isEmpty)
+        #expect(appState.session.settings.pinnedRepositories(for: bob.id).isEmpty)
+        #expect(appState.session.settings.hiddenRepositories(for: bob.id) == ["owner/shared"])
+        #expect(appState.session.settings.repoList.pinnedRepositories == ["owner/other", "owner/shared"])
+        #expect(appState.session.settings.repoList.hiddenRepositories.isEmpty)
+    }
 }
 
 private func makeRepository(

--- a/Tests/repobarcliTests/AccountRepositoryTransitionTests.swift
+++ b/Tests/repobarcliTests/AccountRepositoryTransitionTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+@testable import repobarcli
 import RepoBarCore
 import Testing
 
@@ -77,11 +78,88 @@ struct AccountRepositoryTransitionTests {
         #expect(settings.repoList.hiddenRepositories.isEmpty)
     }
 
-    private static func account(_ username: String) throws -> Account {
+    @Test
+    func `CLI repository mutation preserves scoped empty across account switches`() throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob")
+        var settings = UserSettings()
+        settings.accounts = [alice, bob]
+        settings.activeAccountID = alice.id
+        settings.accountRepoLists.setPinned(["owner/repo"], for: alice.id)
+        settings.accountRepoLists.setHidden(["owner/bob-hidden"], for: bob.id)
+        settings.mirrorRepositoryListsToLegacy(for: alice.id)
+
+        applyRepoListMutation(.unpin, repository: "owner/repo", settings: &settings)
+        settings.prepareRepositoryListsForActiveAccountChange(to: bob.id)
+        settings.prepareRepositoryListsForActiveAccountChange(to: alice.id)
+
+        #expect(settings.pinnedRepositories(for: alice.id).isEmpty)
+        #expect(settings.repoList.pinnedRepositories.isEmpty)
+        #expect(settings.hiddenRepositories(for: bob.id) == ["owner/bob-hidden"])
+    }
+
+    @Test
+    func `CLI repository mutations isolate active account lists`() throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob")
+        var settings = UserSettings()
+        settings.accounts = [alice, bob]
+        settings.activeAccountID = alice.id
+        settings.accountRepoLists.setPinned(["owner/bob"], for: bob.id)
+        settings.accountRepoLists.setHidden(["owner/bob-hidden"], for: bob.id)
+        settings.mirrorRepositoryListsToLegacy(for: alice.id)
+
+        applyRepoListMutation(.pin, repository: "owner/alice", settings: &settings)
+        applyRepoListMutation(.hide, repository: "owner/alice-hidden", settings: &settings)
+        applyRepoListMutation(.show, repository: "owner/alice-hidden", settings: &settings)
+
+        #expect(settings.pinnedRepositories(for: alice.id) == ["owner/alice"])
+        #expect(settings.hiddenRepositories(for: alice.id).isEmpty)
+        #expect(settings.pinnedRepositories(for: bob.id) == ["owner/bob"])
+        #expect(settings.hiddenRepositories(for: bob.id) == ["owner/bob-hidden"])
+    }
+
+    @Test
+    func `OAuth activation migrates sole implicit account before append`() throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob", authMethod: .oauth)
+        var settings = UserSettings()
+        settings.accounts = [alice]
+        settings.activeAccountID = nil
+        settings.repoList.pinnedRepositories = ["owner/alice"]
+        settings.repoList.hiddenRepositories = ["owner/alice-hidden"]
+
+        activateCLIAccount(bob, settings: &settings)
+
+        #expect(settings.pinnedRepositories(for: alice.id) == ["owner/alice"])
+        #expect(settings.hiddenRepositories(for: alice.id) == ["owner/alice-hidden"])
+        #expect(settings.pinnedRepositories(for: bob.id).isEmpty)
+        #expect(settings.hiddenRepositories(for: bob.id).isEmpty)
+        #expect(settings.repoList.pinnedRepositories.isEmpty)
+        #expect(settings.repoList.hiddenRepositories.isEmpty)
+    }
+
+    @Test
+    func `PAT import activation migrates sole implicit account before append`() throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob", authMethod: .pat)
+        var settings = UserSettings()
+        settings.accounts = [alice]
+        settings.activeAccountID = nil
+        settings.repoList.pinnedRepositories = ["owner/alice"]
+
+        activateCLIAccount(bob, settings: &settings)
+
+        #expect(settings.pinnedRepositories(for: alice.id) == ["owner/alice"])
+        #expect(settings.pinnedRepositories(for: bob.id).isEmpty)
+        #expect(settings.repoList.pinnedRepositories.isEmpty)
+    }
+
+    private static func account(_ username: String, authMethod: AuthMethod = .oauth) throws -> Account {
         try Account(
             username: username,
             host: #require(URL(string: "https://github.com")),
-            authMethod: .oauth
+            authMethod: authMethod
         )
     }
 }

--- a/Tests/repobarcliTests/AccountRepositoryTransitionTests.swift
+++ b/Tests/repobarcliTests/AccountRepositoryTransitionTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import RepoBarCore
+import Testing
+
+struct AccountRepositoryTransitionTests {
+    @Test
+    func `account use preserves old lists and restores selected lists`() throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob")
+        var settings = UserSettings()
+        settings.accounts = [alice, bob]
+        settings.activeAccountID = alice.id
+        settings.repoList.pinnedRepositories = ["owner/alice"]
+        settings.repoList.hiddenRepositories = ["owner/alice-hidden"]
+        settings.accountRepoLists.setPinned(["owner/bob"], for: bob.id)
+        settings.accountRepoLists.setHidden(["owner/bob-hidden"], for: bob.id)
+
+        settings.prepareRepositoryListsForActiveAccountChange(to: bob.id)
+
+        #expect(settings.pinnedRepositories(for: alice.id) == ["owner/alice"])
+        #expect(settings.hiddenRepositories(for: alice.id) == ["owner/alice-hidden"])
+        #expect(settings.repoList.pinnedRepositories == ["owner/bob"])
+        #expect(settings.repoList.hiddenRepositories == ["owner/bob-hidden"])
+    }
+
+    @Test
+    func `login activation initializes new account without inheriting active lists`() throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob")
+        var settings = UserSettings()
+        settings.accounts = [alice]
+        settings.activeAccountID = alice.id
+        settings.repoList.pinnedRepositories = ["owner/alice"]
+        settings.accounts.append(bob)
+
+        settings.prepareRepositoryListsForActiveAccountChange(to: bob.id)
+
+        #expect(settings.pinnedRepositories(for: alice.id) == ["owner/alice"])
+        #expect(settings.pinnedRepositories(for: bob.id).isEmpty)
+        #expect(settings.repoList.pinnedRepositories.isEmpty)
+    }
+
+    @Test
+    func `active removal restores fallback account lists`() throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob")
+        var settings = UserSettings()
+        settings.accounts = [alice, bob]
+        settings.activeAccountID = alice.id
+        settings.repoList.pinnedRepositories = ["owner/alice"]
+        settings.accountRepoLists.setPinned(["owner/bob"], for: bob.id)
+
+        settings.prepareRepositoryListsForActiveAccountChange(to: bob.id)
+        settings.accounts.removeAll { $0.id == alice.id }
+        settings.removeRepositoryLists(for: alice.id)
+
+        #expect(settings.activeAccountID == bob.id)
+        #expect(settings.repoList.pinnedRepositories == ["owner/bob"])
+        #expect(settings.pinnedRepositories(for: bob.id) == ["owner/bob"])
+    }
+
+    @Test
+    func `deliberate empty selected account clears stale legacy lists`() throws {
+        let alice = try Self.account("alice")
+        let bob = try Self.account("bob")
+        var settings = UserSettings()
+        settings.accounts = [alice, bob]
+        settings.activeAccountID = alice.id
+        settings.repoList.pinnedRepositories = ["owner/alice"]
+        settings.repoList.hiddenRepositories = ["owner/alice-hidden"]
+        settings.accountRepoLists.setPinned([], for: bob.id)
+        settings.accountRepoLists.setHidden([], for: bob.id)
+
+        settings.prepareRepositoryListsForActiveAccountChange(to: bob.id)
+
+        #expect(settings.repoList.pinnedRepositories.isEmpty)
+        #expect(settings.repoList.hiddenRepositories.isEmpty)
+    }
+
+    private static func account(_ username: String) throws -> Account {
+        try Account(
+            username: username,
+            host: #require(URL(string: "https://github.com")),
+            authMethod: .oauth
+        )
+    }
+}

--- a/docs/multi-account-auth-plan.md
+++ b/docs/multi-account-auth-plan.md
@@ -43,7 +43,7 @@ The implementation is a sequential bottom-to-top stack:
 9. `multi-account-operations-status` — Actions & Runners, monitored owners, rate limits, contribution/global activity, and worst-health state.
 10. `multi-account-integration-proof` — integration fixtures, accessibility and UI polish, redacted personal plus EMU proof, and final README, docs, CHANGELOG, and issue updates.
 
-Only Layer 1, `multi-account-contracts`, is implemented in this change. Layers 2 through 10 remain deferred, and the new contracts do not change runtime, UI, notification, refresh, or CLI behavior.
+Layers 1 and 2 are implemented. `multi-account-refresh` adds account-scoped repository snapshot loading, bounded selected-account fan-out, cached-first hydration, last-good partial-failure handling, and the active-account compatibility projection. Layers 3 through 10 remain deferred; repository grouping, account-scoped settings writes, CLI scope changes, attention and navigator collectors, notifications, Actions, and other user-visible fan-out are unchanged.
 
 Landed:
 
@@ -55,6 +55,7 @@ Landed:
 - Phase 4 — `HTTPResponseDiskCache` and `RepoBarPersistentCache` accept an `accountID:` parameter and resolve to `~/Library/Application Support/RepoBar/Cache/<account>.sqlite` (legacy path used when `accountID` is `nil`). `GraphQLResponseDiskCache.scoped(accountID:)` follows the same pattern.
 - Phase 5 — `AccountSettingsView` shows an account list (use / visibility / verify / remove) above the legacy single-account form, which is now labelled "Add Account".
 - Phase 6 — CLI gains `repobar accounts list/use/remove`, plus `--account`/`--all` on `logout`, `--account` on `status`, and `--label` on `login`/`import-gh-token`. After successful auth both commands fetch `GET /user`, derive a stable `Account`, and persist tokens under the account-scoped keys in addition to the legacy fast-path entries.
+- Issue #101 Layer 2 — `AppState` resolves the included account/client pairs once, hydrates each scoped repository cache independently, refreshes through a bounded task group, retains per-account last-good state on failures, and rebuilds `Session.accountSessions` / `aggregatedRepositories` in settings order. Existing menu, activity, notification, and Actions surfaces remain projected from the active account.
 
 Deferred:
 

--- a/docs/multi-account-auth-plan.md
+++ b/docs/multi-account-auth-plan.md
@@ -15,6 +15,36 @@ RepoBar's current authentication code is intentionally small and clean, but it i
 
 The 0.6.6 cycle landed the bulk of the plan end-to-end behind a backward-compatible facade. The legacy single-account `TokenStore` keys (`default`, `client`, `pat`) and the `githubHost` / `enterpriseHost` / `loopbackPort` / `authMethod` `UserSettings` fields are still authoritative for installs that have not been re-auth'd; the new account-scoped keys, settings, caches, and clients are populated on first login (or via the legacy migration on bootstrap) without removing those legacy entries.
 
+### Issue #101 consolidated experience
+
+The next programme adds an optional consolidated experience on top of the existing multi-account foundations. Its accepted product contract is:
+
+1. Consolidation is opt-in through one global **Consolidate accounts** toggle that defaults off. Existing `AccountSelection` remains the source of per-account inclusion; no second account-selection list is introduced.
+2. The supported surfaces are the macOS app and bundled CLI. RepoBarCore contracts remain reusable by iOS, but iOS UI is out of scope.
+3. Every existing GitHub-backed read and monitoring surface will become account-aware. New remote GitHub mutations, including assign, label, comment, review, rerun, merge, and administration actions, are out of scope.
+4. Repositories and items visible through multiple accounts remain separate internally and visually, grouped and labelled by account. Repository display limits apply independently to each account.
+5. Existing per-account SQLite caches remain separate, and consolidated state is an in-memory union. The programme will not use SQLite `ATTACH` or add a shared `attention.sqlite` unless later profiling justifies it.
+6. When one account fails, its last-good cached rows remain visible and are marked stale or errored while healthy accounts continue. The menu-bar indicator reports the worst included-account health, while details remain per account.
+7. Notifications remain separate and account-labelled when multiple accounts observe the same pull request or release.
+8. The CLI adds explicit `--all-accounts`, retains `--account` and active-account defaults, and does not implicitly inherit the GUI consolidation toggle.
+9. Issue Navigator content from a non-active account requires a second explicit opt-in before OpenAI summaries are allowed.
+10. **Needs Attention** uses typed configurable rules for category, account, owner/repository filters, state, and priority. It does not expose arbitrary expressions or a nested AND/OR DSL. Its conservative default preset covers review requests, assignments, and failed workflows on pinned repositories.
+
+The implementation is a sequential bottom-to-top stack:
+
+1. `multi-account-contracts` — settings, account-scoped identities, attention-rule contracts, and Codable compatibility.
+2. `multi-account-refresh` — repository snapshot loader, bounded fan-out, last-good partial failures, and active-account compatibility projection.
+3. `multi-account-repo-state` — account-scoped pinned/hidden migration, cache and submenu identities, local host matching, and explicit client resolution.
+4. `multi-account-cli` — shared account scope, `--all-accounts`, stable output envelopes, and account settings/cache operations.
+5. `multi-account-dashboard` — Settings opt-in controls, grouped dashboard/menu, account headers, per-account limits, and account-aware submenus.
+6. `multi-account-attention` — typed rule evaluation, shared collectors, the default preset, normalized `AttentionItem`, and `repobar triage`.
+7. `multi-account-navigator` — Issue Navigator, Needs Attention mode, reference monitor fan-out, scopes/previews, and the AI secondary opt-in.
+8. `multi-account-notifications` — account-namespaced pull request/release polling, baselines, event IDs, labels, and click context.
+9. `multi-account-operations-status` — Actions & Runners, monitored owners, rate limits, contribution/global activity, and worst-health state.
+10. `multi-account-integration-proof` — integration fixtures, accessibility and UI polish, redacted personal plus EMU proof, and final README, docs, CHANGELOG, and issue updates.
+
+Only Layer 1, `multi-account-contracts`, is implemented in this change. Layers 2 through 10 remain deferred, and the new contracts do not change runtime, UI, notification, refresh, or CLI behavior.
+
 Landed:
 
 - Phase 0/1 — `Account`, `AccountSelection`, and `AccountScopedRepositoryLists` live in `RepoBarCore`; `UserSettings` decodes/encodes the new fields with safe defaults and omits them when empty so legacy reads stay clean.

--- a/docs/multi-account-auth-plan.md
+++ b/docs/multi-account-auth-plan.md
@@ -43,7 +43,7 @@ The implementation is a sequential bottom-to-top stack:
 9. `multi-account-operations-status` — Actions & Runners, monitored owners, rate limits, contribution/global activity, and worst-health state.
 10. `multi-account-integration-proof` — integration fixtures, accessibility and UI polish, redacted personal plus EMU proof, and final README, docs, CHANGELOG, and issue updates.
 
-Layers 1 and 2 are implemented. `multi-account-refresh` adds account-scoped repository snapshot loading, bounded selected-account fan-out, cached-first hydration, last-good partial-failure handling, and the active-account compatibility projection. Layers 3 through 10 remain deferred; repository grouping, account-scoped settings writes, CLI scope changes, attention and navigator collectors, notifications, Actions, and other user-visible fan-out are unchanged.
+Layers 1 through 3 are implemented. `multi-account-refresh` adds account-scoped repository snapshot loading, bounded selected-account fan-out, cached-first hydration, last-good partial-failure handling, and the active-account compatibility projection. `multi-account-repo-state` makes repository preferences account-scoped, isolates repository caches and submenu identities, resolves clients explicitly, and matches local checkouts by GitHub host. Layers 4 through 10 remain deferred; repository grouping, CLI scope changes, attention and navigator collectors, notifications, Actions, and other user-visible fan-out are unchanged.
 
 Landed:
 
@@ -56,6 +56,7 @@ Landed:
 - Phase 5 — `AccountSettingsView` shows an account list (use / visibility / verify / remove) above the legacy single-account form, which is now labelled "Add Account".
 - Phase 6 — CLI gains `repobar accounts list/use/remove`, plus `--account`/`--all` on `logout`, `--account` on `status`, and `--label` on `login`/`import-gh-token`. After successful auth both commands fetch `GET /user`, derive a stable `Account`, and persist tokens under the account-scoped keys in addition to the legacy fast-path entries.
 - Issue #101 Layer 2 — `AppState` resolves the included account/client pairs once, hydrates each scoped repository cache independently, refreshes through a bounded task group, retains per-account last-good state on failures, and rebuilds `Session.accountSessions` / `aggregatedRepositories` in settings order. Existing menu, activity, notification, and Actions surfaces remain projected from the active account.
+- Issue #101 Layer 3 — pinned and hidden repository lists migrate to explicit account entries without losing deliberate emptiness, active-account mutations retain legacy compatibility mirrors, recent/changelog/display caches use account-scoped repository identities, local checkout matching rejects cross-host collisions, and consolidated request paths resolve the owning account's client explicitly. Existing menu and repository Settings presentation remains active-account-only.
 
 Deferred:
 


### PR DESCRIPTION
Depends on #106

This is Layer 3 of the fork-backed consolidated multi-account stack. The PR currently includes the lower #105 and #106 commits because the stack targets `main`; that cumulative diff will shrink as those lower PRs merge.

Refs #101

## Summary

- make pinned and hidden repository preferences authoritative per account while preserving active-account legacy compatibility and deliberate empty-list migration
- route existing CLI repository mutations and account activation/removal paths through the same repository-list transition policy
- add explicit account-aware repository preference operations and throwing per-account GitHub client resolution
- scope recent-list, changelog, display, submenu, and inflight cache identities by account and repository
- prevent removed-account recent/changelog completions from repopulating caches after stable account IDs are re-added
- make local checkout matching and local-menu remote substitution host-aware, including custom-port GitHub Enterprise authorities
- keep current repository menus, settings UI, and session repository presentation active-account-only
- mark Layers 1-3 landed in the multi-account implementation plan

## Validation

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer npx --yes pnpm@11.21.0 test --filter AccountRepositoryTransitionTests --filter SettingsCommandTests --filter AccountScopedRepositoryListsTests --filter RecentListMenuTests --filter MenuSignatureTests --filter LocalProjectsServiceTests` — 51 tests across 6 suites passed
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer npx --yes pnpm@11.21.0 check` — SwiftFormat, SwiftLint, and 709 tests across 115 suites passed

## Review

The first follow-up fixed CLI active-account transitions, cross-host local-menu substitution, custom-port remote parsing, and removed-account recent/changelog cache races.

The second follow-up routes the real CLI `pin`/`unpin`/`hide`/`show` commands through account-scoped lists, migrates a sole implicit-active account before OAuth or PAT account insertion, makes same-key recent-list completion idempotent for all coalesced waiters while retaining lifecycle-generation protection, and resolves local matching from the active account host before legacy Enterprise/GitHub fallbacks. Regression coverage exercises those real helper paths, deliberate scoped emptiness across account switches, OAuth/PAT nil-active additions, two successful same-key waiters with one transport request, remove/re-add stale rejection, and active Enterprise custom-port matching with GitHub.com rejection.

A focused post-fix audit found no remaining high-confidence Layer 3 blocker.