### PR TITLE
Read five more CLI options by their property name

### DIFF
--- a/Sources/repobarcli/LocalActionsCommands.swift
+++ b/Sources/repobarcli/LocalActionsCommands.swift
@@ -117,7 +117,7 @@ struct LocalResetCommand: CommanderRunnableCommand {
 
     mutating func bind(_ values: ParsedValues) throws {
         self.output.bind(values)
-        self.assumeYes = values.flag("yes")
+        self.assumeYes = values.flag("assumeYes")
         if values.positional.count > 1 {
             throw ValidationError("Only one repository or path can be specified")
         }
@@ -329,7 +329,7 @@ struct CheckoutCommand: CommanderRunnableCommand {
         self.output.bind(values)
         self.root = try values.decodeOption("root")
         self.destination = try values.decodeOption("destination")
-        self.openAfter = values.flag("open")
+        self.openAfter = values.flag("openAfter")
         if values.positional.count > 1 {
             throw ValidationError("Only one repository can be specified")
         }

--- a/Sources/repobarcli/VerifyCommands.swift
+++ b/Sources/repobarcli/VerifyCommands.swift
@@ -85,9 +85,9 @@ struct RepoCommand: CommanderRunnableCommand {
     }
 
     mutating func bind(_ values: ParsedValues) throws {
-        self.includeTraffic = values.flag("traffic")
-        self.includeHeatmap = values.flag("heatmap")
-        self.includeRelease = values.flag("release")
+        self.includeTraffic = values.flag("includeTraffic")
+        self.includeHeatmap = values.flag("includeHeatmap")
+        self.includeRelease = values.flag("includeRelease")
         self.output.bind(values)
 
         if values.positional.count > 1 {

--- a/Tests/repobarcliTests/CLIParsingTests.swift
+++ b/Tests/repobarcliTests/CLIParsingTests.swift
@@ -54,7 +54,7 @@ struct CLIParsingTests {
 
     @Test
     @MainActor
-    func `local reset yes flag binds assume yes`() throws {
+    func test_localResetYesFlagBindsAssumeYes() throws {
         let defaultCommand = try parseCommand(LocalResetCommand.self, arguments: ["local-reset"])
         let flaggedCommand = try parseCommand(LocalResetCommand.self, arguments: ["local-reset", "--yes"])
 
@@ -64,7 +64,7 @@ struct CLIParsingTests {
 
     @Test
     @MainActor
-    func `checkout open flag binds open after`() throws {
+    func test_checkoutOpenFlagBindsOpenAfter() throws {
         let defaultCommand = try parseCommand(CheckoutCommand.self, arguments: ["checkout"])
         let flaggedCommand = try parseCommand(CheckoutCommand.self, arguments: ["checkout", "--open"])
 
@@ -74,7 +74,7 @@ struct CLIParsingTests {
 
     @Test
     @MainActor
-    func `repo traffic flag binds include traffic`() throws {
+    func test_repoTrafficFlagBindsIncludeTraffic() throws {
         let defaultCommand = try parseCommand(RepoCommand.self, arguments: ["repo"])
         let flaggedCommand = try parseCommand(RepoCommand.self, arguments: ["repo", "--traffic"])
 
@@ -84,7 +84,7 @@ struct CLIParsingTests {
 
     @Test
     @MainActor
-    func `repo heatmap flag binds include heatmap`() throws {
+    func test_repoHeatmapFlagBindsIncludeHeatmap() throws {
         let defaultCommand = try parseCommand(RepoCommand.self, arguments: ["repo"])
         let flaggedCommand = try parseCommand(RepoCommand.self, arguments: ["repo", "--heatmap"])
 
@@ -94,7 +94,7 @@ struct CLIParsingTests {
 
     @Test
     @MainActor
-    func `repo release flag binds include release`() throws {
+    func test_repoReleaseFlagBindsIncludeRelease() throws {
         let defaultCommand = try parseCommand(RepoCommand.self, arguments: ["repo"])
         let flaggedCommand = try parseCommand(RepoCommand.self, arguments: ["repo", "--release"])
 

--- a/Tests/repobarcliTests/CLIParsingTests.swift
+++ b/Tests/repobarcliTests/CLIParsingTests.swift
@@ -51,4 +51,65 @@ struct CLIParsingTests {
             _ = try parseRepoName("steipete/RepoBar/issues/1")
         }
     }
+
+    @Test
+    @MainActor
+    func `local reset yes flag binds assume yes`() throws {
+        let defaultCommand = try parseCommand(LocalResetCommand.self, arguments: ["local-reset"])
+        let flaggedCommand = try parseCommand(LocalResetCommand.self, arguments: ["local-reset", "--yes"])
+
+        #expect(defaultCommand.assumeYes == false)
+        #expect(flaggedCommand.assumeYes)
+    }
+
+    @Test
+    @MainActor
+    func `checkout open flag binds open after`() throws {
+        let defaultCommand = try parseCommand(CheckoutCommand.self, arguments: ["checkout"])
+        let flaggedCommand = try parseCommand(CheckoutCommand.self, arguments: ["checkout", "--open"])
+
+        #expect(defaultCommand.openAfter == false)
+        #expect(flaggedCommand.openAfter)
+    }
+
+    @Test
+    @MainActor
+    func `repo traffic flag binds include traffic`() throws {
+        let defaultCommand = try parseCommand(RepoCommand.self, arguments: ["repo"])
+        let flaggedCommand = try parseCommand(RepoCommand.self, arguments: ["repo", "--traffic"])
+
+        #expect(defaultCommand.includeTraffic == false)
+        #expect(flaggedCommand.includeTraffic)
+    }
+
+    @Test
+    @MainActor
+    func `repo heatmap flag binds include heatmap`() throws {
+        let defaultCommand = try parseCommand(RepoCommand.self, arguments: ["repo"])
+        let flaggedCommand = try parseCommand(RepoCommand.self, arguments: ["repo", "--heatmap"])
+
+        #expect(defaultCommand.includeHeatmap == false)
+        #expect(flaggedCommand.includeHeatmap)
+    }
+
+    @Test
+    @MainActor
+    func `repo release flag binds include release`() throws {
+        let defaultCommand = try parseCommand(RepoCommand.self, arguments: ["repo"])
+        let flaggedCommand = try parseCommand(RepoCommand.self, arguments: ["repo", "--release"])
+
+        #expect(defaultCommand.includeRelease == false)
+        #expect(flaggedCommand.includeRelease)
+    }
+}
+
+@MainActor
+private func parseCommand<T: CommanderRunnableCommand>(
+    _: T.Type,
+    arguments: [String]
+) throws -> T {
+    let argv = CLIArgumentNormalizer.normalize(["repobar"] + arguments)
+    let program = Program(descriptors: [RepoBarRoot.descriptor()])
+    let invocation = try program.resolve(argv: argv)
+    return try #require(RepoBarCLI.makeCommand(from: invocation) as? T)
 }


### PR DESCRIPTION
Follow-up to #109, which fixed this same defect for `changelog --release`.

## Problem

`ParsedValues` keys parsed options by the Swift property name. `OutputOptions.bind` shows the convention: it reads `values.flag("jsonOutput")` and `values.flag("noColor")`, not `"json"` and `"no-color"`.

Five commands declare a property whose name differs from the long flag, then read the long name. `flag()` returns false and the option is ignored. There is no error and no warning.

| flag | property | read key before |
|---|---|---|
| `--yes` | `LocalResetCommand.assumeYes` | `"yes"` |
| `--open` | `CheckoutCommand.openAfter` | `"open"` |
| `--traffic` | `RepoCommand.includeTraffic` | `"traffic"` |
| `--heatmap` | `RepoCommand.includeHeatmap` | `"heatmap"` |
| `--release` | `RepoCommand.includeRelease` | `"release"` |

So `repobar repo OWNER/NAME --traffic` printed the table without traffic, and `repobar local-reset --yes` still prompted.

`ArchiveCommands.swift` is not affected. It reads `decodeOption("repoPath") ?? decodeOption("repo")`, property name first with the long name as a fallback.

## Change

Each of the five now reads its property name. No flag name and no help text changes.

## Tests

Five tests in `Tests/repobarcliTests/CLIParsingTests.swift`, one per flag. Each asserts the default is false and that passing the flag binds true.

```
swift build --product repobarcli
swift test --filter "CLIParsingTests"
Test run with 12 tests in 1 suite passed
```

Reverting the five key strings and keeping the tests fails exactly five, one per flag:

```
* "local reset yes flag binds assume yes"
* "checkout open flag binds open after"
* "repo traffic flag binds include traffic"
* "repo heatmap flag binds include heatmap"
* "repo release flag binds include release"
```

Test naming follows the surrounding file. `AGENTS.md:31` asks for `test_<behavior>()`, but the repository has zero functions in that style and 668 backticked sentence-style ones.


## Real behavior proof

`local-reset` is the one affected command that runs without a stored login, so it is the one I can show end to end. Same command, same flag, same fixture repository, stdin closed so the confirmation prompt cannot be answered interactively.

Before, on `main`'s lookup key:

```
$ .build/debug/repobarcli local-reset /tmp/rbtest/fakerepo --yes < /dev/null
Error: Refusing to hard reset in non-interactive mode without --yes
```

`--yes` was passed and the command still refused, because `values.flag("yes")` returned false.

After, on this branch:

```
$ .build/debug/repobarcli local-reset /tmp/rbtest/fakerepo --yes < /dev/null
Error: No upstream branch configured.
```

The confirmation gate is now satisfied and the command proceeds to the real reset, which stops on the fixture having no upstream. That second error is the fixture, not the flag.

`repo --traffic`, `--heatmap` and `--release` need a stored login, so I cannot show those without credentials. They share the single `bind` method changed here and are covered by the parsing tests.
