### PR TITLE
docs: consolidate 0.8.8 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,10 @@
 
 ## 0.8.8 - Unreleased
 
-- Update pnpm to 11.25.0 and Octokit request tooling to 10.0.16.
 - Honor `repobar changelog --release` and count newer dated entries when the Unreleased section is empty (thanks @devYRPauli). (#109)
-- Update AppAuth to 3.0.0, refresh Apollo, Kingfisher, Sparkle, and Octokit dependencies, and update pnpm and the Node.js setup action.
+- Honor `local-reset --yes`, `checkout --open`, and `repo --traffic`, `--heatmap`, and `--release`, which were silently ignored (thanks @devYRPauli). (#113)
 - Rewrite the README around installation and first use, with dynamic project badges and tighter links to reference documentation.
-- Update Sparkle, swift-log, Swiftdansi, Octokit request tooling, and tsx to their latest compatible releases.
+- Update AppAuth to 3.0.0 and refresh Apollo, Kingfisher, Sparkle, swift-log, Swiftdansi, GraphQL, Octokit, tsx, pnpm, and the Node.js setup action.
 
 ## 0.8.7 - 2026-08-02
 


### PR DESCRIPTION
The 0.8.8 Unreleased notes omitted the five CLI flag fixes from #113 and repeated overlapping dependency updates across several bullets. Add the missing user-visible behavior, preserve contributor credit, and consolidate maintenance notes without changing released sections or version metadata.

The pending changes since v0.8.7 support a patch release. Validation: reviewed against the complete v0.8.7..main diff, `git diff --check`, and Codex autoreview (no actionable P0–P2 findings). Final CI and runtime validation will be recorded below before landing.
