### PR TITLE
chore(deps): refresh Swift packages and development tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: corepack enable
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.5.0
+        uses: actions/setup-node@v7.0.0
         with:
           node-version: '22'
           cache: 'pnpm'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.8.8 - Unreleased
 
+- Update AppAuth to 3.0.0, refresh Apollo, Kingfisher, Sparkle, and Octokit dependencies, and update pnpm and the Node.js setup action.
 - Rewrite the README around installation and first use, with dynamic project badges and tighter links to reference documentation.
 - Update Sparkle, swift-log, Swiftdansi, Octokit request tooling, and tsx to their latest compatible releases.
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "2a313dba8f5a9e0cba03579cd463dda169608a7496294454be595ff7559c4c81",
+  "originHash" : "37faab75eed7ba06dbff056dce994407a3c8ba1e63c3a434d774a2ab3a9d7c66",
   "pins" : [
     {
       "identity" : "apollo-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apollographql/apollo-ios",
       "state" : {
-        "revision" : "a6668545666c48b25ddb67c1329048633f45168b",
-        "version" : "2.3.0"
+        "revision" : "fe14c216aaea3d25274343e80ccb3015fc3fb0b0",
+        "version" : "2.4.0"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/openid/AppAuth-iOS",
       "state" : {
-        "revision" : "a7caeda164dc5108bf4649472b28a5af65dc6f33",
-        "version" : "2.1.0"
+        "revision" : "a972daac82d449d58ab119e91c68153e29ddac33",
+        "version" : "3.0.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher",
       "state" : {
-        "revision" : "410984bf301f4fa224fe56277b3f8672cc465c79",
-        "version" : "8.11.0"
+        "revision" : "be0d257b9bd47a4e6e1265fc8c237411825f107a",
+        "version" : "8.12.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "79bc9e872948e47877e76f194cb0c8e0412b0b90",
-        "version" : "2.9.5"
+        "revision" : "ac2def288cbff5cfc7df3ffef6abdf45b72bcb0a",
+        "version" : "2.9.6"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .package(url: "https://github.com/orchetect/MenuBarExtraAccess", from: "1.3.1"),
         .package(url: "https://github.com/apple/swift-algorithms", from: "1.2.1"),
         .package(url: "https://github.com/apple/swift-log", from: "1.8.0"),
-        .package(url: "https://github.com/openid/AppAuth-iOS", from: "2.0.0"),
+        .package(url: "https://github.com/openid/AppAuth-iOS", from: "3.0.0"),
         .package(url: "https://github.com/apollographql/apollo-ios", from: "2.0.3"),
         .package(url: "https://github.com/onevcat/Kingfisher", from: "8.6.0"),
         .package(url: "https://github.com/steipete/Swiftdansi", from: "0.1.1"),

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "repobar",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@11.21.0",
+  "packageManager": "pnpm@11.24.0",
   "engines": {
     "node": ">=22.12.0"
   },
@@ -28,7 +28,7 @@
     "graphql": "^17.0.2"
   },
   "devDependencies": {
-    "@octokit/request": "^10.0.13",
+    "@octokit/request": "^10.0.15",
     "chalk": "^6.0.0",
     "commander": "^15.0.0",
     "dotenv-cli": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
         version: 17.0.2
     devDependencies:
       '@octokit/request':
-        specifier: ^10.0.13
-        version: 10.0.13
+        specifier: ^10.0.15
+        version: 10.0.15
       chalk:
         specifier: ^6.0.0
         version: 6.0.0
@@ -203,15 +203,15 @@ packages:
     resolution: {integrity: sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==}
     engines: {node: '>= 20'}
 
-  '@octokit/request@10.0.13':
-    resolution: {integrity: sha512-v2269YxL9Yf+x3d+gRI63FP0vFQEiWgLyBzxe/Y+0yFDg2B/Tzf5dhh9VNfccVAQnfcfwQWyk/y6Bn7rUXXs7A==}
+  '@octokit/request@10.0.15':
+    resolution: {integrity: sha512-3CBg9aJ0hO9Pjyij8LbK/xYtEaPws9SW7xKz67daPNxQB1q5Y9OMA7DDOG0A6Hwf9ygGu3tvzusg0LXQ8/wAjA==}
     engines: {node: '>= 20'}
 
   '@octokit/types@17.0.0':
     resolution: {integrity: sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==}
 
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+  ansi-regex@6.3.0:
+    resolution: {integrity: sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==}
     engines: {node: '>=12'}
 
   chalk@5.6.2:
@@ -234,9 +234,9 @@ packages:
     resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
     engines: {node: '>=22.12.0'}
 
-  content-type@2.0.0:
-    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
-    engines: {node: '>=18'}
+  content-type@3.0.0:
+    resolution: {integrity: sha512-AIi5H6p0xk5uknXcN3/rmhP8jgp69OfSe/JuKiQAFprJ7UGw7mwj7m4XcmDzlrnJDG+cGpphAINGdU3g3g7kDw==}
+    engines: {node: '>=22'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -287,8 +287,8 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  json-with-bigint@3.5.10:
-    resolution: {integrity: sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w==}
+  json-with-bigint@3.5.12:
+    resolution: {integrity: sha512-uwbF/wSSuOgC7qqlq27Xp5B6a2MHVug3t0idZdTqu0JnlFvgJuH7ju+KAk/J06C7GfhoYy2gnb9wz2INqcne7w==}
 
   log-symbols@7.0.1:
     resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
@@ -452,20 +452,20 @@ snapshots:
     dependencies:
       '@octokit/types': 17.0.0
 
-  '@octokit/request@10.0.13':
+  '@octokit/request@10.0.15':
     dependencies:
       '@octokit/endpoint': 11.0.4
       '@octokit/request-error': 7.1.1
       '@octokit/types': 17.0.0
-      content-type: 2.0.0
-      json-with-bigint: 3.5.10
+      content-type: 3.0.0
+      json-with-bigint: 3.5.12
       universal-user-agent: 7.0.3
 
   '@octokit/types@17.0.0':
     dependencies:
       '@octokit/openapi-types': 28.0.0
 
-  ansi-regex@6.2.2: {}
+  ansi-regex@6.3.0: {}
 
   chalk@5.6.2: {}
 
@@ -479,7 +479,7 @@ snapshots:
 
   commander@15.0.0: {}
 
-  content-type@2.0.0: {}
+  content-type@3.0.0: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -544,7 +544,7 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  json-with-bigint@3.5.10: {}
+  json-with-bigint@3.5.12: {}
 
   log-symbols@7.0.1:
     dependencies:
@@ -594,7 +594,7 @@ snapshots:
 
   strip-ansi@7.2.0:
     dependencies:
-      ansi-regex: 6.2.2
+      ansi-regex: 6.3.0
 
   tsx@4.23.12:
     dependencies:


### PR DESCRIPTION
Refresh the macOS app's dependencies and development tooling without changing application code. The baseline `main` CI and Pages deployment were both green.

Updates:

- SwiftPM: AppAuth 2.1.0 → 3.0.0, Apollo 2.3.0 → 2.4.0, Kingfisher 8.11.0 → 8.12.0, and Sparkle 2.9.5 → 2.9.6. AppAuth's new minimum platforms fit RepoBar's existing deployment targets; no source migration was required. Other direct and transitive Swift packages are already current.
- pnpm: 11.21.0 → 11.24.0; `@octokit/request` 10.0.13 → 10.0.15. Refresh transitive `content-type` 2.0.0 → 3.0.0, `json-with-bigint` 3.5.10 → 3.5.12, and `ansi-regex` 6.2.2 → 6.3.0. The Node.js minimum remains unchanged and satisfies the updated dependencies.
- GitHub Actions: `actions/setup-node` 6.5.0 → 7.0.0. Existing `actions/checkout@v7` and `setup-xcode@v1` already track current release lines.
- Add one entry to the existing Unreleased changelog section.

Held upgrades: none. `pnpm outdated --format json` returns `{}`. No open Dependabot or Renovate PRs are superseded.

Proof on macOS arm64, Xcode 26.6 / Swift 6.3.3, Node.js 24.20.0, pnpm 11.24.0:

- `pnpm install --frozen-lockfile` and `swift package update` passed.
- `pnpm build` passed for the app and CLI (226 seconds).
- `pnpm check` passed: formatting left all 355 checked files unchanged, strict lint passed, and 666 tests in 109 suites passed with zero failures.
- `pnpm check:coverage` passed: 86.0% line coverage (9,950 / 11,567), above the 70% threshold.
- Developer ID-signed CLI passed help, fixture changelog JSON parsing, and fixture Markdown rendering; both `pnpm ghql --help` and `pnpm ghrest --help` passed.
- Mocked Octokit request dispatch and JSON response decoding passed without live credentials or network requests.
- `git diff --check` passed; isolated Codex autoreview reported no actionable findings at its default P0 threshold.

The existing hosted CI continues to select Xcode 26.1 and Node.js 22; its run provides the separate check for that toolchain. No app UI was launched and no release was created.
