### PR TITLE
docs: prepare Turkish localization release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Highlights:** RepoBar now follows your macOS language preference with Turkish menus and common Settings controls.
+
+- Add Turkish translations for macOS menu actions, Settings tabs, repository visibility controls, and Display customization, with English fallback and unchanged CLI output (thanks @husodrn46). (#114)
+
 ## 0.8.8 - 2026-09-06
 
 **Highlights:** CLI flags now behave as requested, and workflow names make CI runs for the same commit easy to distinguish.


### PR DESCRIPTION
Adds the complete Unreleased notes for the macOS Turkish localization in #114, including contributor credit. Recommended merge order: #119, #114, then this PR. Released sections are unchanged.

The application’s npm and Swift resolutions and existing Actions references remain current. The local Octokit install was synchronized to the already-committed lockfile. Package-manager updates are held: pnpm 11.26.0 was released only hours before this check, while pnpm 12.3.4 is a recent major; this pass retains the documented and verified pnpm 11.25.0 toolchain.

Release recommendation after the prepared PRs: 0.9.0, for the new macOS language support. This PR does not bump the version, tag, or publish.

Validation: changelog diff checked; local and branch autoreview passed through P2; CI passed on head 236eb76391ecd6a9f7a56f4845eb7d24b986efc7: https://github.com/steipete/RepoBar/actions/runs/34098985209
