### PR TITLE
menu: show workflow name on CI run rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 0.8.8 - Unreleased
 
-- Distinguish CI runs for the same commit by showing workflow names in the menu and CLI output (thanks @jiimaho). (#115)
 - Honor `repobar changelog --release` and count newer dated entries when the Unreleased section is empty (thanks @devYRPauli). (#109)
+- Distinguish CI runs for the same commit by showing workflow names in the menu and CLI output (thanks @jiimaho). (#115)
 - Update AppAuth to 3.0.0, refresh Apollo, Kingfisher, Sparkle, and Octokit dependencies, and update pnpm and the Node.js setup action.
 - Rewrite the README around installation and first use, with dynamic project badges and tighter links to reference documentation.
 - Update Sparkle, swift-log, Swiftdansi, Octokit request tooling, and tsx to their latest compatible releases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 ## 0.8.8 - Unreleased
 
 - Honor `repobar changelog --release` and count newer dated entries when the Unreleased section is empty (thanks @devYRPauli). (#109)
-- Distinguish CI runs for the same commit by showing workflow names in the menu and CLI output (thanks @jiimaho). (#115)
 - Update AppAuth to 3.0.0, refresh Apollo, Kingfisher, Sparkle, and Octokit dependencies, and update pnpm and the Node.js setup action.
 - Rewrite the README around installation and first use, with dynamic project badges and tighter links to reference documentation.
 - Update Sparkle, swift-log, Swiftdansi, Octokit request tooling, and tsx to their latest compatible releases.
+
+- Distinguish CI runs for the same commit by showing workflow names in the menu and CLI output (thanks @jiimaho). (#115)
 
 ## 0.8.7 - 2026-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.8.8 - Unreleased
 
+- Distinguish CI runs for the same commit by showing workflow names in the menu and CLI output (thanks @jiimaho). (#115)
 - Honor `repobar changelog --release` and count newer dated entries when the Unreleased section is empty (thanks @devYRPauli). (#109)
 - Update AppAuth to 3.0.0, refresh Apollo, Kingfisher, Sparkle, and Octokit dependencies, and update pnpm and the Node.js setup action.
 - Rewrite the README around installation and first use, with dynamic project badges and tighter links to reference documentation.

--- a/Sources/RepoBar/Views/WorkflowRunMenuItemView.swift
+++ b/Sources/RepoBar/Views/WorkflowRunMenuItemView.swift
@@ -20,6 +20,13 @@ struct WorkflowRunMenuItemView: View {
                     .foregroundStyle(MenuHighlightStyle.primary(self.isHighlighted))
                     .lineLimit(2)
 
+                if let workflowName = self.summary.workflowName, workflowName.isEmpty == false {
+                    Text(workflowName)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                        .lineLimit(1)
+                }
+
                 HStack(spacing: 6) {
                     if let branch = self.summary.branch, branch.isEmpty == false {
                         Text(branch)

--- a/Sources/RepoBarCore/API/GitHubRecentDecoders.swift
+++ b/Sources/RepoBarCore/API/GitHubRecentDecoders.swift
@@ -117,6 +117,7 @@ enum GitHubRecentDecoders {
             let updatedAt = run.updatedAt ?? run.createdAt ?? Date.distantPast
             return RepoWorkflowRunSummary(
                 name: title,
+                workflowName: self.workflowName(run, title: title),
                 url: url,
                 updatedAt: updatedAt,
                 status: GitHubStatusMapper.ciStatus(fromStatus: run.status, conclusion: run.conclusion),
@@ -190,6 +191,14 @@ enum GitHubRecentDecoders {
                 contributions: $0.contributions ?? 0
             )
         }
+    }
+
+    /// Returns the workflow name when it adds information beyond the run title.
+    /// GitHub's `name` is the workflow (e.g. "Deploy") while `display_title` is the commit/PR title.
+    private static func workflowName(_ run: ActionsRunsResponse.WorkflowRun, title: String) -> String? {
+        let name = (run.name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard name.isEmpty == false, name != title else { return nil }
+        return name
     }
 
     private static func workflowRunTitle(_ run: ActionsRunsResponse.WorkflowRun) -> String {

--- a/Sources/RepoBarCore/API/GitHubRecentDecoders.swift
+++ b/Sources/RepoBarCore/API/GitHubRecentDecoders.swift
@@ -198,6 +198,7 @@ enum GitHubRecentDecoders {
     private static func workflowName(_ run: ActionsRunsResponse.WorkflowRun, title: String) -> String? {
         let name = (run.name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         guard name.isEmpty == false, name != title else { return nil }
+
         return name
     }
 

--- a/Sources/RepoBarCore/Models/RepoRecentItems.swift
+++ b/Sources/RepoBarCore/Models/RepoRecentItems.swift
@@ -158,6 +158,7 @@ public struct RepoReleaseSummary: Sendable, Hashable {
 
 public struct RepoWorkflowRunSummary: Sendable, Hashable {
     public let name: String
+    public let workflowName: String?
     public let url: URL
     public let updatedAt: Date
     public let status: CIStatus
@@ -170,6 +171,7 @@ public struct RepoWorkflowRunSummary: Sendable, Hashable {
 
     public init(
         name: String,
+        workflowName: String? = nil,
         url: URL,
         updatedAt: Date,
         status: CIStatus,
@@ -181,6 +183,7 @@ public struct RepoWorkflowRunSummary: Sendable, Hashable {
         runNumber: Int?
     ) {
         self.name = name
+        self.workflowName = workflowName
         self.url = url
         self.updatedAt = updatedAt
         self.status = status

--- a/Sources/repobarcli/RecentListOutputModels.swift
+++ b/Sources/repobarcli/RecentListOutputModels.swift
@@ -43,6 +43,7 @@ struct ReleaseAssetOutput: Encodable {
 
 struct WorkflowRunOutput: Encodable {
     let name: String
+    let workflowName: String?
     let url: URL
     let updatedAt: Date
     let status: CIStatus
@@ -55,6 +56,7 @@ struct WorkflowRunOutput: Encodable {
 
     init(_ run: RepoWorkflowRunSummary) {
         self.name = run.name
+        self.workflowName = run.workflowName
         self.url = run.url
         self.updatedAt = run.updatedAt
         self.status = run.status

--- a/Sources/repobarcli/RecentListsOutput.swift
+++ b/Sources/repobarcli/RecentListsOutput.swift
@@ -52,10 +52,15 @@ func workflowRunsTableLines(
     guard runs.isEmpty == false else { return ["No workflow runs."] }
 
     let rows = runs.map { run in
-        RepoRecentRow(
+        let name = if let workflowName = run.workflowName, workflowName.isEmpty == false {
+            "\(workflowName) · \(run.name)"
+        } else {
+            run.name
+        }
+        return RepoRecentRow(
             updatedLabel: RelativeFormatter.string(from: run.updatedAt, relativeTo: now),
             primaryLabel: ciStatusLabel(run.status, conclusion: run.conclusion),
-            secondaryLabel: truncate(run.name.singleLine, max: 80),
+            secondaryLabel: truncate(name.singleLine, max: 80),
             tertiaryLabel: run.branch ?? "-",
             url: run.url
         )

--- a/Tests/RepoBarTests/RecentRepoItemsDecodingTests.swift
+++ b/Tests/RepoBarTests/RecentRepoItemsDecodingTests.swift
@@ -159,4 +159,49 @@ struct RecentRepoItemsDecodingTests {
         #expect(items.first?.assetCount == 2)
         #expect(items.first?.downloadCount == 15)
     }
+
+    @Test
+    func `actions endpoint exposes workflow name alongside run title`() throws {
+        let json = """
+        {
+          "total_count": 2,
+          "workflow_runs": [
+            {
+              "id": 1,
+              "name": "Deploy",
+              "display_title": "feat(dns): cut over fleet prod to Gateway API LB",
+              "run_number": 100,
+              "event": "push",
+              "head_branch": "main",
+              "status": "completed",
+              "conclusion": "success",
+              "html_url": "https://github.com/acme/widget/actions/runs/1",
+              "updated_at": "2025-12-28T10:00:00Z",
+              "actor": { "login": "alice", "avatar_url": "https://avatars.githubusercontent.com/u/1?v=4" }
+            },
+            {
+              "id": 2,
+              "name": "CI",
+              "display_title": "CI",
+              "run_number": 101,
+              "event": "push",
+              "head_branch": "main",
+              "status": "completed",
+              "conclusion": "success",
+              "html_url": "https://github.com/acme/widget/actions/runs/2",
+              "updated_at": "2025-12-28T11:00:00Z"
+            }
+          ]
+        }
+        """
+
+        let items = try GitHubClient.decodeRecentWorkflowRuns(from: Data(json.utf8))
+        #expect(items.count == 2)
+        #expect(items[0].name == "feat(dns): cut over fleet prod to Gateway API LB")
+        #expect(items[0].workflowName == "Deploy")
+        #expect(items[0].runNumber == 100)
+        // Workflow name is omitted when it merely repeats the run title.
+        #expect(items[1].name == "CI")
+        #expect(items[1].workflowName == nil)
+    }
 }

--- a/Tests/RepoBarTests/RepoRecentItemsInitializerTests.swift
+++ b/Tests/RepoBarTests/RepoRecentItemsInitializerTests.swift
@@ -58,6 +58,7 @@ struct RepoRecentItemsInitializerTests {
 
         let run = RepoWorkflowRunSummary(
             name: "CI",
+            workflowName: "Deploy",
             url: url,
             updatedAt: now,
             status: .passing,
@@ -70,6 +71,7 @@ struct RepoRecentItemsInitializerTests {
         )
         #expect(run.status == .passing)
         #expect(run.runNumber == 7)
+        #expect(run.workflowName == "Deploy")
 
         let discussion = RepoDiscussionSummary(
             title: "Discuss",

--- a/Tests/repobarcliTests/WorkflowRunOutputTests.swift
+++ b/Tests/repobarcliTests/WorkflowRunOutputTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 @testable import repobarcli
-import RepoBarCore
+@testable import RepoBarCore
 import Testing
 
 struct WorkflowRunOutputTests {

--- a/Tests/repobarcliTests/WorkflowRunOutputTests.swift
+++ b/Tests/repobarcliTests/WorkflowRunOutputTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+@testable import repobarcli
+import RepoBarCore
+import Testing
+
+struct WorkflowRunOutputTests {
+    @Test(arguments: ["Deploy", "CI", "", "  \n"])
+    func `workflow identity survives decoding and JSON without redundant keys`(workflowName: String) throws {
+        let response: [String: Any] = [
+            "workflow_runs": [[
+                "id": 1,
+                "name": workflowName,
+                "display_title": "CI",
+                "html_url": "https://github.com/acme/widget/actions/runs/1",
+                "status": "completed",
+                "conclusion": "success"
+            ]]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: response)
+        let run = try #require(GitHubClient.decodeRecentWorkflowRuns(from: data).first)
+        let encoded = try JSONEncoder().encode(WorkflowRunOutput(run))
+        let output = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+
+        #expect(output["name"] as? String == "CI")
+        if workflowName == "Deploy" {
+            #expect(output["workflowName"] as? String == "Deploy")
+        } else {
+            #expect(output.keys.contains("workflowName") == false)
+        }
+    }
+
+    @Test(arguments: ["Deploy", nil] as [String?])
+    func `workflow table retains titles and adds distinct workflow names`(workflowName: String?) throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let run = try RepoWorkflowRunSummary(
+            name: "Fix cache refresh",
+            workflowName: workflowName,
+            url: #require(URL(string: "https://github.com/acme/widget/actions/runs/1")),
+            updatedAt: now,
+            status: .passing,
+            conclusion: "success",
+            event: "push",
+            branch: "main",
+            actorLogin: "alice",
+            actorAvatarURL: nil,
+            runNumber: 1
+        )
+        let output = workflowRunsTableLines([run], useColor: false, includeURL: false, now: now)
+            .joined(separator: "\n")
+
+        #expect(output.contains("Fix cache refresh"))
+        #expect(output.contains("main"))
+        if workflowName != nil {
+            #expect(output.contains("Deploy · Fix cache refresh"))
+        } else {
+            #expect(output.contains(" · ") == false)
+        }
+    }
+}

--- a/Tests/repobarcliTests/WorkflowRunOutputTests.swift
+++ b/Tests/repobarcliTests/WorkflowRunOutputTests.swift
@@ -39,8 +39,8 @@ struct WorkflowRunOutputTests {
             updatedAt: now,
             status: .passing,
             conclusion: "success",
-            event: "push",
             branch: "main",
+            event: "push",
             actorLogin: "alice",
             actorAvatarURL: nil,
             runNumber: 1

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -55,6 +55,7 @@ The file store lives under `~/Library/Application Support/RepoBar/DebugAuth`. Se
   - Flags: `--limit`.
 - `ci <owner/name>`: workflow runs / CI runs.
   - Flags: `--limit`.
+  - The table shows `workflow · run title` when the workflow name differs from the run title. JSON includes an optional `workflowName` field in that case and omits it otherwise.
 - `discussions <owner/name>`: recent discussions.
   - Flags: `--limit`.
 - `tags <owner/name>`: recent tags.


### PR DESCRIPTION
When several GitHub Actions workflows run for one commit, the CI Runs submenu currently shows identical run titles. Preserve the distinct workflow name in the shared decoder and show it on a separate caption line, so users can distinguish build, test, and deploy runs without losing branch, event, actor, or timestamp details.

The CLI table renders `workflow · run title`, and JSON gains an optional `workflowName` field. Empty or redundant names are omitted. The public summary initializer defaults the new property to nil, preserving existing call sites. No additional API requests or menu preferences are introduced.

Thanks @jiimaho for the implementation. Maintainer additions cover decoder-to-JSON omission and table output, document the new field, and add the Unreleased note.

Validation: 677 tests in 110 suites via `pnpm check`, signed app build/launch and native interaction, before/after production-view captures with synthetic data, real signed CLI queries against RepoBar's Actions history, and clean Codex autoreview through P2. See the maintainer proof comment for commands, observations, and screenshots. GitHub CI must be green on the exact head before landing.
