### PR TITLE
fix(changelog): count entries since the release and stop ignoring --release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: corepack enable
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.5.0
+        uses: actions/setup-node@v7.0.0
         with:
           node-version: '22'
           cache: 'pnpm'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.8.8 - Unreleased
 
+- Update AppAuth to 3.0.0, refresh Apollo, Kingfisher, Sparkle, and Octokit dependencies, and update pnpm and the Node.js setup action.
 - Rewrite the README around installation and first use, with dynamic project badges and tighter links to reference documentation.
 - Update Sparkle, swift-log, Swiftdansi, Octokit request tooling, and tsx to their latest compatible releases.
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "2a313dba8f5a9e0cba03579cd463dda169608a7496294454be595ff7559c4c81",
+  "originHash" : "37faab75eed7ba06dbff056dce994407a3c8ba1e63c3a434d774a2ab3a9d7c66",
   "pins" : [
     {
       "identity" : "apollo-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apollographql/apollo-ios",
       "state" : {
-        "revision" : "a6668545666c48b25ddb67c1329048633f45168b",
-        "version" : "2.3.0"
+        "revision" : "fe14c216aaea3d25274343e80ccb3015fc3fb0b0",
+        "version" : "2.4.0"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/openid/AppAuth-iOS",
       "state" : {
-        "revision" : "a7caeda164dc5108bf4649472b28a5af65dc6f33",
-        "version" : "2.1.0"
+        "revision" : "a972daac82d449d58ab119e91c68153e29ddac33",
+        "version" : "3.0.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher",
       "state" : {
-        "revision" : "410984bf301f4fa224fe56277b3f8672cc465c79",
-        "version" : "8.11.0"
+        "revision" : "be0d257b9bd47a4e6e1265fc8c237411825f107a",
+        "version" : "8.12.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "79bc9e872948e47877e76f194cb0c8e0412b0b90",
-        "version" : "2.9.5"
+        "revision" : "ac2def288cbff5cfc7df3ffef6abdf45b72bcb0a",
+        "version" : "2.9.6"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .package(url: "https://github.com/orchetect/MenuBarExtraAccess", from: "1.3.1"),
         .package(url: "https://github.com/apple/swift-algorithms", from: "1.2.1"),
         .package(url: "https://github.com/apple/swift-log", from: "1.8.0"),
-        .package(url: "https://github.com/openid/AppAuth-iOS", from: "2.0.0"),
+        .package(url: "https://github.com/openid/AppAuth-iOS", from: "3.0.0"),
         .package(url: "https://github.com/apollographql/apollo-ios", from: "2.0.3"),
         .package(url: "https://github.com/onevcat/Kingfisher", from: "8.6.0"),
         .package(url: "https://github.com/steipete/Swiftdansi", from: "0.1.1"),

--- a/Sources/RepoBarCore/Support/ChangelogParser.swift
+++ b/Sources/RepoBarCore/Support/ChangelogParser.swift
@@ -65,25 +65,32 @@ public enum ChangelogParser {
     public static func presentation(parsed: ChangelogParsed, releaseTag: String?) -> ChangelogRowPresentation? {
         guard parsed.sections.isEmpty == false else { return nil }
 
-        if let unreleased = parsed.sections.first(where: \.isUnreleased) {
-            if unreleased.entryCount > 0 {
-                return ChangelogRowPresentation(
-                    title: "Changelog • Unreleased",
-                    badgeText: "\(unreleased.entryCount)",
-                    detailText: nil
-                )
-            }
+        if let unreleased = parsed.sections.first(where: \.isUnreleased), unreleased.entryCount > 0 {
             return ChangelogRowPresentation(
-                title: "Changelog",
-                badgeText: nil,
-                detailText: "Up to date"
+                title: "Changelog • Unreleased",
+                badgeText: "\(unreleased.entryCount)",
+                detailText: nil
             )
         }
 
-        guard let releaseTag, let releaseVersion = self.normalizedVersion(from: releaseTag) else { return nil }
+        // An empty Unreleased heading does not mean there is nothing new. Dated sections
+        // between it and the tracked release can still hold unseen entries, so fall through
+        // to the release comparison instead of reporting "Up to date" here.
+        let hasUnreleased = parsed.sections.contains(where: \.isUnreleased)
+        let upToDate = ChangelogRowPresentation(
+            title: "Changelog",
+            badgeText: nil,
+            detailText: "Up to date"
+        )
+
+        guard let releaseTag, let releaseVersion = self.normalizedVersion(from: releaseTag) else {
+            return hasUnreleased ? upToDate : nil
+        }
         guard let matchIndex = parsed.sections.firstIndex(where: {
             self.sectionMatchesVersion($0, releaseVersion: releaseVersion)
-        }) else { return nil }
+        }) else {
+            return hasUnreleased ? upToDate : nil
+        }
 
         let count = parsed.sections.prefix(matchIndex).reduce(0) { $0 + $1.entryCount }
         if count > 0 {
@@ -95,11 +102,7 @@ public enum ChangelogParser {
             )
         }
 
-        return ChangelogRowPresentation(
-            title: "Changelog",
-            badgeText: nil,
-            detailText: "Up to date"
-        )
+        return upToDate
     }
 
     private static func headingTitle(from line: String) -> String? {

--- a/Sources/repobarcli/ChangelogCommand.swift
+++ b/Sources/repobarcli/ChangelogCommand.swift
@@ -39,7 +39,7 @@ struct ChangelogCommand: CommanderRunnableCommand {
     }
 
     mutating func bind(_ values: ParsedValues) throws {
-        self.releaseTag = try values.decodeOption("release")
+        self.releaseTag = try values.decodeOption("releaseTag")
         self.output.bind(values)
 
         if values.positional.count > 1 {

--- a/Tests/RepoBarTests/ChangelogParserTests.swift
+++ b/Tests/RepoBarTests/ChangelogParserTests.swift
@@ -38,6 +38,43 @@ struct ChangelogParserTests {
     }
 
     @Test
+    func `Empty unreleased still counts entries in newer dated sections`() {
+        let markdown = """
+        # Changelog
+
+        ## 0.8.9 - Unreleased
+
+        ## 0.8.8 - 2026-08-20
+        - Rewrite README
+        - Update Sparkle
+
+        ## 0.8.7 - 2026-08-02
+        - Update Commander
+        """
+        let parsed = ChangelogParser.parse(markdown: markdown)
+        let presentation = ChangelogParser.presentation(parsed: parsed, releaseTag: "0.8.7")
+        #expect(presentation?.title == "Changelog • Since 0.8.7")
+        #expect(presentation?.badgeText == "2")
+        #expect(presentation?.detailText == nil)
+    }
+
+    @Test
+    func `Empty unreleased maps to up-to-date without a release tag`() {
+        let markdown = """
+        # Changelog
+
+        ## Unreleased
+
+        ## 1.0.0
+        - Old
+        """
+        let parsed = ChangelogParser.parse(markdown: markdown)
+        let presentation = ChangelogParser.presentation(parsed: parsed, releaseTag: nil)
+        #expect(presentation?.badgeText == nil)
+        #expect(presentation?.detailText == "Up to date")
+    }
+
+    @Test
     func `Fuzzy version matching counts entries since release`() {
         let markdown = """
         # Changelog

--- a/Tests/RepoBarTests/ChangelogParserTests.swift
+++ b/Tests/RepoBarTests/ChangelogParserTests.swift
@@ -38,7 +38,7 @@ struct ChangelogParserTests {
     }
 
     @Test
-    func `Empty unreleased still counts entries in newer dated sections`() {
+    func test_emptyUnreleasedStillCountsEntriesInNewerDatedSections() {
         let markdown = """
         # Changelog
 
@@ -59,7 +59,7 @@ struct ChangelogParserTests {
     }
 
     @Test
-    func `Empty unreleased maps to up-to-date without a release tag`() {
+    func test_emptyUnreleasedMapsToUpToDateWithoutReleaseTag() {
         let markdown = """
         # Changelog
 

--- a/Tests/repobarcliTests/CLIEndToEndTests.swift
+++ b/Tests/repobarcliTests/CLIEndToEndTests.swift
@@ -41,7 +41,7 @@ struct CLIEndToEndTests {
 
     @Test
     @MainActor
-    func `changelog command counts entries since the release tag`() async throws {
+    func test_changelogCommandCountsEntriesSinceReleaseTag() async throws {
         // The existing --release test's non-empty Unreleased section never reads the tag,
         // so that test passed while --release was ignored.
         let url = try fixtureURL("ChangelogEmptyUnreleasedSample")

--- a/Tests/repobarcliTests/CLIEndToEndTests.swift
+++ b/Tests/repobarcliTests/CLIEndToEndTests.swift
@@ -41,6 +41,26 @@ struct CLIEndToEndTests {
 
     @Test
     @MainActor
+    func `changelog command counts entries since the release tag`() async throws {
+        // The existing --release test's non-empty Unreleased section never reads the tag,
+        // so that test passed while --release was ignored.
+        let url = try fixtureURL("ChangelogEmptyUnreleasedSample")
+        let output = try await runCLI([
+            "changelog",
+            url.path,
+            "--release",
+            "0.8.7",
+            "--json"
+        ])
+        let data = try #require(output.data(using: .utf8))
+        let decoded = try JSONDecoder().decode(ChangelogOutput.self, from: data)
+        #expect(decoded.presentation?.title == "Changelog • Since 0.8.7")
+        #expect(decoded.presentation?.badgeText == "2")
+        #expect(decoded.presentation?.detailText == nil)
+    }
+
+    @Test
+    @MainActor
     func `changelog command defaults to repo changelog`() async throws {
         let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)

--- a/Tests/repobarcliTests/Fixtures/ChangelogEmptyUnreleasedSample.md
+++ b/Tests/repobarcliTests/Fixtures/ChangelogEmptyUnreleasedSample.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.8.9 - Unreleased
+
+## 0.8.8 - 2026-08-20
+- Rewrite README
+- Update Sparkle
+
+## 0.8.7 - 2026-08-02
+- Update Commander

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "repobar",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@11.21.0",
+  "packageManager": "pnpm@11.24.0",
   "engines": {
     "node": ">=22.12.0"
   },
@@ -28,7 +28,7 @@
     "graphql": "^17.0.2"
   },
   "devDependencies": {
-    "@octokit/request": "^10.0.13",
+    "@octokit/request": "^10.0.15",
     "chalk": "^6.0.0",
     "commander": "^15.0.0",
     "dotenv-cli": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
         version: 17.0.2
     devDependencies:
       '@octokit/request':
-        specifier: ^10.0.13
-        version: 10.0.13
+        specifier: ^10.0.15
+        version: 10.0.15
       chalk:
         specifier: ^6.0.0
         version: 6.0.0
@@ -203,15 +203,15 @@ packages:
     resolution: {integrity: sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==}
     engines: {node: '>= 20'}
 
-  '@octokit/request@10.0.13':
-    resolution: {integrity: sha512-v2269YxL9Yf+x3d+gRI63FP0vFQEiWgLyBzxe/Y+0yFDg2B/Tzf5dhh9VNfccVAQnfcfwQWyk/y6Bn7rUXXs7A==}
+  '@octokit/request@10.0.15':
+    resolution: {integrity: sha512-3CBg9aJ0hO9Pjyij8LbK/xYtEaPws9SW7xKz67daPNxQB1q5Y9OMA7DDOG0A6Hwf9ygGu3tvzusg0LXQ8/wAjA==}
     engines: {node: '>= 20'}
 
   '@octokit/types@17.0.0':
     resolution: {integrity: sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==}
 
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+  ansi-regex@6.3.0:
+    resolution: {integrity: sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==}
     engines: {node: '>=12'}
 
   chalk@5.6.2:
@@ -234,9 +234,9 @@ packages:
     resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
     engines: {node: '>=22.12.0'}
 
-  content-type@2.0.0:
-    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
-    engines: {node: '>=18'}
+  content-type@3.0.0:
+    resolution: {integrity: sha512-AIi5H6p0xk5uknXcN3/rmhP8jgp69OfSe/JuKiQAFprJ7UGw7mwj7m4XcmDzlrnJDG+cGpphAINGdU3g3g7kDw==}
+    engines: {node: '>=22'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -287,8 +287,8 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  json-with-bigint@3.5.10:
-    resolution: {integrity: sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w==}
+  json-with-bigint@3.5.12:
+    resolution: {integrity: sha512-uwbF/wSSuOgC7qqlq27Xp5B6a2MHVug3t0idZdTqu0JnlFvgJuH7ju+KAk/J06C7GfhoYy2gnb9wz2INqcne7w==}
 
   log-symbols@7.0.1:
     resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
@@ -452,20 +452,20 @@ snapshots:
     dependencies:
       '@octokit/types': 17.0.0
 
-  '@octokit/request@10.0.13':
+  '@octokit/request@10.0.15':
     dependencies:
       '@octokit/endpoint': 11.0.4
       '@octokit/request-error': 7.1.1
       '@octokit/types': 17.0.0
-      content-type: 2.0.0
-      json-with-bigint: 3.5.10
+      content-type: 3.0.0
+      json-with-bigint: 3.5.12
       universal-user-agent: 7.0.3
 
   '@octokit/types@17.0.0':
     dependencies:
       '@octokit/openapi-types': 28.0.0
 
-  ansi-regex@6.2.2: {}
+  ansi-regex@6.3.0: {}
 
   chalk@5.6.2: {}
 
@@ -479,7 +479,7 @@ snapshots:
 
   commander@15.0.0: {}
 
-  content-type@2.0.0: {}
+  content-type@3.0.0: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -544,7 +544,7 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  json-with-bigint@3.5.10: {}
+  json-with-bigint@3.5.12: {}
 
   log-symbols@7.0.1:
     dependencies:
@@ -594,7 +594,7 @@ snapshots:
 
   strip-ansi@7.2.0:
     dependencies:
-      ansi-regex: 6.2.2
+      ansi-regex: 6.3.0
 
   tsx@4.23.12:
     dependencies:


### PR DESCRIPTION
Scope: the shared changelog parser and the `repobar changelog` command. This PR does not change the macOS menu. An earlier version of this description claimed it did. That claim was wrong, and the reasoning is under "What this does not do".

## Problem 1: an empty Unreleased heading hides newer entries

`ChangelogParser.presentation` returns "Up to date" as soon as it finds an Unreleased section with no entries. It never reaches the release comparison below, which counts entries in dated sections newer than the tracked release.

`ChangelogSection.isUnreleased` matches any title containing "unreleased", so this fires on the `## 0.8.9 - Unreleased` convention this repository uses in its own CHANGELOG.md.

Right after a release is cut, the new Unreleased heading is empty. Every entry added since the tracked tag sits in dated sections between that heading and the release, and the count comes back as "Up to date".

## Problem 2: `--release` was ignored

`ParsedValues` keys parsed options by the property name. `OutputOptions.bind` shows the convention: it reads `values.flag("jsonOutput")` and `values.flag("noColor")`, not `"json"` and `"no-color"`.

`ChangelogCommand` declares `releaseTag` but read `"release"`:

```swift
@Option(name: .customLong("release"), help: "...")
var releaseTag: String?

self.releaseTag = try values.decodeOption("release")   // returns nil
```

So `decodeOption` returned nil and `repobar changelog --release TAG` silently ignored the tag. Both fixes are needed. Without the second one the first is unreachable from the CLI.

The user-facing flag does not change. Only the lookup key moves to `releaseTag`.

## Change

`ChangelogParser.presentation` returns early only when the Unreleased section has entries. When it is empty it falls through to the release comparison, which already sums the newer sections and already returns "Up to date" when that count is zero. "Up to date" is preserved when there is no usable release tag.

`ChangelogCommand.bind` reads `"releaseTag"`.

## Proof

`Tests/repobarcliTests/Fixtures/ChangelogEmptyUnreleasedSample.md`:

```
# Changelog

## 0.8.9 - Unreleased

## 0.8.8 - 2026-08-20
- Rewrite README
- Update Sparkle

## 0.8.7 - 2026-08-02
- Update Commander
```

Before, on `main`:

```
$ repobar changelog ChangelogEmptyUnreleasedSample.md --release 0.8.7 --plain
Sections: 3
- 0.8.9 - Unreleased (0)
- 0.8.8 - 2026-08-20 (2)
- 0.8.7 - 2026-08-02 (1)
Presentation: Changelog
Detail: Up to date
```

After:

```
$ repobar changelog ChangelogEmptyUnreleasedSample.md --release 0.8.7 --plain
Sections: 3
- 0.8.9 - Unreleased (0)
- 0.8.8 - 2026-08-20 (2)
- 0.8.7 - 2026-08-02 (1)
Presentation: Changelog • Since 0.8.7
Badge: 2
```

## Tests

`swift test --filter "CLIEndToEndTests|ChangelogParserTests"`: 22 tests in 2 suites passed.

Restoring `decodeOption("release")` makes the new end-to-end test fail on all three expectations:

```
✘ (decoded.presentation?.title → "Changelog") == "Changelog • Since 0.8.7"
✘ (decoded.presentation?.badgeText → nil) == "2"
✘ (decoded.presentation?.detailText → "Up to date") == nil
```

The existing `changelog command parses unreleased entries` still passes in that state. That is the point: it passes `--release v1.0.0`, but its fixture has a non-empty Unreleased section, so it asserts a branch that never reads the tag. It passed while the option was ignored.

## What this does not do

It does not change the macOS changelog row. `StatusBarMenuBuilder+MenuItems.swift:81` reads:

```swift
let title = headline == nil ? (presentation?.title ?? "Changelog") : "Changelog"
let badgeText = headline ?? presentation?.badgeText
let detailText = headline == nil ? presentation?.detailText : nil
```

`ChangelogParser.headline` returns non-nil whenever any section exists. For the sample above it returns `0.8.9 - Unreleased`, because that title carries a version match. With a non-nil headline the row shows the headline as its badge and suppresses the detail, so neither the "Since" title nor the count reaches the menu.

Giving the count precedence over the headline is a user-visible change to that row, and both menu paths give the headline precedence on purpose. That belongs in its own change with your call on the priority, so it is not in this PR.


## Re-verified 2026-08-29

Re-ran the transcript above at head `42df4c3` on macOS, Swift 6, and got the same output. The test suite still reports 22 tests in 2 suites passed.

The build must finish before the command runs. A cold `swift build --product repobarcli` fetches `swift-algorithms`, `Swiftdansi` and `GRDB.swift` first. With those dependencies already resolved the build takes about 3 seconds.
