### PR TITLE
settings: rename ambiguous "Display" section header to "Heatmap"

### DIFF
--- a/Sources/RepoBar/Settings/GeneralSettingsView.swift
+++ b/Sources/RepoBar/Settings/GeneralSettingsView.swift
@@ -76,7 +76,7 @@ struct GeneralSettingsView: View {
                         }
                     }
                 } header: {
-                    Text("Display")
+                    Text("Heatmap")
                 } footer: {
                     Text("Repository heatmaps show recent commit activity for each repository.")
                 }


### PR DESCRIPTION
## Why

Preferences → General has a section titled \"Display\" for the repository heatmap controls (style, window span, color). Preferences also has its own top-level \"Display\" tab right next to General, for a completely different set of settings (main menu layout, repo submenu items). Same label, two unrelated places - #26 is exactly this confusion (\"a bit confusing that there are two 'Display' setting instances\").

## Change

One label: `Sources/RepoBar/Settings/GeneralSettingsView.swift` - the General → heatmap section header goes from \"Display\" to \"Heatmap\", matching its own footer text (\"Repository heatmaps show recent commit activity...\") and its Picker labels (\"Repository heatmap\", \"Heatmap window\", \"Heatmap color\"). No behavior change, no new setting, nothing else renamed - checked the iOS settings screen too and it doesn't have this collision (no separate top-level Display tab there).

No screenshot attached - it's a one-line header string, and I don't have an interactive session here to capture the live menu bar app; happy to add one if you'd like it anyway.

## Test plan

- [x] `pnpm check` (swiftformat + swiftlint + swift test) - clean, 666 tests passed
- [x] `pnpm build` - builds and links